### PR TITLE
fix multiclass precision and recall calculation for NA zero values in heatmap

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -342,7 +342,8 @@ class _AggFunc(_BaseAggFunc):
 class _MultiMetricAggFunc(_BaseAggFunc):
     def __init__(self, aggfunc, labels):
         super(_MultiMetricAggFunc, self).__init__(aggfunc)
-        if len(labels) == 2:
+        self.num_labels = len(labels)
+        if self.num_labels == 2:
             # for binary classification case, choose positive class label
             self.labels = [labels[1]]
         else:
@@ -371,12 +372,15 @@ class _MultiMetricAggFunc(_BaseAggFunc):
 
     def _agg_func_triplet(self, pair):
         if pair.empty:
-            return (0, [0], [0], [0], [0], 0)
+            return self._fill_na_value()
         (true_y, pred_y) = zip(*pair.values.tolist())
         return self._multi_metric_result(true_y, pred_y)
 
     def _fill_na_value(self):
-        return (0, [0], [0], [0], [0], 0)
+        zero_array = [0]
+        if self.num_labels > 2:
+            zero_array = zero_array * self.num_labels
+        return (0, zero_array, zero_array, zero_array, zero_array, 0)
 
 
 def matrix_2d(categories1, categories2, matrix_counts,

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '23'
+_patch = '24'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- fixed bug with multiclass precision and recall calculations when there are empty cells (NA values) in heatmap
- added testing for the multiclass metrics in the python erroranalysis package