### PR TITLE
suppress distracting logging from flask when running widgets

### DIFF
--- a/wrapped-flask/rai_core_flask/flask_helper.py
+++ b/wrapped-flask/rai_core_flask/flask_helper.py
@@ -14,6 +14,7 @@ import time
 
 from gevent.pywsgi import WSGIServer
 
+import logging
 
 LOCALHOST = 'localhost'
 VM_ENVS = {CREDENTIALED_VM, PUBLIC_VM}
@@ -25,6 +26,7 @@ class FlaskHelper(object):
     def __init__(self, ip=None, port=None, with_credentials=False):
         # The name passed to Flask needs to be unique per instance.
         self.app = Flask(uuid.uuid4().hex)
+
         self.port = port
         self.ip = ip
         self.with_credentials = with_credentials
@@ -95,7 +97,9 @@ class FlaskHelper(object):
         if self.env_name in VM_ENVS:
             host_name = socket.gethostname()
             ip = socket.gethostbyname(host_name)
-        self.server = WSGIServer((ip, self.port), self.app)
+        logger = logging.getLogger('wsgiserver')
+        logger.setLevel(logging.ERROR)
+        self.server = WSGIServer((ip, self.port), self.app, log=logger)
         self.app.config["server"] = self.server
         # self.app.config["CACHE_TYPE"] = "null"
         self.server.serve_forever()


### PR DESCRIPTION
I was seeing distracting logging in our notebooks whenever running widgets:

![image](https://user-images.githubusercontent.com/24683184/131154338-10bcbfb6-9626-48c2-a86d-0b47211a2c86.png)

this fix disables these distracting messages from flask/WSGIServer