### PR TITLE
fix class length causing labels to not be shown in simple view of EA

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -181,10 +181,23 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       featureNamesAbridged = featureNames;
     }
     let classNames = props.dataSummary.classNames;
-    const classLength = getClassLength(
-      props.precomputedExplanations,
+    let classLength = 1;
+    if (
+      (props.precomputedExplanations &&
+        (props.precomputedExplanations.localFeatureImportance ||
+          props.precomputedExplanations.globalFeatureImportance)) ||
       props.probabilityY
-    );
+    ) {
+      classLength = getClassLength(
+        props.precomputedExplanations,
+        props.probabilityY
+      );
+    } else if (modelType === ModelTypes.Binary) {
+      classLength = 2;
+    } else if (modelType === ModelTypes.Multiclass) {
+      classLength = new Set([...props.trueY!].concat(props.predictedY!)).size;
+    }
+
     if (!classNames || classNames.length !== classLength) {
       classNames = buildIndexedNames(
         classLength,


### PR DESCRIPTION
resolves issue:
https://github.com/microsoft/responsible-ai-widgets/issues/931

In simple view, the labels are not being shown because getClassLength thinks the task is a regression task incorrectly since there is 1.) no explanation or 2.) no probability column specified.