### PR TITLE
adjust to main branch (instead of master)

### DIFF
--- a/.azure-devops/component-governance.yml
+++ b/.azure-devops/component-governance.yml
@@ -1,7 +1,7 @@
 # Run Component Governance to register all dependencies.
 
 trigger:
-  - master
+  - main
 
 pool:
   vmImage: "ubuntu-latest"

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,7 +11,7 @@ env:
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/CI-rai_core_flask.yml
+++ b/.github/workflows/CI-rai_core_flask.yml
@@ -2,9 +2,9 @@ name: Responsible AI Core Flask
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ env:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,7 @@
 {
   "npmScope": "responsible-ai",
   "affected": {
-    "defaultBase": "master"
+    "defaultBase": "main"
   },
   "implicitDependencies": {
     "workspace.json": "*",


### PR DESCRIPTION
The only mentions of "master" left are in _NOTICE.md and CI.yml because they reference the "master" branch of other repositories/projects which we don't have control over.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>