### PR TITLE
fix precision and recall score failing on string labels in error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -26,7 +26,8 @@ class BaseAnalyzer(ABC):
                  feature_names,
                  categorical_features,
                  model_task,
-                 metric):
+                 metric,
+                 classes):
         self._dataset = self._make_pandas_copy(dataset)
         self._true_y = true_y
         self._categorical_features = categorical_features
@@ -37,6 +38,7 @@ class BaseAnalyzer(ABC):
         self._categorical_indexes = []
         self._category_dictionary = {}
         self._model_task = model_task
+        self._classes = classes
         if model_task == ModelTask.CLASSIFICATION:
             if metric is None:
                 metric = Metrics.ERROR_RATE
@@ -76,6 +78,10 @@ class BaseAnalyzer(ABC):
     @property
     def categorical_indexes(self):
         return self._categorical_indexes
+
+    @property
+    def classes(self):
+        return self._classes
 
     @property
     def dataset(self):
@@ -187,7 +193,8 @@ class ModelAnalyzer(BaseAnalyzer):
                  feature_names,
                  categorical_features,
                  model_task=ModelTask.UNKNOWN,
-                 metric=None):
+                 metric=None,
+                 classes=None):
         self._model = model
         if model_task == ModelTask.UNKNOWN:
             # Try to automatically infer the model task
@@ -201,7 +208,8 @@ class ModelAnalyzer(BaseAnalyzer):
                                             feature_names,
                                             categorical_features,
                                             model_task,
-                                            metric)
+                                            metric,
+                                            classes)
 
     @property
     def model(self):
@@ -222,7 +230,8 @@ class PredictionsAnalyzer(BaseAnalyzer):
                  feature_names,
                  categorical_features,
                  model_task=ModelTask.CLASSIFICATION,
-                 metric=None):
+                 metric=None,
+                 classes=None):
         self._pred_y = pred_y
         if model_task == ModelTask.UNKNOWN:
             raise ValueError(
@@ -232,7 +241,8 @@ class PredictionsAnalyzer(BaseAnalyzer):
                                                   feature_names,
                                                   categorical_features,
                                                   model_task,
-                                                  metric)
+                                                  metric,
+                                                  classes)
 
     @property
     def pred_y(self):

--- a/erroranalysis/erroranalysis/_internal/metrics.py
+++ b/erroranalysis/erroranalysis/_internal/metrics.py
@@ -26,6 +26,21 @@ def macro_recall_score(y_true, y_pred):
     return recall_score(y_true, y_pred, average=MACRO)
 
 
+def get_ordered_labels(classes, true_y, pred_y):
+    # If classes is none, or disagrees with labels from true and predicted
+    # arrays, return the sorted set of labels.
+    # Otherwise return classes as it provides the correct ordering and any
+    # classes we may be missing for the subset of data evaluated.
+    labels = list(set(true_y) | set(pred_y))
+    labels.sort()
+    if classes is None:
+        return labels
+    for label in labels:
+        if label not in classes:
+            return labels
+    return classes
+
+
 metric_to_func = {
     Metrics.MEAN_ABSOLUTE_ERROR: mean_absolute_error,
     Metrics.MEAN_SQUARED_ERROR: mean_squared_error,

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '24'
+_patch = '25'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -101,9 +101,12 @@ def create_wine_data():
     return X_train, X_test, y_train, y_test, feature_names, classes
 
 
-def create_adult_census_data():
+def create_adult_census_data(string_labels=False):
     X, y = shap.datasets.adult()
-    y = [1 if r else 0 for r in y]
+    if string_labels:
+        y = [">=50K" if r else "<50K" for r in y]
+    else:
+        y = [1 if r else 0 for r in y]
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=7, stratify=y)

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pytest
+
 from common_utils import (
     create_iris_data, create_models_classification,
     create_adult_census_data, create_kneighbors_classifier)
@@ -8,7 +10,8 @@ from erroranalysis._internal.error_analyzer import ModelAnalyzer
 from erroranalysis._internal.surrogate_error_tree import (
     create_surrogate_model, get_categorical_info, get_max_split_index,
     traverse, TreeSide)
-from erroranalysis._internal.constants import (PRED_Y,
+from erroranalysis._internal.constants import (Metrics,
+                                               PRED_Y,
                                                TRUE_Y,
                                                DIFF,
                                                SPLIT_INDEX,
@@ -42,14 +45,19 @@ class TestSurrogateErrorTree(object):
         run_error_analyzer(model, X_test, y_test, list(X_train.columns),
                            categorical_features)
 
-    def test_traverse_tree(self):
+    @pytest.mark.parametrize('string_labels', [True, False])
+    @pytest.mark.parametrize('metric', [Metrics.ERROR_RATE,
+                                        Metrics.PRECISION_SCORE,
+                                        Metrics.RECALL_SCORE])
+    def test_traverse_tree(self, string_labels, metric):
         X_train, X_test, y_train, y_test, categorical_features = \
-            create_adult_census_data()
+            create_adult_census_data(string_labels)
         model = create_kneighbors_classifier(X_train, y_train)
         feature_names = list(X_train.columns)
         error_analyzer = ModelAnalyzer(model, X_test, y_test,
                                        feature_names,
-                                       categorical_features)
+                                       categorical_features,
+                                       metric=metric)
         categorical_info = get_categorical_info(error_analyzer,
                                                 feature_names)
         cat_ind_reindexed, categories_reindexed = categorical_info
@@ -87,25 +95,37 @@ class TestSurrogateErrorTree(object):
         validate_traversed_tree(tree_structure, tree_dict,
                                 max_split_index, feature_names)
 
-    def test_min_child_samples(self):
+    @pytest.mark.parametrize('metric', [Metrics.ERROR_RATE,
+                                        Metrics.MACRO_PRECISION_SCORE,
+                                        Metrics.MICRO_PRECISION_SCORE,
+                                        Metrics.MACRO_RECALL_SCORE,
+                                        Metrics.MICRO_RECALL_SCORE])
+    @pytest.mark.parametrize('min_child_samples', [5, 10, 20])
+    @pytest.mark.parametrize('max_depth', [3, 4])
+    @pytest.mark.parametrize('num_leaves', [5, 10, 31])
+    def test_parameters(self, metric, min_child_samples,
+                        max_depth, num_leaves):
         X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
         model = create_kneighbors_classifier(X_train, y_train)
         categorical_features = []
-        min_child_samples_list = [5, 10, 20]
-        for min_child_samples in min_child_samples_list:
-            run_error_analyzer(model, X_test, y_test, feature_names,
-                               categorical_features,
-                               min_child_samples=min_child_samples)
+        run_error_analyzer(model, X_test, y_test, feature_names,
+                           categorical_features,
+                           max_depth=max_depth,
+                           num_leaves=num_leaves,
+                           min_child_samples=min_child_samples,
+                           metric=metric)
 
 
 def run_error_analyzer(model, X_test, y_test, feature_names,
                        categorical_features, tree_features=None,
                        max_depth=3, num_leaves=31,
-                       min_child_samples=20):
+                       min_child_samples=20,
+                       metric=None):
     error_analyzer = ModelAnalyzer(model, X_test, y_test,
                                    feature_names,
-                                   categorical_features)
+                                   categorical_features,
+                                   metric=metric)
     if tree_features is None:
         tree_features = feature_names
     filters = None


### PR DESCRIPTION
fixes issue: https://github.com/microsoft/responsible-ai-widgets/issues/903

When calling precision_score and recall_score scikit-learn APIs, the implied positive label is the integer 1.  When passing string labels, we have to explicitly specify what the positive label should be.