### PR TITLE
fix build break due to new docutils release

### DIFF
--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -30,6 +30,7 @@ scrapbook
 jupyter
 nbval
 
+docutils<0.18
 sphinx==3.1.1
 sphinx-gallery==0.8.1
 pydata-sphinx-theme==0.3.0


### PR DESCRIPTION
docutils 0.18 was just released a couple hours ago to pypi which seems to lead to our builds breaking.  Pinning it to <0.18 keep the builds working for now.

https://pypi.org/project/docutils/#history