### PR TITLE
Fairness: fix bug that prevented regression and probability plots from displaying properly

### DIFF
--- a/libs/fairness/src/lib/v2/Controls/OutcomePlot.tsx
+++ b/libs/fairness/src/lib/v2/Controls/OutcomePlot.tsx
@@ -91,7 +91,9 @@ export class OutcomePlot extends React.PureComponent<IOutcomePlotProps> {
           text: outcomeText,
           type: "box",
           x: this.props.metrics.predictions,
-          y: groupNamesWithBuffer
+          y: this.props.dashboardContext.binVector.map(
+            (binIndex) => groupNamesWithBuffer[binIndex]
+          )
         } as any
       ];
       outcomeChartModalHelpStrings = [
@@ -121,7 +123,9 @@ export class OutcomePlot extends React.PureComponent<IOutcomePlotProps> {
           text: outcomeText,
           type: "box",
           x: this.props.metrics.predictions,
-          y: groupNamesWithBuffer
+          y: this.props.dashboardContext.binVector.map(
+            (binIndex) => groupNamesWithBuffer[binIndex]
+          )
         } as any
       ];
       outcomeChartModalHelpStrings = [

--- a/libs/fairness/src/lib/v2/Controls/PerformancePlot.tsx
+++ b/libs/fairness/src/lib/v2/Controls/PerformancePlot.tsx
@@ -213,7 +213,9 @@ export class PerformancePlot extends React.PureComponent<
           text: performanceText,
           type: "box",
           x: this.props.metrics.errors,
-          y: groupNamesWithBuffer
+          y: this.props.dashboardContext.binVector.map(
+            (binIndex) => groupNamesWithBuffer[binIndex]
+          )
         } as any
       ];
       performanceChartModalHelpStrings = [

--- a/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
+++ b/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
@@ -85,7 +85,7 @@ export class ReportChart extends React.Component<IReportChartProps, IState> {
         this.props.metrics.overpredictions &&
         this.props.metrics.underpredictions) ||
       (this.props.dashboardContext.modelMetadata.PredictionType ===
-        PredictionTypes.Probability &&
+        PredictionTypes.Regression &&
         this.props.metrics.errors)
     ) {
       displayOptions.push({


### PR DESCRIPTION
This PR fixes issues that prevented the regression performance chart from showing and prevented the error plot from rendering properly. A recent change mistakenly changed the inputs. To detect this in the future we're planning to add more tests shortly!

Signed-off-by: Roman Lutz <rolutz@microsoft.com>