### PR TITLE
update features list text for static case

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -169,7 +169,10 @@ export class FeatureList extends React.Component<
           <Stack tokens={checkboxStackTokens} verticalAlign="space-around">
             <Stack.Item key="decisionTreeKey" align="start">
               <Text key="decisionTreeTextKey" variant="medium">
-                {localization.ErrorAnalysis.treeMapDescription}
+                {this.props.isEnabled
+                  ? localization.ErrorAnalysis.FeatureList.treeMapDescription
+                  : localization.ErrorAnalysis.FeatureList
+                      .staticTreeMapDescription}
               </Text>
             </Stack.Item>
             <Stack.Item key="searchKey" align="start">

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -155,7 +155,9 @@
     },
     "FeatureList": {
       "features": "Features",
-      "importances": "Importances"
+      "importances": "Importances",
+      "treeMapDescription": "To retrain the tree map, select and save the features below. The feature importances were calculated using mutual information with the error on the true labels.  Please use it as a guideline for training the tree map.",
+      "staticTreeMapDescription": "View the features that were used to train the tree map. The feature importances were calculated using mutual information with the error on the true labels."
     },
     "TreeViewParameters": {
       "maximumDepth": "Maximum depth",
@@ -325,7 +327,6 @@
     "instanceView": "Instance View",
     "localExplanationView": "Local explanation",
     "noFeature": "No feature",
-    "treeMapDescription": "To retrain the tree map, select and save the features below. The feature importances were calculated using mutual information with the error on the true labels.  Please use it as a guideline for training the tree map.",
     "whatIfDatapoints": "What-If datapoints"
   },
   "Fairness": {


### PR DESCRIPTION
Updates features list description text for static view.
Description below copied from PM:

Update string in flyout panel:
- Instead of this text at the top of the feature list flyout: "To retrain the tree map, select and save the features below. The feature importances were calculated using mutual information with the error on the true labels. Please use it as a guideline for training the tree map."
- Replace with: "View the features that were used to train the tree map. The feature importances were calculated using mutual information with the error on the true labels."

Screenshot of updated text in static view:

![image](https://user-images.githubusercontent.com/24683184/138763948-68579487-c7ec-45e7-9a49-6ced5434f01d.png)
