### PR TITLE
updated cohort interaction in panels and add more breadcrumb interactions

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
@@ -23,6 +23,7 @@ import { Fabric } from "office-ui-fabric-react/lib/Fabric";
 import { Stack } from "office-ui-fabric-react/lib/Stack";
 import React from "react";
 
+import { ErrorCohort } from "../../ErrorCohort";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
 import { constructRows, constructCols } from "../../utils/DatasetUtils";
 
@@ -40,6 +41,7 @@ export interface IInspectionViewProps {
   weightOptions: WeightVectorOption[];
   weightLabels: any;
   onWeightChange: (option: WeightVectorOption) => void;
+  selectedCohort: ErrorCohort;
 }
 
 export interface IInspectionViewState {
@@ -68,12 +70,14 @@ export class InspectionView extends React.PureComponent<
       sortArray: [],
       sortingSeriesIndex: undefined
     };
-    const numRows: number = this.props.jointDataset.datasetRowCount;
+    const cohortData = this.props.selectedCohort.cohort.filteredData;
+    const numRows: number = cohortData.length;
     const viewedRows: number = Math.min(
       Math.min(numRows, 8),
       this.props.inspectedIndexes.length
     );
     this._rows = constructRows(
+      cohortData,
       this.props.jointDataset,
       viewedRows,
       undefined,

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
@@ -18,6 +18,7 @@ import { Stack } from "office-ui-fabric-react/lib/Stack";
 import React from "react";
 
 import { PredictionTabKeys } from "../../ErrorAnalysisDashboard";
+import { ErrorCohort } from "../../ErrorCohort";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
 import { InspectionView } from "../InspectionView/InspectionView";
 import {
@@ -48,6 +49,7 @@ export interface IInstanceViewProps {
   activePredictionTab: PredictionTabKeys;
   setActivePredictionTab: (key: PredictionTabKeys) => void;
   customPoints: Array<{ [key: string]: any }>;
+  selectedCohort: ErrorCohort;
 }
 
 export interface IInstanceViewState {
@@ -126,6 +128,7 @@ export class InstanceView extends React.PureComponent<
             weightLabels={this.props.weightLabels}
             invokeModel={this.props.invokeModel}
             onWeightChange={this.props.onWeightChange}
+            selectedCohort={this.props.selectedCohort}
           />
         </div>
       );
@@ -168,6 +171,7 @@ export class InstanceView extends React.PureComponent<
                 this.state.selectionDetails.selectedCorrectDatasetIndexes
               }
               setSelectedIndexes={this.setCorrectSelectedIndexes.bind(this)}
+              selectedCohort={this.props.selectedCohort}
             />
           </div>
         )}
@@ -184,6 +188,7 @@ export class InstanceView extends React.PureComponent<
                 this.state.selectionDetails.selectedIncorrectDatasetIndexes
               }
               setSelectedIndexes={this.setIncorrectSelectedIndexes.bind(this)}
+              selectedCohort={this.props.selectedCohort}
             />
           </div>
         )}
@@ -203,6 +208,7 @@ export class InstanceView extends React.PureComponent<
               allSelectedIndexes={
                 this.state.selectionDetails.selectedAllSelectedIndexes
               }
+              selectedCohort={this.props.selectedCohort}
             />
           </div>
         )}
@@ -223,6 +229,7 @@ export class InstanceView extends React.PureComponent<
               allSelectedIndexes={
                 this.state.selectionDetails.selectedAllSelectedIndexes
               }
+              selectedCohort={this.props.selectedCohort}
             />
           </div>
         )}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -258,6 +258,7 @@ export class MatrixArea extends React.PureComponent<
     const category1Values = [];
     let cat1HasIntervals = false;
     let cat2HasIntervals = false;
+    // Extract categories for first selected feature in matrix filter
     for (let i = 0; i < matrix.length - 1; i++) {
       const cellCat1 = matrix[i][0];
       const category1 = cellCat1.category1;
@@ -270,6 +271,7 @@ export class MatrixArea extends React.PureComponent<
     }
     const category2Values = [];
     const rowLength = matrix[0].length;
+    // Extract categories for second selected feature in matrix filter
     for (let i = 1; i < rowLength; i++) {
       const cellCat2 = matrix[matrix.length - 1][i];
       const category2 = cellCat2.category2;
@@ -283,6 +285,7 @@ export class MatrixArea extends React.PureComponent<
     const multiCellCompositeFilters: ICompositeFilter[] = [];
     const keyFeature1 = this.getKey(this.props.selectedFeature1!);
     let keyFeature2 = this.getKey(this.props.selectedFeature2!);
+    // Create filters based on the selected cells in the matrix filter
     for (let i = 0; i < matrix.length - 1; i++) {
       for (let j = 1; j < rowLength; j++) {
         const index = j + i * rowLength;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
@@ -6,33 +6,80 @@ import { Link } from "office-ui-fabric-react/lib/Link";
 import { IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
 import React from "react";
 
-import { ViewTypeKeys } from "../../ErrorAnalysisDashboard";
+import {
+  ViewTypeKeys,
+  GlobalTabKeys,
+  PredictionTabKeys
+} from "../../ErrorAnalysisDashboard";
 
 import { navigationStyles } from "./Navigation.styles";
 
 export interface INavigationProps {
   updateViewState: (viewTypeKeys: ViewTypeKeys) => void;
+  updateGlobalTabState: (globalTab: GlobalTabKeys) => void;
+  updatePredictionTabState: (predictionTab: PredictionTabKeys) => void;
   viewType: ViewTypeKeys;
+  activeGlobalTab: GlobalTabKeys;
+  activePredictionTab: PredictionTabKeys;
 }
 
-export class Navigation extends React.PureComponent<INavigationProps> {
+export class Navigation extends React.Component<INavigationProps> {
   public render(): React.ReactNode {
-    let items: IBreadcrumbItem[] = [];
+    const items: IBreadcrumbItem[] = [];
     if (this.props.viewType === ViewTypeKeys.ExplanationView) {
-      items = [
-        {
-          key: ViewTypeKeys.ErrorAnalysisView,
-          onClick: (
-            e?: React.MouseEvent<HTMLElement>,
-            item?: IBreadcrumbItem
-          ): void => {
-            if (e !== undefined && item !== undefined) {
-              this._errorDetectorBreadcrumbClicked(e, item);
-            }
-          },
-          text: "< Error Detector"
+      items.push({
+        key: ViewTypeKeys.ErrorAnalysisView,
+        onClick: (
+          e?: React.MouseEvent<HTMLElement>,
+          item?: IBreadcrumbItem
+        ): void => {
+          if (e !== undefined && item !== undefined) {
+            this.errorDetectorBreadcrumbClicked(e, item);
+          }
+        },
+        text: "Error Detector"
+      });
+      if (this.props.activeGlobalTab === GlobalTabKeys.DataExplorerTab) {
+        items.push({
+          key: GlobalTabKeys.DataExplorerTab,
+          text: "Data Explorer"
+        });
+      } else if (
+        this.props.activeGlobalTab === GlobalTabKeys.GlobalExplanationTab
+      ) {
+        items.push({
+          key: GlobalTabKeys.GlobalExplanationTab,
+          text: "Global Explanation"
+        });
+      } else if (
+        this.props.activeGlobalTab === GlobalTabKeys.LocalExplanationTab
+      ) {
+        if (
+          this.props.activePredictionTab !== PredictionTabKeys.InspectionTab
+        ) {
+          items.push({
+            key: GlobalTabKeys.LocalExplanationTab,
+            text: "Local Explanation"
+          });
+        } else {
+          items.push({
+            key: GlobalTabKeys.LocalExplanationTab,
+            onClick: (
+              e?: React.MouseEvent<HTMLElement>,
+              item?: IBreadcrumbItem
+            ): void => {
+              if (e !== undefined && item !== undefined) {
+                this.localExplanationBreadcrumbClicked(e, item);
+              }
+            },
+            text: "Local Explanation"
+          });
+          items.push({
+            key: PredictionTabKeys.InspectionTab,
+            text: "Local Explanation (Inspection)"
+          });
         }
-      ];
+      }
     }
     const classNames = navigationStyles();
     return (
@@ -58,14 +105,14 @@ export class Navigation extends React.PureComponent<INavigationProps> {
     if (!item) {
       return <div></div>;
     }
-    if (item.onClick || item.href) {
+    if (item.onClick) {
       return (
         <Link
           as={item.as}
           className="ms-Breadcrumb-itemLink"
           href={item.href}
           onClick={(e: React.MouseEvent<HTMLElement>): void =>
-            this._errorDetectorBreadcrumbClicked(e, item)
+            item.onClick!(e, item)
           }
           color="blue"
         >
@@ -80,12 +127,23 @@ export class Navigation extends React.PureComponent<INavigationProps> {
     );
   };
 
-  private _errorDetectorBreadcrumbClicked(
+  private errorDetectorBreadcrumbClicked(
     _: React.MouseEvent<HTMLElement>,
     item: IBreadcrumbItem
   ): void {
     if (item !== undefined && item.key === ViewTypeKeys.ErrorAnalysisView) {
       this.props.updateViewState(item.key);
+    }
+  }
+
+  private localExplanationBreadcrumbClicked(
+    _: React.MouseEvent<HTMLElement>,
+    item: IBreadcrumbItem
+  ): void {
+    if (item !== undefined && item.key === GlobalTabKeys.LocalExplanationTab) {
+      this.props.updatePredictionTabState(
+        PredictionTabKeys.CorrectPredictionTab
+      );
     }
   }
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TabularDataView/TabularDataView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TabularDataView/TabularDataView.tsx
@@ -24,6 +24,7 @@ import { TooltipHost } from "office-ui-fabric-react/lib/Tooltip";
 import { IRenderFunction } from "office-ui-fabric-react/lib/Utilities";
 import React from "react";
 
+import { ErrorCohort } from "../../ErrorCohort";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
 import {
   constructRows,
@@ -43,6 +44,7 @@ export interface ITabularDataViewProps {
   selectedIndexes: number[];
   allSelectedIndexes?: number[];
   customPoints?: Array<{ [key: string]: any }>;
+  selectedCohort: ErrorCohort;
 }
 
 export enum DataViewKeys {
@@ -90,12 +92,14 @@ export class TabularDataView extends React.PureComponent<
         viewedRows
       );
     } else {
-      const numRows: number = this.props.jointDataset.datasetRowCount;
+      const cohortData = this.props.selectedCohort.cohort.filteredData;
+      const numRows: number = cohortData.length;
       let viewedRows: number = numRows;
       if (this.props.allSelectedIndexes) {
         viewedRows = Math.min(numRows, this.props.allSelectedIndexes.length);
       }
       this._rows = constructRows(
+        cohortData,
         this.props.jointDataset,
         viewedRows,
         this.tabularDataFilter.bind(this),
@@ -142,7 +146,6 @@ export class TabularDataView extends React.PureComponent<
                 checkButtonAriaLabel="Row checkbox"
                 selectionMode={SelectionMode.multiple}
                 selection={this._selection}
-                //onItemInvoked={this._onItemInvoked}
               />
             </MarqueeSelection>
           </ScrollablePane>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
@@ -28,7 +28,8 @@ export class ErrorCohort {
     public cohort: Cohort,
     public jointDataset: JointDataset,
     public cells: number = 0,
-    public source: ErrorDetectorCohortSource = ErrorDetectorCohortSource.None
+    public source: ErrorDetectorCohortSource = ErrorDetectorCohortSource.None,
+    public isTemporary: boolean = false
   ) {
     this.cohort = cohort;
     this.jointDataset = jointDataset;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/utils/DatasetUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/utils/DatasetUtils.ts
@@ -5,6 +5,7 @@ import { JointDataset } from "@responsible-ai/interpret";
 import { IColumn } from "office-ui-fabric-react";
 
 export function constructRows(
+  cohortData: Array<{ [key: string]: number }>,
   jointDataset: JointDataset,
   viewedRows: number,
   filterFunction?: (row: { [key: string]: number }) => boolean,
@@ -16,7 +17,7 @@ export function constructRows(
     if (indexes) {
       index = indexes[i];
     }
-    const row = jointDataset.getRow(index);
+    const row = cohortData[index];
     if (filterFunction && filterFunction(row)) {
       continue;
     }


### PR DESCRIPTION
- fixed cohort interactions in panels, so that Data Explorer, Global Explanation and Local Explanation tabs use the selected cohort
- added breadcrumb interations for the explanation view, especially the local explanation (and inspection views) to allow the user to go back from the inspection view
![image](https://user-images.githubusercontent.com/24683184/99421486-6ce02380-28cc-11eb-9c03-c43589d9f954.png)
- fixed several comments from previous PR