### PR TITLE
Hide removal dialog on click

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/DashboardSettingDeleteButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/DashboardSettingDeleteButton.tsx
@@ -61,5 +61,6 @@ export class DashboardSettingDeleteButton extends React.PureComponent<
 
   private removeTab = (): void => {
     this.props.removeTab(this.props.index);
+    this.hideDialog();
   };
 }


### PR DESCRIPTION
When adding multiple components and deleting them sometimes the dialog does not hide after confirming the removal. This addition ensures that we always call hideDialog after the removal.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>