### PR TITLE
added full circle around selected node and error rate gradient to tree and matrix filter views, fixed ICE plots

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export enum ColorPalette {
+  MinColor = "#F4D1D2",
+  MaxColor = "#8d2323",
+  ErrorAvgColor = "#b2b7bd"
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorRateGradient/ErrorRateGradient.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorRateGradient/ErrorRateGradient.styles.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet
+} from "office-ui-fabric-react";
+
+export interface IErrorRateGradientStyles {
+  gradientTick: IStyle;
+}
+
+export const errorRateGradientStyles: () => IProcessedStyleSet<
+  IErrorRateGradientStyles
+> = () => {
+  return mergeStyleSets<IErrorRateGradientStyles>({
+    gradientTick: {
+      stroke: "black",
+      strokeWidth: 1
+    }
+  });
+};

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorRateGradient/ErrorRateGradient.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorRateGradient/ErrorRateGradient.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from "react";
+
+import { ColorPalette } from "../../ColorPalette";
+import { ErrorCohort } from "../../ErrorCohort";
+
+import { errorRateGradientStyles } from "./ErrorRateGradient.styles";
+
+export interface IErrorRateGradientProps {
+  max: number;
+  minPct: number;
+  selectedCohort: ErrorCohort;
+}
+
+export class ErrorRateGradient extends React.Component<
+  IErrorRateGradientProps
+> {
+  public render(): React.ReactNode {
+    const classNames = errorRateGradientStyles();
+    const errorRateRectHeight = 40;
+    const errorRateLineHeight =
+      errorRateRectHeight -
+      (this.props.selectedCohort.errorRate / (this.props.max * 100)) *
+        errorRateRectHeight;
+    const gradientMidPct = `${100 - (1 / this.props.max) * this.props.minPct}%`;
+    const minColor = ColorPalette.MinColor;
+    const maxColor = ColorPalette.MaxColor;
+    const errorAvgColor = ColorPalette.ErrorAvgColor;
+    return (
+      <g>
+        <linearGradient
+          id="gradient"
+          x1="0%"
+          x2="100%"
+          gradientTransform="rotate(90)"
+        >
+          <stop offset="0%" stopColor={maxColor} />
+          <stop offset={gradientMidPct} stopColor={minColor} />
+          <stop offset={gradientMidPct} stopColor={errorAvgColor} />
+          <stop offset="100%" stopColor={errorAvgColor} />
+        </linearGradient>
+        <rect
+          x="0"
+          y="0"
+          width="40"
+          height={errorRateRectHeight}
+          fill="url(#gradient)"
+        />
+        <g>
+          <line
+            x1="0"
+            y1={errorRateLineHeight}
+            x2="40"
+            y2={errorRateLineHeight}
+            className={classNames.gradientTick}
+          />
+        </g>
+      </g>
+    );
+  }
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
@@ -7,11 +7,13 @@ import {
   IExplanationModelMetadata,
   IGlobalSeries,
   ModelExplanationUtils,
-  WeightVectorOption
+  WeightVectorOption,
+  FabricStyles
 } from "@responsible-ai/interpret";
 import { localization } from "@responsible-ai/localization";
 import {
   IColumn,
+  IDropdownOption,
   ITheme,
   IStackTokens,
   DetailsList,
@@ -63,6 +65,28 @@ export class InspectionView extends React.PureComponent<
   private _columns: IColumn[];
   private _selection: Selection;
   private _selectionInitialized = false;
+  private featuresOption: IDropdownOption[] = new Array(
+    this.props.jointDataset.datasetFeatureCount
+  )
+    .fill(0)
+    .map((_, index) => {
+      const key = JointDataset.DataLabelRoot + index.toString();
+      const meta = this.props.jointDataset.metaDict[key];
+      const options = meta.isCategorical
+        ? meta.sortedCategoricalValues?.map((optionText, index) => {
+            return { key: index, text: optionText };
+          })
+        : undefined;
+      return {
+        data: {
+          categoricalOptions: options,
+          fullLabel: meta.label.toLowerCase()
+        },
+        key,
+        text: meta.abbridgedLabel
+      };
+    });
+
   public constructor(props: IInspectionViewProps) {
     super(props);
     this.state = {
@@ -126,6 +150,15 @@ export class InspectionView extends React.PureComponent<
 
   public render(): React.ReactNode {
     const classNames = InspectionViewStyles();
+    const testableDatapoints = this.state.includedFeatureImportance.map(
+      (item) => item.unsortedFeatureValues as any[]
+    );
+    const testableDatapointColors = this.state.includedFeatureImportance.map(
+      (item) => FabricStyles.fabricColorPalette[item.colorIndex]
+    );
+    const testableDatapointNames = this.state.includedFeatureImportance.map(
+      (item) => item.name
+    );
     return (
       <div>
         <Stack tokens={alignmentStackTokens}>
@@ -156,10 +189,10 @@ export class InspectionView extends React.PureComponent<
               selectedWeightVector={this.props.selectedWeightVector}
               weightOptions={this.props.weightOptions}
               weightLabels={this.props.weightLabels}
-              testableDatapoints={[]}
-              testableDatapointColors={[]}
-              testableDatapointNames={[]}
-              featuresOption={[]}
+              testableDatapoints={testableDatapoints}
+              testableDatapointColors={testableDatapointColors}
+              testableDatapointNames={testableDatapointNames}
+              featuresOption={this.featuresOption}
               sortArray={this.state.sortArray}
               sortingSeriesIndex={this.state.sortingSeriesIndex}
               invokeModel={this.props.invokeModel}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -23,6 +23,7 @@ import {
 } from "office-ui-fabric-react";
 import React from "react";
 
+import { ColorPalette } from "../../ColorPalette";
 import { ErrorCohort, ErrorDetectorCohortSource } from "../../ErrorCohort";
 import { FilterProps } from "../../FilterProps";
 import { FilterTooltip } from "../FilterTooltip/FilterTooltip";
@@ -43,6 +44,7 @@ export interface IMatrixAreaProps {
   ) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;
+  updateMatrixLegendState: (maxError: number) => void;
 }
 
 export interface IMatrixAreaState {
@@ -267,12 +269,16 @@ export class MatrixArea extends React.PureComponent<
   }
 
   private reloadData(matrix: any[]): void {
-    const maxErrorRate = 0;
+    let maxErrorRate = 0;
     matrix.forEach((row: any): void => {
       row.forEach((value: any): void => {
-        Math.max(maxErrorRate, (value.falseCount / value.count) * 100);
+        const errorRate = value.falseCount / value.count;
+        if (!Number.isNaN(errorRate)) {
+          maxErrorRate = Math.max(maxErrorRate, errorRate);
+        }
       });
     });
+    this.props.updateMatrixLegendState(maxErrorRate);
     this.setState({
       matrix,
       maxErrorRate,
@@ -440,7 +446,7 @@ export class MatrixArea extends React.PureComponent<
     return d3scaleLinear<string>()
       .domain([0, 1])
       .interpolate(d3interpolateHcl)
-      .range(["#F4D1D2", "#8d2323"])(value)!;
+      .range([ColorPalette.MinColor, ColorPalette.MaxColor])(value)!;
   }
 
   private colorLookup(ratio: number): string {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -32,9 +32,14 @@ export interface IMatrixFilterProps {
   baseCohort: ErrorCohort;
 }
 
+export interface IMatrixLegendState {
+  maxError: number;
+}
+
 export interface IMatrixFilterState {
   selectedFeature1?: string;
   selectedFeature2?: string;
+  matrixLegendState: IMatrixLegendState;
 }
 
 const stackTokens: IStackTokens = { childrenGap: 5 };
@@ -47,6 +52,7 @@ export class MatrixFilter extends React.PureComponent<
   public constructor(props: IMatrixFilterProps) {
     super(props);
     this.state = {
+      matrixLegendState: { maxError: 0 },
       selectedFeature1: undefined,
       selectedFeature2: undefined
     };
@@ -60,7 +66,10 @@ export class MatrixFilter extends React.PureComponent<
     return (
       <div className={classNames.matrixFilter}>
         <Stack tokens={stackTokens}>
-          <MatrixLegend selectedCohort={this.props.selectedCohort} />
+          <MatrixLegend
+            selectedCohort={this.props.selectedCohort}
+            max={this.state.matrixLegendState.maxError}
+          />
           <Stack horizontal tokens={stackTokens} horizontalAlign="start">
             <Stack.Item key="feature1key">
               <ComboBox
@@ -100,6 +109,7 @@ export class MatrixFilter extends React.PureComponent<
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}
+            updateMatrixLegendState={this.updateMatrixLegendState}
           />
         </Stack>
       </div>
@@ -122,5 +132,9 @@ export class MatrixFilter extends React.PureComponent<
     if (item !== undefined) {
       this.setState({ selectedFeature2: item.text });
     }
+  };
+
+  private updateMatrixLegendState = (maxError: number): void => {
+    this.setState({ matrixLegendState: { maxError } });
   };
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
@@ -5,11 +5,13 @@ import { IStackTokens, Stack, Text } from "office-ui-fabric-react";
 import React from "react";
 
 import { ErrorCohort } from "../../ErrorCohort";
+import { ErrorRateGradient } from "../ErrorRateGradient/ErrorRateGradient";
 
 import { matrixLegendStyles } from "./MatrixLegend.styles";
 
 export interface IMatrixLegendProps {
   selectedCohort: ErrorCohort;
+  max: number;
 }
 
 const stackTokens: IStackTokens = { childrenGap: 5 };
@@ -43,14 +45,25 @@ export class MatrixLegend extends React.Component<IMatrixLegendProps> {
                 </div>
               </Stack>
             </Stack>
-            <Stack horizontal>
-              <div className={classNames.metricBarRed}></div>
-              <Stack tokens={cellTokens}>
-                <div className={classNames.smallHeader}>Error Rate</div>
-                <div className={classNames.valueBlack}>
-                  {this.props.selectedCohort.errorRate.toFixed(2)}%
-                </div>
+            <Stack>
+              <Stack horizontal>
+                <div className={classNames.metricBarRed}></div>
+                <Stack tokens={cellTokens}>
+                  <div className={classNames.smallHeader}>Error Rate</div>
+                  <div className={classNames.valueBlack}>
+                    {this.props.selectedCohort.errorRate.toFixed(2)}%
+                  </div>
+                </Stack>
               </Stack>
+              <svg width="60" height="60" viewBox="0 0 40 40">
+                <g>
+                  <ErrorRateGradient
+                    max={this.props.max}
+                    minPct={0}
+                    selectedCohort={this.props.selectedCohort}
+                  />
+                </g>
+              </svg>
             </Stack>
           </Stack>
         </Stack>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -10,6 +10,7 @@ import {
 
 export interface ITreeViewRendererStyles {
   clickedNodeDashed: IStyle;
+  clickedNodeFull: IStyle;
   mainFrame: IStyle;
   svgOuterFrame: IStyle;
   innerFrame: IStyle;
@@ -22,7 +23,7 @@ export interface ITreeViewRendererStyles {
   innerOpacityToggle: IStyle;
   opacityToggleRect: IStyle;
   opacityToggleCircle: IStyle;
-  nonOpacityToggleCircle: IStyle;
+  errorRateGradientStyle: IStyle;
   linksTransitionGroup: IStyle;
   nodesTransitionGroup: IStyle;
   linkLabelsTransitionGroup: IStyle;
@@ -46,6 +47,11 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
       strokeDasharray: "3, 3",
       strokeWidth: 2
     },
+    clickedNodeFull: {
+      fill: "none",
+      stroke: "#0078D4",
+      strokeWidth: 2
+    },
     detailLines: mergeStyles([
       detailStyle,
       {
@@ -55,6 +61,9 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     ]),
     details: {
       transform: "translate(0px, 5px)"
+    },
+    errorRateGradientStyle: {
+      transform: "translate(100px, 60px)"
     },
     innerFrame: {
       height: "100%",
@@ -101,9 +110,6 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
       fontSize: "9px",
       pointerEvents: "none",
       transform: "translate(0px, 0px)"
-    },
-    nonOpacityToggleCircle: {
-      transform: "translate(126px, 80px)"
     },
     nopointer: {
       pointerEvents: "none"


### PR DESCRIPTION
- Added full circle around selected node in tree view (as opposed to dashed)
![image](https://user-images.githubusercontent.com/24683184/104048774-d0dae600-51b1-11eb-9a06-12a059ccbd21.png)

- Added error rate gradient (a custom SVG) to both the tree view and matrix filter legends
![image](https://user-images.githubusercontent.com/24683184/104048806-dcc6a800-51b1-11eb-821d-f3d75f7f516e.png)
![image](https://user-images.githubusercontent.com/24683184/104048847-eea84b00-51b1-11eb-8848-fd3b6a6a042e.png)

- Fixed/added ICE plots to inspection view
![image](https://user-images.githubusercontent.com/24683184/104048924-07b0fc00-51b2-11eb-9c8b-257d4cea1169.png)
