### PR TITLE
fix issue with widgets rendering with 8px height related to recent change

### DIFF
--- a/raiwidgets/raiwidgets/dashboard.py
+++ b/raiwidgets/raiwidgets/dashboard.py
@@ -27,6 +27,10 @@ class InLineScript(HTMLParser):
                 if att[0] == "src":
                     src = att[1]
                     continue
+                # skip module type as it causes ipython to render widget
+                # with 8px height
+                if att[0] == "type":
+                    continue
                 scriptTag += f' {att[0]}={att[1]}'
             if src is not None:
                 content = self.load_widget_file(src)


### PR DESCRIPTION
widgets on master are rendering with 8px height, which was caused by recent change:
https://github.com/microsoft/responsible-ai-widgets/pull/959
it seems setting in script tag:
```type=module```
causes the ipython display function to miscalculate the final height of the widget.
The fix is to ignore the type attribute and not propagate it to the displayed html.

