### PR TITLE
matrix filter updates and various other fixes

### DIFF
--- a/apps/dashboard/src/error-analysis/App.tsx
+++ b/apps/dashboard/src/error-analysis/App.tsx
@@ -132,7 +132,10 @@ export class App extends React.Component<IAppProps> {
           data[0][1] === "mean texture"
         ) {
           resolve(_.cloneDeep(dummyMatrix2dInterval));
-        } else if (data[0][0] === "mean radius") {
+        } else if (
+          data[0][0] === "mean radius" ||
+          data[0][1] === "mean radius"
+        ) {
           resolve(_.cloneDeep(dummyMatrix1dInterval));
         } else {
           resolve(_.cloneDeep(dummyMatrixData));

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Constants.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Constants.ts
@@ -1,4 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export const noFeature = "No Feature";
+import { localization } from "@responsible-ai/localization";
+
+export const noFeature = localization.ErrorAnalysis.noFeature;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/CohortInfo/CohortInfo.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/CohortInfo/CohortInfo.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { JointDataset } from "@responsible-ai/interpret";
+import { localization } from "@responsible-ai/localization";
 import {
   DefaultButton,
   IFocusTrapZoneProps,
@@ -48,7 +49,7 @@ export class CohortInfo extends React.PureComponent<ICohortInfoProps> {
 
     return (
       <Panel
-        headerText="Cohort Information"
+        headerText={localization.ErrorAnalysis.CohortInfo.cohortInformation}
         isOpen={this.props.isOpen}
         focusTrapZoneProps={focusTrapZoneProps}
         // You MUST provide this prop! Otherwise screen readers will just say "button" with no label.
@@ -62,7 +63,7 @@ export class CohortInfo extends React.PureComponent<ICohortInfoProps> {
         <div className={classNames.section}>
           <div className={classNames.subsection}>
             <DefaultButton
-              text="Save Cohort"
+              text={localization.ErrorAnalysis.CohortInfo.saveCohort}
               onClick={(): any => this.props.onSaveCohortClick()}
             />
           </div>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
@@ -94,18 +94,18 @@ export class InstanceView extends React.Component<
       text: localization.ErrorAnalysis.incorrectPrediction
     });
     this.choiceItems.push({
-      key: PredictionTabKeys.WhatIfDatapointsTab,
-      styles: {
-        root: classNames.choiceItemRootStyle
-      },
-      text: localization.ErrorAnalysis.whatIfDatapoints
-    });
-    this.choiceItems.push({
       key: PredictionTabKeys.AllSelectedTab,
       styles: {
         root: classNames.choiceItemRootStyle
       },
       text: localization.ErrorAnalysis.allSelected
+    });
+    this.choiceItems.push({
+      key: PredictionTabKeys.WhatIfDatapointsTab,
+      styles: {
+        root: classNames.choiceItemRootStyle
+      },
+      text: localization.ErrorAnalysis.whatIfDatapoints
     });
   }
 

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MainMenu/MainMenu.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MainMenu/MainMenu.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { localization } from "@responsible-ai/localization";
 import {
   CommandBar,
   Dropdown,
@@ -87,8 +88,14 @@ export class MainMenu extends React.PureComponent<
 
   public render(): React.ReactNode {
     const errorAnalysisOptionsDropdown: IDropdownOption[] = [
-      { key: ErrorAnalysisOptions.TreeMap, text: "Tree Map" },
-      { key: ErrorAnalysisOptions.HeatMap, text: "Heat Map" }
+      {
+        key: ErrorAnalysisOptions.TreeMap,
+        text: localization.ErrorAnalysis.MainMenu.treeMap
+      },
+      {
+        key: ErrorAnalysisOptions.HeatMap,
+        text: localization.ErrorAnalysis.MainMenu.heatMap
+      }
     ];
 
     let items: ICommandBarItemProps[] = [];
@@ -96,7 +103,9 @@ export class MainMenu extends React.PureComponent<
       items = [
         {
           commandBarButtonAs: (): any => (
-            <Label styles={labelStyle}>Error Detector:</Label>
+            <Label styles={labelStyle}>
+              {localization.ErrorAnalysis.MainMenu.errorDetectorLabel}
+            </Label>
           ),
           key: "errorDetectorLabel",
           text: "Error Detector Label"
@@ -111,7 +120,7 @@ export class MainMenu extends React.PureComponent<
             />
           ),
           key: "errorDetector",
-          text: "Error Detector"
+          text: localization.ErrorAnalysis.MainMenu.errorDetector
         }
       ];
     } else {
@@ -134,7 +143,7 @@ export class MainMenu extends React.PureComponent<
         iconProps: fullscreenIcon,
         key: "fullscreen",
         onClick: (): any => window.open(this.props.localUrl),
-        text: "Fullscreen"
+        text: localization.ErrorAnalysis.MainMenu.fullscreen
       }
     ];
     if (
@@ -147,7 +156,7 @@ export class MainMenu extends React.PureComponent<
         iconProps: whatIfIcon,
         key: "whatIf",
         onClick: () => this.props.onWhatIfClick(),
-        text: "What-If"
+        text: localization.ErrorAnalysis.MainMenu.whatIf
       });
     }
     if (
@@ -159,7 +168,7 @@ export class MainMenu extends React.PureComponent<
         iconProps: featureListIcon,
         key: "featureList",
         onClick: () => this.props.onFeatureListClick(),
-        text: "Feature List"
+        text: localization.ErrorAnalysis.MainMenu.featureList
       });
     }
     const helpItems: ICommandBarItemProps[] = [
@@ -173,30 +182,30 @@ export class MainMenu extends React.PureComponent<
               iconProps: { iconName: "Import" },
               key: "shiftCohort",
               onClick: (): any => this.props.onShiftCohortClick(),
-              text: "Shift Cohort"
+              text: localization.ErrorAnalysis.MainMenu.shiftCohort
             },
             {
               iconProps: { iconName: "Save" },
               key: "saveCohort",
               onClick: (): any => this.props.onSaveCohortClick(),
-              text: "Save Cohort"
+              text: localization.ErrorAnalysis.MainMenu.saveCohort
             },
             {
               iconProps: { iconName: "PageList" },
               key: "cohortList",
               onClick: (): any => this.props.onCohortListPanelClick(),
-              text: "Cohort List"
+              text: localization.ErrorAnalysis.MainMenu.cohortList
             }
           ]
         },
-        text: "Cohort Settings"
+        text: localization.ErrorAnalysis.MainMenu.cohortSettings
       },
       {
         buttonStyles: buttonStyle,
         iconProps: infoIcon,
         key: "cohortInfo",
         onClick: (): any => this.props.onInfoPanelClick(),
-        text: "Cohort Info"
+        text: localization.ErrorAnalysis.MainMenu.cohortInfo
       }
     ];
     farItems.push(...helpItems);
@@ -214,7 +223,7 @@ export class MainMenu extends React.PureComponent<
           />
         ),
         key: "explanation",
-        text: "Explanation"
+        text: localization.ErrorAnalysis.MainMenu.explanation
       });
     }
     const classNames = mainMenuStyles();

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.styles.ts
@@ -15,6 +15,7 @@ export interface IMatrixAreaStyles {
   matrixCell: IStyle;
   matrixCellPivot1Categories: IStyle;
   matrixCellPivot2Categories: IStyle;
+  matrixCol: IStyle;
   matrixRow: IStyle;
   matrixArea: IStyle;
   nanMatrixCell: IStyle;
@@ -72,6 +73,13 @@ export const matrixAreaStyles: () => IProcessedStyleSet<
       maxWidth: "60px",
       minWidth: "60px",
       overflow: "hidden"
+    },
+    matrixCol: {
+      display: "flex",
+      flexDirection: "column",
+      fontFamily: "Segoe UI",
+      fontStyle: "normal",
+      fontWeight: "normal"
     },
     matrixLabel: {
       paddingLeft: "20px"

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -71,6 +71,7 @@ export class MatrixFilter extends React.PureComponent<
         <Stack tokens={stackTokens}>
           <MatrixLegend
             selectedCohort={this.props.selectedCohort}
+            baseCohort={this.props.baseCohort}
             max={this.state.matrixLegendState.maxError}
           />
           <Stack horizontal tokens={stackTokens} horizontalAlign="start">

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 
 import { localization } from "@responsible-ai/localization";
-import { IStackTokens, Stack, Text } from "office-ui-fabric-react";
+import {
+  IStackStyles,
+  IStackTokens,
+  Stack,
+  Text
+} from "office-ui-fabric-react";
 import React from "react";
 
 import { ErrorCohort } from "../../ErrorCohort";
@@ -12,20 +17,35 @@ import { matrixLegendStyles } from "./MatrixLegend.styles";
 
 export interface IMatrixLegendProps {
   selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
   max: number;
 }
 
 const stackTokens: IStackTokens = { childrenGap: 5 };
 const cellTokens: IStackTokens = { padding: 10 };
+const legendDescriptionPadding: IStackTokens = { padding: "20px 0px 20px 0px" };
+const legendDescriptionStyle: IStackStyles = {
+  root: {
+    width: 500
+  }
+};
 
 export class MatrixLegend extends React.Component<IMatrixLegendProps> {
   public render(): React.ReactNode {
     const classNames = matrixLegendStyles();
     return (
       <div className={classNames.matrixLegend}>
+        <Stack
+          styles={legendDescriptionStyle}
+          tokens={legendDescriptionPadding}
+        >
+          <Text variant={"smallPlus"}>
+            {localization.ErrorAnalysis.MatrixLegend.heatMapDescription}
+          </Text>
+        </Stack>
         <Stack tokens={stackTokens}>
           <Text variant={"xLarge"} block>
-            Cohort: {this.props.selectedCohort.cohort.name}
+            Cohort: {this.props.baseCohort.cohort.name}
           </Text>
           <Stack horizontal>
             <Stack horizontal>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { localization } from "@responsible-ai/localization";
 import {
   Breadcrumb,
   IBreadcrumbItem,
@@ -39,19 +40,19 @@ export class Navigation extends React.Component<INavigationProps> {
             this.errorDetectorBreadcrumbClicked(e, item);
           }
         },
-        text: "Error Detector"
+        text: localization.ErrorAnalysis.Navigation.errorDetector
       });
       if (this.props.activeGlobalTab === GlobalTabKeys.DataExplorerTab) {
         items.push({
           key: GlobalTabKeys.DataExplorerTab,
-          text: "Data Explorer"
+          text: localization.ErrorAnalysis.Navigation.dataExplorer
         });
       } else if (
         this.props.activeGlobalTab === GlobalTabKeys.GlobalExplanationTab
       ) {
         items.push({
           key: GlobalTabKeys.GlobalExplanationTab,
-          text: "Global Explanation"
+          text: localization.ErrorAnalysis.Navigation.globalExplanation
         });
       } else if (
         this.props.activeGlobalTab === GlobalTabKeys.LocalExplanationTab
@@ -61,7 +62,7 @@ export class Navigation extends React.Component<INavigationProps> {
         ) {
           items.push({
             key: GlobalTabKeys.LocalExplanationTab,
-            text: "Local Explanation"
+            text: localization.ErrorAnalysis.Navigation.localExplanation
           });
         } else {
           items.push({
@@ -74,11 +75,12 @@ export class Navigation extends React.Component<INavigationProps> {
                 this.localExplanationBreadcrumbClicked(e, item);
               }
             },
-            text: "Local Explanation"
+            text: localization.ErrorAnalysis.Navigation.localExplanation
           });
           items.push({
             key: PredictionTabKeys.InspectionTab,
-            text: "Local Explanation (Inspection)"
+            text:
+              localization.ErrorAnalysis.Navigation.localExplanationInspection
           });
         }
       }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
@@ -10,6 +10,7 @@ import { treeLegendStyles } from "./TreeLegend.styles";
 
 export interface ITreeLegendProps {
   selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
 }
 
 export class TreeLegend extends React.Component<ITreeLegendProps> {
@@ -19,7 +20,7 @@ export class TreeLegend extends React.Component<ITreeLegendProps> {
       <g className={classNames.treeLegend}>
         <g>
           <text className={classNames.cohortName}>
-            Cohort: {this.props.selectedCohort.cohort.name}
+            Cohort: {this.props.baseCohort.cohort.name}
           </text>
           <g>
             <g className={classNames.errorCoverageCell}>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -372,7 +372,10 @@ export class TreeViewRenderer extends React.PureComponent<
                     height="140"
                     fill="transparent"
                   />
-                  <TreeLegend selectedCohort={this.props.selectedCohort} />
+                  <TreeLegend
+                    selectedCohort={this.props.selectedCohort}
+                    baseCohort={this.props.baseCohort}
+                  />
                   <g className={classNames.opacityToggleCircle}>
                     <circle
                       r="26"

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -726,7 +726,9 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
 
   private addCustomPoint(temporaryPoint: { [key: string]: any }): void {
     this.setState({
-      customPoints: [...this.state.customPoints, temporaryPoint]
+      customPoints: [...this.state.customPoints, temporaryPoint],
+      openWhatIf: false,
+      predictionTab: PredictionTabKeys.WhatIfDatapointsTab
     });
   }
 
@@ -744,10 +746,11 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
 
     let selectedCohortName = "";
     let addTemporaryCohort = true;
-    if (source === ErrorDetectorCohortSource.TreeMap) {
-      selectedCohortName = `${this.state.baseCohort.cohort.name} (${filtersRelabeled.length} filters)`;
-    } else if (source === ErrorDetectorCohortSource.HeatMap) {
-      selectedCohortName = `${this.state.baseCohort.cohort.name} (${cells} cells)`;
+    if (
+      source === ErrorDetectorCohortSource.TreeMap ||
+      source === ErrorDetectorCohortSource.HeatMap
+    ) {
+      selectedCohortName = "Unsaved";
     } else {
       selectedCohortName = this.state.baseCohort.cohort.name;
       addTemporaryCohort = false;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
@@ -12,8 +12,8 @@ import {
 
 export enum ErrorDetectorCohortSource {
   None = "None",
-  TreeMap = "Tree Map",
-  HeatMap = "Heat Map"
+  TreeMap = "Tree map",
+  HeatMap = "Heat map"
 }
 
 export class ErrorCohort {

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -578,23 +578,24 @@
     "defaultFeatureNames": "Feature {0}",
     "_defaultFeatureNames.comment": "the default column names",
     "cohortInfo": "Cohort info",
-    "correctPrediction": "Correct Predictions",
-    "incorrectPrediction": "Incorrect Predictions",
-    "whatIfDatapoints": "What-If Datapoints",
-    "allSelected": "All Selected",
+    "correctPrediction": "Correct predictions",
+    "incorrectPrediction": "Incorrect predictions",
+    "whatIfDatapoints": "What-If datapoints",
+    "allSelected": "All selected",
     "correctTotal": "Correct/Total",
     "dataExploration": "Dataset Exploration",
     "_dataExploration.comment": "Label for tab showing scatterplot of dataset and predictions",
     "instanceView": "Instance View",
     "_instanceView.comment": "Label for tab showing instances",
-    "dataExplorerView": "Data Explorer",
+    "dataExplorerView": "Data explorer",
     "_dataExplorerView.comment": "Data explorer view",
     "errorCoverage": "Error coverage",
     "errorRate": "Error rate",
-    "globalExplanationView": "Global Explanation",
+    "globalExplanationView": "Global explanation",
     "_globalExplanationView.comment": "Global explanation view",
-    "localExplanationView": "Local Explanation",
+    "localExplanationView": "Local explanation",
     "_localExplanationView.comment": "Local explanation view",
+    "noFeature": "No feature",
     "globalImportance": "Global Importance",
     "_globalImportance.comment": "Label for tab showing bar chart of importance of features at a global level",
     "incorrectTotal": "Incorrect/Total",
@@ -603,6 +604,14 @@
       "cohort": "Cohort",
       "_cohort.comment": "a subset of the data is called a cohort",
       "defaultLabel": "All data"
+    },
+    "CohortInfo": {
+      "cohortInformation": "Cohort information",
+      "saveCohort": "Save as a new cohort"
+    },
+    "EditCohort": {
+      "subText": "Learn about the selected cohort. Edit its cohort name. Delete this cohort.",
+      "cohortName": "Cohort name"
     },
     "ExplanationScatter": {
       "dataLabel": "Data : {0}",
@@ -630,12 +639,36 @@
       "count": "Count",
       "_count.comment": "the default axis is the count of items"
     },
+    "MainMenu": {
+      "treeMap": "Tree map",
+      "heatMap": "Heat map",
+      "errorDetectorLabel": "Error detector:",
+      "errorDetector": "Error detector",
+      "fullscreen": "Fullscreen",
+      "whatIf": "What-If",
+      "featureList": "Feature list",
+      "shiftCohort": "Shift cohort",
+      "saveCohort": "Save cohort",
+      "cohortList": "Cohort list",
+      "cohortInfo": "Cohort info",
+      "explanation": "Explanation",
+      "cohortSettings": "Cohort settings"
+    },
+    "MatrixArea": {
+      "emptyText": "Select two features by using the dropdowns above.  You can cluster and filter your data along two dimensions."
+    },
+    "MatrixLegend": {
+      "heatMapDescription": "With the grid map you can focus on specific filters and combine error rates.  Start with two dataset features to compare."
+    },
+    "Navigation": {
+      "errorDetector": "Error detector",
+      "dataExplorer": "Data explorer",
+      "globalExplanation": "Global explanation",
+      "localExplanation": "Local explanation",
+      "localExplanationInspection": "Local explanation (Inspection)"
+    },
     "WhatIfPanel": {
       "whatIfHeader": "What-If"
-    },
-    "EditCohort": {
-      "subText": "Learn about the selected cohort. Edit its cohort name. Delete this cohort.",
-      "cohortName": "Cohort name"
     }
   },
   "Fairness": {

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -469,7 +469,7 @@ class ErrorAnalysisDashboardInput:
 
     def matrix(self, features, filters, composite_filters):
         try:
-            if features[0] is None:
+            if features[0] is None and features[1] is None:
                 return {WidgetRequestResponseConstants.DATA: []}
             interface = ExplanationDashboardInterface
             feature_names = self.dashboard_input[interface.FEATURE_NAMES]


### PR DESCRIPTION
- if matrix filter has same feature chosen, show a row.  If matrix filter has no feature for x axis and feature selected for y axis, show a column  (https://github.com/microsoft/responsible-ai-widgets/issues/178, https://github.com/microsoft/responsible-ai-widgets/issues/177)
![image](https://user-images.githubusercontent.com/24683184/105075102-50d93980-5a57-11eb-8caf-89d246bc3863.png)
- add helper text to heatmap, both a summary at top and when no features selected (https://github.com/microsoft/responsible-ai-widgets/issues/190)
![image](https://user-images.githubusercontent.com/24683184/105075049-3acb7900-5a57-11eb-86f5-444121c79d6a.png)
- change text to be sentence case (https://github.com/microsoft/responsible-ai-widgets/issues/226)
- what if workflow update: after adding what-if point, automatically go to the what-if datapoints tab and close the what-if tab (https://github.com/microsoft/responsible-ai-widgets/issues/254)
- in legend show base cohort name and also get rid of "<base cohort> (* filters)" and just call temporary cohorts "Unsaved" (https://github.com/microsoft/responsible-ai-widgets/issues/248)
