### PR TITLE
Bump fairlearn dashboard version to 0.1.0 to publish to npm

### DIFF
--- a/libs/fairlearn/package.json
+++ b/libs/fairlearn/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@responsible-ai/fairlearn",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "license": "MIT"
 }


### PR DESCRIPTION
This will publish v0.1.0 to npm so that both v1 and v2 dashboards are consumable in the new python package.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>