### PR TITLE
bump requirement version of rai_core_flask in raiwidgets

### DIFF
--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.17.2
 ipywidgets>=7.5.0
 pandas>=0.25.1
 scipy>=1.4.1
-rai-core-flask==0.0.2
+rai-core-flask==0.0.3
 gevent>=1.3.6
 jinja2==2.11.1
 ipython==7.16.1

--- a/wrapped-flask/setup.py
+++ b/wrapped-flask/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 # The version must be incremented every time we push an update to pypi (but
 # not before)
-VERSION = "0.0.3-dev"
+VERSION = "0.0.4-dev"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Updating since a `rai_core_flask` release happened on Friday last week.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>