### PR TITLE
fix color for metrics that are not error metrics to be green in legend and heatmap nan cells

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
@@ -8,7 +8,7 @@ const theme = getTheme();
 
 export class ColorPalette {
   public static MinErrorColor = "#F4D1D2";
-  public static MaxErrorColor = "#8d2323";
+  public static MaxErrorColor = theme.palette.redDark;
   public static MinMetricColor = theme.palette.greenLight;
   public static MaxMetricColor = theme.palette.greenDark;
   public static ErrorAvgColor = "#b2b7bd";

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.styles.ts
@@ -9,14 +9,16 @@ import {
   mergeStyles
 } from "office-ui-fabric-react";
 
+import { ColorPalette } from "../../ColorPalette";
+
 export interface IFilterTooltipStyles {
   hideFilterTooltip: IStyle;
   tooltipRect: IStyle;
   metricBarBlack: IStyle;
+  metricBarGreen: IStyle;
   metricBarRed: IStyle;
   showFilterTooltip: IStyle;
   smallHeader: IStyle;
-  valueRed: IStyle;
   valueBlack: IStyle;
   metricValueCell: IStyle;
   errorCoverageCell: IStyle;
@@ -48,8 +50,11 @@ export const filterTooltipStyles: () => IProcessedStyleSet<IFilterTooltipStyles>
       metricBarBlack: mergeStyles(metricBar, {
         fill: theme.palette.black
       }),
+      metricBarGreen: mergeStyles(metricBar, {
+        fill: ColorPalette.MaxMetricColor
+      }),
       metricBarRed: mergeStyles(metricBar, {
-        fill: theme.palette.red
+        fill: ColorPalette.MaxErrorColor
       }),
       metricValueCell: {
         transform: "translate(20px, 75px)"
@@ -76,9 +81,6 @@ export const filterTooltipStyles: () => IProcessedStyleSet<IFilterTooltipStyles>
       },
       valueBlack: mergeStyles(value, {
         color: theme.palette.black
-      }),
-      valueRed: mergeStyles(value, {
-        color: theme.palette.red
       })
     });
   };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.tsx
@@ -19,7 +19,12 @@ export class FilterTooltip extends React.Component<IFilterTooltipProps> {
   public render(): React.ReactNode {
     const classNames = filterTooltipStyles();
     const theme = getTheme();
-    const isErrorRate = this.props.filterProps.metricName === Metrics.ErrorRate;
+    const metricName = this.props.filterProps.metricName;
+    const isErrorRate = metricName === Metrics.ErrorRate;
+    const isErrorMetric =
+      metricName === Metrics.ErrorRate ||
+      metricName === Metrics.MeanSquaredError ||
+      metricName === Metrics.MeanAbsoluteError;
     return (
       <>
         <g>
@@ -73,7 +78,13 @@ export class FilterTooltip extends React.Component<IFilterTooltipProps> {
             </g>
           </g>
           <g className={classNames.metricValueCell}>
-            <rect className={classNames.metricBarRed} />
+            <rect
+              className={
+                isErrorMetric
+                  ? classNames.metricBarRed
+                  : classNames.metricBarGreen
+              }
+            />
             <g>
               <text className={classNames.smallHeader}>
                 {MetricUtils.getLocalizedMetric(

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.styles.ts
@@ -11,7 +11,8 @@ export interface IMatrixCellsStyles {
   matrixCell: IStyle;
   matrixCol: IStyle;
   matrixRow: IStyle;
-  nanMatrixCell: IStyle;
+  nanErrorMatrixCell: IStyle;
+  nanMetricMatrixCell: IStyle;
   selectedMatrixCell: IStyle;
   styledMatrixCell: IStyle;
 }
@@ -45,9 +46,14 @@ export const matrixCellsStyles: () => IProcessedStyleSet<IMatrixCellsStyles> =
         fontWeight: "normal",
         height: "50px"
       },
-      nanMatrixCell: {
+      nanErrorMatrixCell: {
         background:
           "repeating-linear-gradient(-45deg, white, white 5px, pink 10px, pink 20px)",
+        color: "black"
+      },
+      nanMetricMatrixCell: {
+        background:
+          "repeating-linear-gradient(-45deg, white, white 5px, limegreen 10px, limegreen 20px)",
         color: "black"
       },
       selectedMatrixCell: {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.tsx
@@ -22,6 +22,7 @@ import React from "react";
 
 import { ColorPalette, isColorDark } from "../../../ColorPalette";
 import { FilterProps } from "../../../FilterProps";
+import { MetricUtils } from "../../../MetricUtils";
 import { FilterTooltip } from "../../FilterTooltip/FilterTooltip";
 import { IMatrixSingleCategory } from "../IMatrixCategory";
 
@@ -92,7 +93,8 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
           {row.map((value, j: number) => {
             let errorRatio = 0;
             let styledGradientMatrixCell: IStyle = classNames.styledMatrixCell;
-            let isErrorMetric = true;
+            metricName = value.metricName ?? Metrics.ErrorRate;
+            const isErrorMetric = MetricUtils.isErrorMetricName(metricName);
             if (value.count > 0) {
               if (value.falseCount !== undefined) {
                 errorRatio = (value.falseCount / value.count) * 100;
@@ -109,12 +111,6 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
                   metricName === Metrics.MacroRecallScore
                 ) {
                   errorRatio = (value.metricValue / maxMetricValue) * 100;
-                  if (
-                    metricName !== Metrics.MeanSquaredError &&
-                    metricName !== Metrics.MeanAbsoluteError
-                  ) {
-                    isErrorMetric = false;
-                  }
                 }
               }
               const bkgcolor = this.colorLookup(errorRatio, isErrorMetric);
@@ -129,7 +125,9 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
             } else {
               styledGradientMatrixCell = mergeStyles([
                 styledGradientMatrixCell,
-                classNames.nanMatrixCell
+                isErrorMetric
+                  ? classNames.nanErrorMatrixCell
+                  : classNames.nanMetricMatrixCell
               ]);
             }
             if (

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.styles.ts
@@ -4,55 +4,32 @@
 import {
   IStyle,
   mergeStyleSets,
-  IProcessedStyleSet,
-  getTheme,
-  mergeStyles
+  IProcessedStyleSet
 } from "office-ui-fabric-react";
+
+import { metricStyles, textStyles } from "../../../Styles/CommonStyles.styles";
 
 export interface IMatrixLegendStyles {
   matrixLegend: IStyle;
   metricBarBlack: IStyle;
+  metricBarGreen: IStyle;
   metricBarRed: IStyle;
   smallHeader: IStyle;
-  valueRed: IStyle;
   valueBlack: IStyle;
 }
 
 export const matrixLegendStyles: () => IProcessedStyleSet<IMatrixLegendStyles> =
   () => {
-    const theme = getTheme();
-    const value: IStyle = {
-      fontSize: "28px",
-      fontWeight: "600"
-    };
-    const metricBar: IStyle = {
-      height: "50px",
-      marginTop: "14px",
-      width: "5px"
-    };
+    const commonMetricStyles = metricStyles();
+    const commonTextStyles = textStyles();
     return mergeStyleSets<IMatrixLegendStyles>({
       matrixLegend: {
         padding: "10px"
       },
-      metricBarBlack: mergeStyles(metricBar, {
-        backgroundColor: theme.palette.black
-      }),
-      metricBarRed: mergeStyles(metricBar, {
-        backgroundColor: theme.palette.red
-      }),
-      smallHeader: {
-        fontSize: "15px",
-        fontWeight: "500"
-      },
-      valueBlack: mergeStyles(value, {
-        color: theme.palette.black,
-        fontSize: "28px",
-        fontWeight: "600"
-      }),
-      valueRed: mergeStyles(value, {
-        color: theme.palette.red,
-        fontSize: "28px",
-        fontWeight: "600"
-      })
+      metricBarBlack: commonMetricStyles.metricBarBlack,
+      metricBarGreen: commonMetricStyles.metricBarGreen,
+      metricBarRed: commonMetricStyles.metricBarRed,
+      smallHeader: commonTextStyles.smallHeader,
+      valueBlack: commonMetricStyles.valueBlack
     });
   };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.tsx
@@ -83,7 +83,13 @@ export class MatrixLegend extends React.Component<IMatrixLegendProps> {
             </Stack>
             <Stack>
               <Stack horizontal>
-                <div className={classNames.metricBarRed} />
+                <div
+                  className={
+                    this.props.isErrorMetric
+                      ? classNames.metricBarRed
+                      : classNames.metricBarGreen
+                  }
+                />
                 <Stack tokens={cellTokens}>
                   <div className={classNames.smallHeader}>
                     {MetricUtils.getLocalizedMetric(

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.styles.ts
@@ -4,42 +4,31 @@
 import {
   IStyle,
   mergeStyleSets,
-  IProcessedStyleSet,
-  getTheme,
-  mergeStyles
+  IProcessedStyleSet
 } from "office-ui-fabric-react";
+
+import { metricStyles, textStyles } from "../../Styles/CommonStyles.styles";
 
 export interface ITreeLegendStyles {
   metricBarBlack: IStyle;
+  metricBarGreen: IStyle;
   metricBarRed: IStyle;
   node: IStyle;
   nopointer: IStyle;
   opacityToggleCircle: IStyle;
   smallHeader: IStyle;
   treeLegend: IStyle;
-  valueRed: IStyle;
   valueBlack: IStyle;
 }
 
 export const treeLegendStyles: () => IProcessedStyleSet<ITreeLegendStyles> =
   () => {
-    const theme = getTheme();
-    const value: IStyle = {
-      fontSize: "28px",
-      fontWeight: "600"
-    };
-    const metricBar: IStyle = {
-      height: "50px",
-      marginTop: "14px",
-      width: "5px"
-    };
+    const commonMetricStyles = metricStyles();
+    const commonTextStyles = textStyles();
     return mergeStyleSets<ITreeLegendStyles>({
-      metricBarBlack: mergeStyles(metricBar, {
-        backgroundColor: theme.palette.black
-      }),
-      metricBarRed: mergeStyles(metricBar, {
-        backgroundColor: theme.palette.red
-      }),
+      metricBarBlack: commonMetricStyles.metricBarBlack,
+      metricBarGreen: commonMetricStyles.metricBarGreen,
+      metricBarRed: commonMetricStyles.metricBarRed,
       node: {
         cursor: "default",
         opacity: "1",
@@ -52,23 +41,10 @@ export const treeLegendStyles: () => IProcessedStyleSet<ITreeLegendStyles> =
       opacityToggleCircle: {
         transform: "translate(26px, 26px)"
       },
-      smallHeader: {
-        fontSize: "15px",
-        fontWeight: "500",
-        pointerEvents: "auto"
-      },
+      smallHeader: commonTextStyles.smallHeader,
       treeLegend: {
         width: "15em"
       },
-      valueBlack: mergeStyles(value, {
-        color: theme.palette.black,
-        fontSize: "28px",
-        fontWeight: "600"
-      }),
-      valueRed: mergeStyles(value, {
-        color: theme.palette.red,
-        fontSize: "28px",
-        fontWeight: "600"
-      })
+      valueBlack: commonMetricStyles.valueBlack
     });
   };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
@@ -106,7 +106,13 @@ export class TreeLegend extends React.Component<ITreeLegendProps> {
           </Stack>
           <Stack>
             <Stack horizontal>
-              <div className={classNames.metricBarRed} />
+              <div
+                className={
+                  this.props.isErrorMetric
+                    ? classNames.metricBarRed
+                    : classNames.metricBarGreen
+                }
+              />
               <Stack tokens={cellTokens}>
                 <div className={classNames.smallHeader}>
                   {MetricUtils.getLocalizedMetric(

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/MetricUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/MetricUtils.ts
@@ -12,6 +12,14 @@ export enum MetricLocalizationType {
 }
 
 export class MetricUtils {
+  public static isErrorMetricName(metricName: string): boolean {
+    return (
+      metricName === Metrics.ErrorRate ||
+      metricName === Metrics.MeanSquaredError ||
+      metricName === Metrics.MeanAbsoluteError
+    );
+  }
+
   public static getLocalizedMetric(
     metricName: string,
     type: MetricLocalizationType

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Styles/CommonStyles.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Styles/CommonStyles.styles.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme,
+  mergeStyles
+} from "office-ui-fabric-react";
+
+import { ColorPalette } from "../ColorPalette";
+
+export interface IMetricStyles {
+  metricBarBlack: IStyle;
+  metricBarRed: IStyle;
+  metricBarGreen: IStyle;
+  valueBlack: IStyle;
+}
+
+export interface ITextStyles {
+  smallHeader: IStyle;
+}
+
+export const metricStyles: () => IProcessedStyleSet<IMetricStyles> = () => {
+  const theme = getTheme();
+  const value: IStyle = {
+    fontSize: "28px",
+    fontWeight: "600"
+  };
+  const metricBar: IStyle = {
+    height: "50px",
+    marginTop: "14px",
+    width: "5px"
+  };
+  return mergeStyleSets<IMetricStyles>({
+    metricBarBlack: mergeStyles(metricBar, {
+      backgroundColor: theme.palette.black
+    }),
+    metricBarGreen: mergeStyles(metricBar, {
+      backgroundColor: ColorPalette.MaxMetricColor
+    }),
+    metricBarRed: mergeStyles(metricBar, {
+      backgroundColor: ColorPalette.MaxErrorColor
+    }),
+    valueBlack: mergeStyles(value, {
+      color: theme.palette.black,
+      fontSize: "28px",
+      fontWeight: "600"
+    })
+  });
+};
+
+export const textStyles: () => IProcessedStyleSet<ITextStyles> = () => {
+  return mergeStyleSets<ITextStyles>({
+    smallHeader: {
+      fontSize: "15px",
+      fontWeight: "500",
+      pointerEvents: "auto"
+    }
+  });
+};


### PR DESCRIPTION
- When non-error metrics are selected, such as precision or recall, this PR changes the bar in the legend and tooltip to be green and also the empty cells in the heatmap to be a repeating green linear gradient instead of pink
- Refactor some of the common styling out to a single file that is shared between heatmap and treeview legends.  Note for filter tooltip the values are too different for it to be worth it to reuse that style.

![image](https://user-images.githubusercontent.com/24683184/138494816-d513d5c8-439f-4a23-aeb2-b97ef2585626.png)

![image](https://user-images.githubusercontent.com/24683184/138494833-4a7fba08-a201-4227-aed4-893e4871e13d.png)
