### PR TITLE
add importances to ErrorReport for error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -151,9 +151,11 @@ class BaseAnalyzer(ABC):
             matrix = self.compute_matrix(filter_features,
                                          None,
                                          None)
+        importances = self.compute_importances()
         return ErrorReport(tree, matrix,
                            tree_features=self.feature_names,
-                           matrix_features=filter_features)
+                           matrix_features=filter_features,
+                           importances=importances)
 
     def compute_importances(self):
         input_data = self.dataset

--- a/erroranalysis/erroranalysis/_internal/error_report.py
+++ b/erroranalysis/erroranalysis/_internal/error_report.py
@@ -6,13 +6,17 @@ import uuid
 
 _ErrorReportVersion1 = '1.0'
 _ErrorReportVersion2 = '2.0'
-_AllVersions = [_ErrorReportVersion1, _ErrorReportVersion2]
+_ErrorReportVersion3 = '3.0'
+_AllVersions = [_ErrorReportVersion1,
+                _ErrorReportVersion2,
+                _ErrorReportVersion3]
 _VERSION = 'version'
 
 TREE = 'tree'
 MATRIX = 'matrix'
 TREE_FEATURES = 'tree_features'
 MATRIX_FEATURES = 'matrix_features'
+IMPORTANCES = 'importances'
 ID = 'id'
 METADATA = 'metadata'
 
@@ -53,11 +57,18 @@ def as_error_report(error_dict):
             return ErrorReport(error_dict[TREE],
                                error_dict[MATRIX],
                                error_dict[ID])
+        elif version == _ErrorReportVersion2:
+            return ErrorReport(error_dict[TREE],
+                               error_dict[MATRIX],
+                               error_dict[TREE_FEATURES],
+                               error_dict[MATRIX_FEATURES],
+                               error_dict[ID])
         else:
             return ErrorReport(error_dict[TREE],
                                error_dict[MATRIX],
                                error_dict[TREE_FEATURES],
                                error_dict[MATRIX_FEATURES],
+                               error_dict[IMPORTANCES],
                                error_dict[ID])
     else:
         return error_dict
@@ -81,6 +92,7 @@ class ErrorReport(object):
                  matrix,
                  tree_features=None,
                  matrix_features=None,
+                 importances=None,
                  id=None):
         """Defines the ErrorReport, which contains the tree and matrix filter.
 
@@ -90,10 +102,13 @@ class ErrorReport(object):
         :type matrix: dict
         :param tree_features: The features that were selected to train the
             decision tree on errors.
-        :param tree_features: list[str]
+        :type tree_features: list[str]
         :param matrix_features: The one or two features selected for creating
             the matrix filter (aka heatmap).
-        :param matrix_features: list[str]
+        :type matrix_features: list[str]
+        :param importances: The feature importances calculated using mutual
+            information with the error on the true labels.
+        :type importances: list[float]
         :param id: The unique identifier for the ErrorReport.
             A new unique id is created if none is specified.
         :type id: str
@@ -103,7 +118,8 @@ class ErrorReport(object):
         self._matrix = matrix
         self._tree_features = tree_features
         self._matrix_features = matrix_features
-        self._metadata = {_VERSION: _ErrorReportVersion2}
+        self._importances = importances
+        self._metadata = {_VERSION: _ErrorReportVersion3}
 
     @property
     def __dict__(self):
@@ -119,6 +135,7 @@ class ErrorReport(object):
                 MATRIX: self._matrix,
                 TREE_FEATURES: self._tree_features,
                 MATRIX_FEATURES: self._matrix_features,
+                IMPORTANCES: self._importances,
                 ID: self._id,
                 METADATA: self._metadata}
 
@@ -163,6 +180,20 @@ class ErrorReport(object):
         :rtype: list[str]
         """
         return self._matrix_features
+
+    @property
+    def importances(self):
+        """Returns the feature importances for the tree view.
+
+        The feature importances are calculated using mutual
+        information with the error on the true labels.
+
+        :return: The feature importances for the tree view
+            calculated using mutual information with the error
+            on the true labels.
+        :rtype: list[float]
+        """
+        return self._importances
 
     @property
     def id(self):

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '26'
+_patch = '27'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -105,6 +105,7 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     assert ea_deserialized.tree == error_report1.tree
     assert ea_deserialized.tree_features == error_report1.tree_features
     assert ea_deserialized.matrix_features == error_report1.matrix_features
+    assert ea_deserialized.importances == error_report1.importances
 
     # validate error report does not modify original dataset in ModelAnalyzer
     if isinstance(X_test, pd.DataFrame):

--- a/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
+++ b/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
@@ -6,6 +6,7 @@ export interface IErrorAnalysisData {
   tree_features?: string[];
   matrix?: IErrorAnalysisMatrix;
   matrix_features?: string[];
+  importances?: number[];
   maxDepth: number;
   numLeaves: number;
   minChildSamples: number;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -294,6 +294,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     if (props.requestDebugML === undefined) {
       selectedFeatures = props.errorAnalysisData.tree_features!;
     }
+    const importances = props.errorAnalysisData.importances ?? [];
     return {
       activeGlobalTab: GlobalTabKeys.DataExplorerTab,
       baseCohort: cohorts[0],
@@ -305,7 +306,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       errorAnalysisOption: ErrorAnalysisOptions.TreeMap,
       globalImportance: globalProps.globalImportance,
       globalImportanceIntercept: globalProps.globalImportanceIntercept,
-      importances: [],
+      importances,
       isGlobalImportanceDerivedFromLocal:
         globalProps.isGlobalImportanceDerivedFromLocal,
       jointDataset,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -98,7 +98,7 @@ export function buildInitialModelAssessmentContext(
       name: item.text as string
     };
   });
-
+  const importances = props.errorAnalysisData?.[0].importances ?? [];
   return {
     activeGlobalTabs,
     baseCohort: cohorts[0],
@@ -109,7 +109,7 @@ export function buildInitialModelAssessmentContext(
     errorAnalysisOption: ErrorAnalysisOptions.TreeMap,
     globalImportance: globalProps.globalImportance,
     globalImportanceIntercept: globalProps.globalImportanceIntercept,
-    importances: [],
+    importances,
     isGlobalImportanceDerivedFromLocal:
       globalProps.isGlobalImportanceDerivedFromLocal,
     jointDataset,


### PR DESCRIPTION
Add importances, calculated using mutual information with the error on the true labels, to the ErrorReport object and allow them to be surfaced in the static view of ErrorAnalysisDashboard and ModelAssessmentDashboard.