### PR TITLE
fixed cohort shift functionality by applying filters on backend

### DIFF
--- a/apps/dashboard/src/error-analysis/App.tsx
+++ b/apps/dashboard/src/error-analysis/App.tsx
@@ -80,9 +80,9 @@ export class App extends React.Component<IAppProps> {
     const promise = new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         if (
-          data.length === 2 &&
-          data[0] === "mean radius" &&
-          data[1] === "mean texture"
+          data.length === 3 &&
+          data[0][0] === "mean radius" &&
+          data[0][1] === "mean texture"
         ) {
           resolve(_.cloneDeep(dummyMatrix2dInterval));
         } else if (data[0] === "mean radius") {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
@@ -26,6 +26,7 @@ export interface IErrorAnalysisViewProps {
     cells: number
   ) => void;
   selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
 }
 
 export class ErrorAnalysisView extends React.PureComponent<
@@ -40,9 +41,11 @@ export class ErrorAnalysisView extends React.PureComponent<
               theme={this.props.theme}
               messages={this.props.messages}
               getTreeNodes={this.props.getTreeNodes}
+              features={this.props.features}
               selectedFeatures={this.props.selectedFeatures}
               updateSelectedCohort={this.props.updateSelectedCohort}
               selectedCohort={this.props.selectedCohort}
+              baseCohort={this.props.baseCohort}
             />
           )}
           {this.props.errorAnalysisOption === ErrorAnalysisOptions.HeatMap && (
@@ -52,6 +55,7 @@ export class ErrorAnalysisView extends React.PureComponent<
               getMatrix={this.props.getMatrix}
               updateSelectedCohort={this.props.updateSelectedCohort}
               selectedCohort={this.props.selectedCohort}
+              baseCohort={this.props.baseCohort}
             />
           )}
         </div>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -31,6 +31,7 @@ export interface IMatrixAreaProps {
     cells: number
   ) => void;
   selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
 }
 
 export interface IMatrixAreaState {
@@ -58,7 +59,11 @@ export class MatrixArea extends React.PureComponent<
       this.props.selectedFeature1 !== prevProps.selectedFeature1;
     const selectedFeature2Changed =
       this.props.selectedFeature2 !== prevProps.selectedFeature2;
-    if (selectedFeature1Changed || selectedFeature2Changed) {
+    if (
+      selectedFeature1Changed ||
+      selectedFeature2Changed ||
+      this.props.baseCohort !== prevProps.baseCohort
+    ) {
       this.fetchMatrix();
     }
   }
@@ -195,9 +200,21 @@ export class MatrixArea extends React.PureComponent<
     if (this.props.getMatrix === undefined) {
       return;
     }
+    const filtersRelabeled = ErrorCohort.getLabeledFilters(
+      this.props.baseCohort.cohort.filters,
+      this.props.baseCohort.jointDataset
+    );
+    const compositeFiltersRelabeled = ErrorCohort.getLabeledCompositeFilters(
+      this.props.baseCohort.cohort.compositeFilters,
+      this.props.baseCohort.jointDataset
+    );
     this.props
       .getMatrix(
-        [this.props.selectedFeature1!, this.props.selectedFeature2!],
+        [
+          [this.props.selectedFeature1!, this.props.selectedFeature2!],
+          filtersRelabeled,
+          compositeFiltersRelabeled
+        ],
         new AbortController().signal
       )
       .then((result) => {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -29,6 +29,7 @@ export interface IMatrixFilterProps {
     cells: number
   ) => void;
   selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
 }
 
 export interface IMatrixFilterState {
@@ -98,6 +99,7 @@ export class MatrixFilter extends React.PureComponent<
             selectedFeature2={this.state.selectedFeature2}
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
+            baseCohort={this.props.baseCohort}
           />
         </Stack>
       </div>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/SaveCohort/SaveCohort.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/SaveCohort/SaveCohort.tsx
@@ -166,7 +166,8 @@ export class SaveCohort extends React.Component<
       new Cohort(
         this.state.cohortName,
         this.props.jointDataset,
-        tempCohort.cohort.filters
+        tempCohort.cohort.filters,
+        tempCohort.cohort.compositeFilters
       ),
       this.props.jointDataset
     );

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ShiftCohort/ShiftCohort.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ShiftCohort/ShiftCohort.tsx
@@ -90,7 +90,7 @@ export class ShiftCohort extends React.Component<
           temporaryCohort={this.props.cohorts[this.state.selectedCohort]}
         ></CohortStats>
         <DialogFooter>
-          <PrimaryButton onClick={this.props.onDismiss} text="Apply" />
+          <PrimaryButton onClick={this.onApplyClick.bind(this)} text="Apply" />
           <DefaultButton onClick={this.props.onDismiss} text="Cancel" />
         </DialogFooter>
       </Dialog>
@@ -105,4 +105,13 @@ export class ShiftCohort extends React.Component<
       this.setState({ selectedCohort: item.key as number });
     }
   };
+
+  private shiftCohort(): void {
+    this.props.onApply(this.props.cohorts[this.state.selectedCohort]);
+  }
+
+  private onApplyClick(): void {
+    this.props.onDismiss();
+    this.shiftCohort();
+  }
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -519,6 +519,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                 (cohort) => cohort.cohort.name !== selectedCohort.cohort.name
               );
               this.setState({
+                baseCohort: selectedCohort,
                 cohorts: [selectedCohort, ...cohorts],
                 selectedCohort
               });
@@ -549,6 +550,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                   selectedFeatures={this.state.selectedFeatures}
                   errorAnalysisOption={this.state.errorAnalysisOption}
                   selectedCohort={this.state.selectedCohort}
+                  baseCohort={this.state.baseCohort}
                 />
               )}
               {this.state.viewType === ViewTypeKeys.ExplanationView && (
@@ -692,17 +694,11 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     cells = 0
   ): void {
     // Need to relabel the filter names based on index in joint dataset
-    const filtersRelabeled = filters.map(
-      (filter: IFilter): IFilter => {
-        const index = this.props.features.indexOf(filter.column);
-        const key = JointDataset.DataLabelRoot + index.toString();
-        return {
-          arg: filter.arg,
-          column: key,
-          method: filter.method
-        };
-      }
+    const filtersRelabeled = ErrorCohort.getDataFilters(
+      filters,
+      this.props.features
     );
+
     let selectedCohortName = "";
     let addTemporaryCohort = true;
     if (source === ErrorDetectorCohortSource.TreeMap) {
@@ -713,12 +709,15 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       selectedCohortName = this.state.baseCohort.cohort.name;
       addTemporaryCohort = false;
     }
+    const baseCohortFilters = this.state.baseCohort.cohort.filters;
+    const baseCohortCompositeFilters = this.state.baseCohort.cohort
+      .compositeFilters;
     const selectedCohort: ErrorCohort = new ErrorCohort(
       new Cohort(
         selectedCohortName,
         this.state.jointDataset,
-        filtersRelabeled,
-        compositeFilters
+        baseCohortFilters.concat(filtersRelabeled),
+        baseCohortCompositeFilters.concat(compositeFilters)
       ),
       this.state.jointDataset,
       cells,

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
@@ -78,6 +78,68 @@ export class ErrorCohort {
     }
   }
 
+  public static getDataFilters(
+    filters: IFilter[],
+    features: string[]
+  ): IFilter[] {
+    // return the filters relabeled from original label to Data#
+    const filtersRelabeled = filters.map(
+      (filter: IFilter): IFilter => {
+        const index = features.indexOf(filter.column);
+        const key = JointDataset.DataLabelRoot + index.toString();
+        return {
+          arg: filter.arg,
+          column: key,
+          method: filter.method
+        };
+      }
+    );
+    return filtersRelabeled;
+  }
+
+  public static getLabeledFilters(
+    filters: IFilter[],
+    jointDataset: JointDataset
+  ): IFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = filters.map(
+      (filter: IFilter): IFilter => {
+        const label = jointDataset.metaDict[filter.column].label;
+        return {
+          arg: filter.arg,
+          column: label,
+          method: filter.method
+        };
+      }
+    );
+    return filtersRelabeled;
+  }
+
+  public static getLabeledCompositeFilters(
+    compositeFilters: ICompositeFilter[],
+    jointDataset: JointDataset
+  ): ICompositeFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = compositeFilters.map(
+      (compositeFilter: ICompositeFilter): ICompositeFilter => {
+        if (compositeFilter.method) {
+          return ErrorCohort.getLabeledFilters(
+            [compositeFilter as IFilter],
+            jointDataset
+          )[0] as ICompositeFilter;
+        }
+        return {
+          compositeFilters: ErrorCohort.getLabeledCompositeFilters(
+            compositeFilter.compositeFilters,
+            jointDataset
+          ),
+          operation: compositeFilter.operation
+        } as ICompositeFilter;
+      }
+    );
+    return filtersRelabeled;
+  }
+
   public cohortFiltersToString(filters: IFilter[]): string[] {
     return filters.map((filter: IFilter): string => {
       let method = "";

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -56,12 +56,12 @@ class ErrorAnalysisDashboard(Dashboard):
 
         def tree():
             data = request.get_json(force=True)
-            return jsonify(self.input.debug_ml(data))
+            return jsonify(self.input.debug_ml(data[0], data[1], data[2]))
 
         self.add_url_rule(tree, '/tree', methods=["POST"])
 
         def matrix():
             data = request.get_json(force=True)
-            return jsonify(self.input.matrix(data))
+            return jsonify(self.input.matrix(data[0], data[1], data[2]))
 
         self.add_url_rule(matrix, '/matrix', methods=["POST"])


### PR DESCRIPTION
Cohort shift functionality involves changing current cohort to selected saved cohort and then using the new selected cohort as the "base cohort".  However this means that the filters selected need to be sent back to the python backend and applied whenever using the heatmap and tree view, which was not implemented previously.  This PR implements this important functionality.