### PR TITLE
add quantile binning and number of bins to UX and hook up calls to backend

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaProps.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaProps.ts
@@ -18,6 +18,7 @@ export interface IMatrixAreaProps {
   features: string[];
   selectedFeature1?: string;
   selectedFeature2?: string;
+  isEnabled: boolean;
   getMatrix?: (
     request: any,
     abortSignal: AbortSignal

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
@@ -15,40 +15,46 @@ import {
   IErrorAnalysisMatrixNode
 } from "@responsible-ai/core-ui";
 
-import { IMatrixAreaProps } from "./MatrixAreaProps";
-
 export async function fetchMatrix(
-  props: IMatrixAreaProps
+  quantileBinning: boolean,
+  numBins: number,
+  baseCohort: ErrorCohort,
+  selectedFeature1: string | undefined,
+  selectedFeature2: string | undefined,
+  getMatrix?: (
+    request: any,
+    abortSignal: AbortSignal
+  ) => Promise<IErrorAnalysisMatrix>,
+  matrix?: IErrorAnalysisMatrix | undefined
 ): Promise<IErrorAnalysisMatrix | undefined> {
-  if (!props.getMatrix && props.matrix) {
-    return props.matrix;
+  if (!getMatrix && matrix) {
+    return matrix;
   }
-  if (
-    props.getMatrix === undefined ||
-    (!props.selectedFeature1 && !props.selectedFeature2)
-  ) {
+  if (getMatrix === undefined || (!selectedFeature1 && !selectedFeature2)) {
     return undefined;
   }
   const filtersRelabeled = ErrorCohort.getLabeledFilters(
-    props.baseCohort.cohort.filters,
-    props.baseCohort.jointDataset
+    baseCohort.cohort.filters,
+    baseCohort.jointDataset
   );
   const compositeFiltersRelabeled = ErrorCohort.getLabeledCompositeFilters(
-    props.baseCohort.cohort.compositeFilters,
-    props.baseCohort.jointDataset
+    baseCohort.cohort.compositeFilters,
+    baseCohort.jointDataset
   );
-  const selectedFeature1: string | undefined =
-    props.selectedFeature1 || props.selectedFeature2 || undefined;
-  const selectedFeature2: string | undefined =
-    props.selectedFeature2 === selectedFeature1
+  const selectedFeature1Request: string | undefined =
+    selectedFeature1 || selectedFeature2 || undefined;
+  const selectedFeature2Request: string | undefined =
+    selectedFeature2 === selectedFeature1Request
       ? undefined
-      : props.selectedFeature2 || undefined;
+      : selectedFeature2 || undefined;
   // Note: edge case, if both features selected are the same one, show just a row
-  return props.getMatrix(
+  return getMatrix(
     [
-      [selectedFeature1, selectedFeature2],
+      [selectedFeature1Request, selectedFeature2Request],
       filtersRelabeled,
-      compositeFiltersRelabeled
+      compositeFiltersRelabeled,
+      quantileBinning,
+      numBins
     ],
     new AbortController().signal
   );

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -23,6 +23,7 @@ import React from "react";
 import { IMatrixAreaState, IMatrixFilterState } from "../../MatrixFilterState";
 import { MatrixArea } from "../MatrixArea/MatrixArea";
 import { MatrixLegend } from "../MatrixLegend/MatrixLegend";
+import { MatrixSummary } from "../MatrixSummary/MatrixSummary";
 
 import { matrixFilterStyles } from "./MatrixFilter.styles";
 
@@ -51,7 +52,7 @@ export interface IMatrixFilterProps {
   isEnabled: boolean;
 }
 
-const stackTokens: IStackTokens = { childrenGap: 5 };
+const stackTokens: IStackTokens = { childrenGap: "l1" };
 
 export class MatrixFilter extends React.PureComponent<
   IMatrixFilterProps,
@@ -86,18 +87,14 @@ export class MatrixFilter extends React.PureComponent<
     return (
       <div className={classNames.matrixFilter}>
         <Stack tokens={stackTokens}>
-          <MatrixLegend
-            selectedCohort={this.props.selectedCohort}
-            baseCohort={this.props.baseCohort}
-            max={this.state.matrixLegendState.maxMetricValue}
-          />
+          <MatrixSummary />
           <Stack horizontal tokens={stackTokens} horizontalAlign="start">
             <Stack.Item key="feature1key">
               <ComboBox
                 defaultSelectedKey={
                   this.props.matrixAreaState?.matrixFeature1 || ""
                 }
-                label="Y-Axis: Feature 1"
+                label="Rows: Feature 1"
                 options={this.options}
                 dropdownMaxWidth={300}
                 useComboBoxAsMenuWidth
@@ -114,7 +111,7 @@ export class MatrixFilter extends React.PureComponent<
                 defaultSelectedKey={
                   this.props.matrixAreaState?.matrixFeature2 || ""
                 }
-                label="X-Axis: Feature 2"
+                label="Columns: Feature 2"
                 options={this.options}
                 dropdownMaxWidth={300}
                 useComboBoxAsMenuWidth
@@ -128,6 +125,11 @@ export class MatrixFilter extends React.PureComponent<
               />
             </Stack.Item>
           </Stack>
+          <MatrixLegend
+            selectedCohort={this.props.selectedCohort}
+            baseCohort={this.props.baseCohort}
+            max={this.state.matrixLegendState.maxMetricValue}
+          />
           <MatrixArea
             theme={this.props.theme}
             features={this.props.features}
@@ -141,6 +143,7 @@ export class MatrixFilter extends React.PureComponent<
             updateMatrixLegendState={this.updateMatrixLegendState}
             state={this.props.matrixAreaState}
             setMatrixAreaState={this.props.setMatrixAreaState}
+            isEnabled={this.props.isEnabled}
           />
         </Stack>
       </div>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
@@ -3,12 +3,7 @@
 
 import { ErrorCohort, Metrics } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
-import {
-  IStackStyles,
-  IStackTokens,
-  Stack,
-  Text
-} from "office-ui-fabric-react";
+import { IStackTokens, Stack, Text } from "office-ui-fabric-react";
 import React from "react";
 
 import { MetricUtils, MetricLocalizationType } from "../../MetricUtils";
@@ -25,12 +20,6 @@ export interface IMatrixLegendProps {
 
 const stackTokens: IStackTokens = { childrenGap: 5 };
 const cellTokens: IStackTokens = { padding: 10 };
-const legendDescriptionPadding: IStackTokens = { padding: "20px 0px 20px 0px" };
-const legendDescriptionStyle: IStackStyles = {
-  root: {
-    width: 500
-  }
-};
 
 export class MatrixLegend extends React.Component<IMatrixLegendProps> {
   private readonly _errorRateIconId = "errorRateIconId";
@@ -42,14 +31,6 @@ export class MatrixLegend extends React.Component<IMatrixLegendProps> {
     const isRate = this.props.selectedCohort.metricName === Metrics.ErrorRate;
     return (
       <div className={classNames.matrixLegend}>
-        <Stack
-          styles={legendDescriptionStyle}
-          tokens={legendDescriptionPadding}
-        >
-          <Text variant={"smallPlus"}>
-            {localization.ErrorAnalysis.MatrixLegend.heatMapDescription}
-          </Text>
-        </Stack>
         <Stack tokens={stackTokens}>
           <Text variant={"xLarge"} block>
             Cohort: {this.props.baseCohort.cohort.name}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixOptions/MatrixOptions.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixOptions/MatrixOptions.styles.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  mergeStyleSets,
+  IProcessedStyleSet,
+  IStyle
+} from "office-ui-fabric-react";
+
+export interface IMatrixLegendStyles {
+  sliderLabelStyle: IStyle;
+  sliderStackStyle: IStyle;
+  toggleStackStyle: IStyle;
+}
+
+export const matrixOptionsStyles: () => IProcessedStyleSet<IMatrixLegendStyles> =
+  () => {
+    return mergeStyleSets<IMatrixLegendStyles>({
+      sliderLabelStyle: {
+        padding: 0
+      },
+      sliderStackStyle: {
+        minWidth: 200
+      },
+      toggleStackStyle: {
+        minWidth: 100
+      }
+    });
+  };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixOptions/MatrixOptions.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixOptions/MatrixOptions.tsx
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { localization } from "@responsible-ai/localization";
+import {
+  IStackTokens,
+  Label,
+  Stack,
+  Slider,
+  Toggle
+} from "office-ui-fabric-react";
+import React from "react";
+
+import { InfoCallout } from "../InfoCallout/InfoCallout";
+
+import { matrixOptionsStyles } from "./MatrixOptions.styles";
+
+export interface IMatrixOptionsProps {
+  quantileBinning: boolean;
+  binningThreshold: number;
+  isEnabled: boolean;
+  updateQuantileBinning: (quantileBinning: boolean) => void;
+  updateNumBins: (numBins: number) => void;
+}
+
+const stackTokens: IStackTokens = { childrenGap: "l1" };
+
+export class MatrixOptions extends React.Component<IMatrixOptionsProps> {
+  private readonly _quantileBinningIconId = "quantileBinningIconId";
+  private readonly _binningThresholdIconId = "binningThresholdIconId";
+
+  public render(): React.ReactNode {
+    const classNames = matrixOptionsStyles();
+    return (
+      <Stack horizontal tokens={stackTokens}>
+        <Stack.Item className={classNames.toggleStackStyle}>
+          <Toggle
+            label={
+              <div>
+                {localization.ErrorAnalysis.MatrixOptions.quantileBinningLabel}
+                <InfoCallout
+                  iconId={this._quantileBinningIconId}
+                  infoText={
+                    localization.ErrorAnalysis.MatrixOptions
+                      .quantileBinningInfoText
+                  }
+                  title={
+                    localization.ErrorAnalysis.MatrixOptions
+                      .quantileBinningTitle
+                  }
+                />
+              </div>
+            }
+            onText={localization.ErrorAnalysis.MatrixOptions.toggleOnLabel}
+            offText={localization.ErrorAnalysis.MatrixOptions.toggleOffLabel}
+            onChange={this.onBinningToggleChange}
+            styles={{ label: { padding: 0 }, root: { padding: 0 } }}
+            disabled={!this.props.isEnabled}
+          />
+        </Stack.Item>
+        <Stack.Item className={classNames.sliderStackStyle}>
+          <Label className={classNames.sliderLabelStyle}>
+            {localization.ErrorAnalysis.MatrixOptions.binningThresholdLabel}
+            <InfoCallout
+              iconId={this._binningThresholdIconId}
+              infoText={
+                localization.ErrorAnalysis.MatrixOptions
+                  .binningThresholdInfoText
+              }
+              title={
+                localization.ErrorAnalysis.MatrixOptions.binningThresholdTitle
+              }
+            />
+          </Label>
+          <Slider
+            min={2}
+            max={20}
+            defaultValue={8}
+            showValue
+            onChanged={this.onBinsSliderChanged}
+            disabled={!this.props.isEnabled}
+          />
+        </Stack.Item>
+      </Stack>
+    );
+  }
+
+  private onBinningToggleChange = (
+    _: React.MouseEvent<HTMLElement>,
+    checked?: boolean
+  ): void => {
+    if (checked !== undefined) {
+      this.props.updateQuantileBinning(checked);
+    }
+  };
+
+  private onBinsSliderChanged = (
+    _: MouseEvent | TouchEvent | KeyboardEvent,
+    value: number
+  ): void => {
+    this.props.updateNumBins(value);
+  };
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixSummary/MatrixSummary.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixSummary/MatrixSummary.styles.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet
+} from "office-ui-fabric-react";
+
+export interface IMatrixSummaryStyles {
+  legendDescriptionStyle: IStyle;
+}
+
+export const matrixSummaryStyles: () => IProcessedStyleSet<IMatrixSummaryStyles> =
+  () => {
+    return mergeStyleSets<IMatrixSummaryStyles>({
+      legendDescriptionStyle: {
+        width: 500
+      }
+    });
+  };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixSummary/MatrixSummary.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixSummary/MatrixSummary.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { localization } from "@responsible-ai/localization";
+import { IStackTokens, Stack, Text } from "office-ui-fabric-react";
+import React from "react";
+
+import { matrixSummaryStyles } from "./MatrixSummary.styles";
+
+const legendDescriptionPadding: IStackTokens = { padding: "20px 0px 20px 0px" };
+
+export class MatrixSummary extends React.Component {
+  public render(): React.ReactNode {
+    const classNames = matrixSummaryStyles();
+    return (
+      <Stack
+        className={classNames.legendDescriptionStyle}
+        tokens={legendDescriptionPadding}
+      >
+        <Text variant={"smallPlus"}>
+          {localization.ErrorAnalysis.MatrixSummary.heatMapDescription}
+        </Text>
+      </Stack>
+    );
+  }
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/MatrixFilterState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/MatrixFilterState.ts
@@ -3,6 +3,8 @@
 
 import { IErrorAnalysisMatrix } from "@responsible-ai/core-ui";
 
+const defaultNumBins = 8;
+
 export interface IMatrixLegendState {
   maxMetricValue: number;
 }
@@ -21,6 +23,8 @@ export interface IMatrixAreaState {
   matrixFeature2?: string;
   disableClearAll: boolean;
   disableSelectAll: boolean;
+  quantileBinning: boolean;
+  numBins: number;
 }
 
 export function createInitialMatrixFilterState(): IMatrixFilterState {
@@ -39,6 +43,8 @@ export function createInitialMatrixAreaState(): IMatrixAreaState {
     matrixFeature1: undefined,
     matrixFeature2: undefined,
     maxMetricValue: 0,
+    numBins: defaultNumBins,
+    quantileBinning: false,
     selectedCells: undefined
   };
 }

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -180,8 +180,18 @@
       "emptyText": "Select two features by using the dropdowns above.  You can cluster and filter your data along two dimensions.",
       "selectAll": "Select all"
     },
-    "MatrixLegend": {
+    "MatrixSummary": {
       "heatMapDescription": "With the heat map you can focus on specific intersectional feature filters and compute disaggregated error rates. Start with two dataset features to compare."
+    },
+    "MatrixOptions": {
+      "quantileBinningLabel": "Quantile binning",
+      "binningThresholdLabel": "Binning threshold",
+      "toggleOnLabel": "On",
+      "toggleOffLabel": "Off",
+      "quantileBinningInfoText": "Distribute values evenly across varying ranges of bins",
+      "quantileBinningTitle": "Additional information on quantile binning",
+      "binningThresholdInfoText": "Number of values required before binning",
+      "binningThresholdTitle": "Additional information on binning threshold"
     },
     "Metrics": {
       "errorRate": "Error rate",

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -151,7 +151,9 @@ class ErrorAnalysisDashboard(Dashboard):
 
         def matrix():
             data = request.get_json(force=True)
-            return jsonify(self.input.matrix(data[0], data[1], data[2]))
+            matrix_result = self.input.matrix(data[0], data[1], data[2],
+                                              data[3], data[4])
+            return jsonify(matrix_result)
 
         self.add_url_rule(matrix, '/matrix', methods=["POST"])
 

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -456,12 +456,14 @@ class ErrorAnalysisDashboardInput:
                 WidgetRequestResponseConstants.DATA: []
             }
 
-    def matrix(self, features, filters, composite_filters):
+    def matrix(self, features, filters, composite_filters,
+               quantile_binning, num_bins):
         try:
             if features[0] is None and features[1] is None:
                 return {WidgetRequestResponseConstants.DATA: []}
             matrix = self._error_analyzer.compute_matrix(
-                features, filters, composite_filters)
+                features, filters, composite_filters,
+                quantile_binning, num_bins)
             return {
                 WidgetRequestResponseConstants.DATA: matrix
             }

--- a/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
@@ -73,11 +73,16 @@ class ModelAnalysisDashboardInput:
 
     def matrix(self, data):
         try:
-            features, filters, composite_filters = data
+            features = data[0]
+            filters = data[1]
+            composite_filters = data[2]
+            quantile_binning = data[3]
+            num_bins = data[4]
             if features[0] is None and features[1] is None:
                 return {WidgetRequestResponseConstants.data: []}
             matrix = self._error_analyzer.compute_matrix(
-                features, filters, composite_filters)
+                features, filters, composite_filters,
+                quantile_binning, num_bins)
             return {
                 WidgetRequestResponseConstants.data: matrix
             }


### PR DESCRIPTION
- add quantile binning toggle
- add slider for number  of bins
- hook up to backend in model analysis and error analysis widgets
- minor styling updates based on new design

![image](https://user-images.githubusercontent.com/24683184/130874043-7461d85f-3ddb-4765-92df-a4d60e006ad8.png)
