### PR TITLE
update notebooks to use the new RAIInsights and ResponsibleAIDashboard APIs

### DIFF
--- a/notebooks/responsibleaitoolbox-dashboard/getting-started.ipynb
+++ b/notebooks/responsibleaitoolbox-dashboard/getting-started.ipynb
@@ -68,15 +68,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets import ModelAnalysisDashboard\n",
-    "from responsibleai import ModelAnalysis"
+    "from raiwidgets import ResponsibleAIDashboard\n",
+    "from responsibleai import RAIInsights"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is necessary to initialize a ModelAnalysis object upon which the different components can be loaded. `task_type` holds the string `'regression'` or `'classification'` depending on the developer's purpose."
+    "It is necessary to initialize a RAIInsights object upon which the different components can be loaded. `task_type` holds the string `'regression'` or `'classification'` depending on the developer's purpose."
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis = ModelAnalysis(model, train_data, test_data, target_feature, task_type, \n",
+    "rai_insights = RAIInsights(model, train_data, test_data, target_feature, task_type, \n",
     "                               categorical_features=['f1', 'f2', 'f3'])"
    ]
   },
@@ -102,8 +102,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.explainer.add()\n",
-    "model_analysis.error_analysis.add()"
+    "rai_insights.explainer.add()\n",
+    "rai_insights.error_analysis.add()"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.causal.add(treatment_features=['f1', 'f2', 'f3'])"
+    "rai_insights.causal.add(treatment_features=['f1', 'f2', 'f3'])"
    ]
   },
   {
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.counterfactual.add(total_CFs=20, desired_class='opposite', continuous_features=['f1', 'f2', 'f3'])"
+    "rai_insights.counterfactual.add(total_CFs=20, desired_class='opposite', continuous_features=['f1', 'f2', 'f3'])"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.counterfactual.add(total_CFs=20, desired_range=[10, 20], continuous_features=['f1', 'f2', 'f3'])"
+    "rai_insights.counterfactual.add(total_CFs=20, desired_range=[10, 20], continuous_features=['f1', 'f2', 'f3'])"
    ]
   },
   {
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After loading the components into the ModelAnalysis object, it is necessary to calculate values relevant to them, such as model metrics and counterfactuals."
+    "After loading the components into the RAIInsights object, it is necessary to calculate values relevant to them, such as model metrics and counterfactuals."
    ]
   },
   {
@@ -181,14 +181,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.compute()"
+    "rai_insights.compute()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the values for each component have been computed, they can be displayed by loading the ModelAnalysis object into a ModelAnalysisDashboard."
+    "Once the values for each component have been computed, they can be displayed by loading the RAIInsights object into a ResponsibleAIDashboard."
    ]
   },
   {
@@ -197,7 +197,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ModelAnalysisDashboard(model_analysis)"
+    "ResponsibleAIDashboard(rai_insights)"
    ]
   },
   {

--- a/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-classification-model-assessment.ipynb
+++ b/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-classification-model-assessment.ipynb
@@ -192,8 +192,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets import ModelAnalysisDashboard\n",
-    "from responsibleai import ModelAnalysis"
+    "from raiwidgets import ResponsibleAIDashboard\n",
+    "from responsibleai import RAIInsights"
    ]
   },
   {
@@ -201,9 +201,9 @@
    "id": "cheap-juice",
    "metadata": {},
    "source": [
-    "To use Responsible AI Toolbox, initialize a ModelAnalysis object upon which different components can be loaded.\n",
+    "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "ModelAnalysis accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
    ]
   },
   {
@@ -215,7 +215,7 @@
    "source": [
     "dashboard_pipeline = Pipeline(steps=[('preprocess', feat_pipe), ('model', model)])\n",
     "\n",
-    "model_analysis = ModelAnalysis(dashboard_pipeline, train_data_sample, test_data_sample, target_feature, 'classification',\n",
+    "rai_insights = RAIInsights(dashboard_pipeline, train_data_sample, test_data_sample, target_feature, 'classification',\n",
     "                               categorical_features=categorical_features)"
    ]
   },
@@ -235,12 +235,12 @@
    "outputs": [],
    "source": [
     "# Interpretability\n",
-    "model_analysis.explainer.add()\n",
+    "rai_insights.explainer.add()\n",
     "# Error Analysis\n",
-    "model_analysis.error_analysis.add()\n",
+    "rai_insights.error_analysis.add()\n",
     "# Counterfactuals: accepts total number of counterfactuals to generate, the label that they should have, and a list of \n",
     "                # strings of categorical feature names\n",
-    "model_analysis.counterfactual.add(total_CFs=10, desired_class='opposite')"
+    "rai_insights.counterfactual.add(total_CFs=10, desired_class='opposite')"
    ]
   },
   {
@@ -258,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.compute()"
+    "rai_insights.compute()"
    ]
   },
   {
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ModelAnalysisDashboard(model_analysis)"
+    "ResponsibleAIDashboard(rai_insights)"
    ]
   },
   {

--- a/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-regression-decision-making.ipynb
+++ b/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-regression-decision-making.ipynb
@@ -133,17 +133,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets import ModelAnalysisDashboard\n",
-    "from responsibleai import ModelAnalysis"
+    "from raiwidgets import ResponsibleAIDashboard\n",
+    "from responsibleai import RAIInsights"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use Responsible AI Toolbox, initialize a ModelAnalysis object upon which different components can be loaded.\n",
+    "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "ModelAnalysis accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
    ]
   },
   {
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis = ModelAnalysis(model, train_data, test_data, target_feature, 'regression',\n",
+    "rai_insights = RAIInsights(model, train_data, test_data, target_feature, 'regression',\n",
     "                               categorical_features=[])"
    ]
   },
@@ -171,9 +171,9 @@
    "source": [
     "# Counterfactuals: accepts total number of counterfactuals to generate, the range that their label should fall under, \n",
     "# and a list of strings of categorical feature names\n",
-    "model_analysis.counterfactual.add(total_CFs=20, desired_range=[50, 120])\n",
+    "rai_insights.counterfactual.add(total_CFs=20, desired_range=[50, 120])\n",
     "# Causal Inference: determines causation between features\n",
-    "model_analysis.causal.add(treatment_features=['bmi', 'bp', 's2'])"
+    "rai_insights.causal.add(treatment_features=['bmi', 'bp', 's2'])"
    ]
   },
   {
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.compute()"
+    "rai_insights.compute()"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ModelAnalysisDashboard(model_analysis)"
+    "ResponsibleAIDashboard(rai_insights)"
    ]
   },
   {

--- a/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-regression-model-assessment.ipynb
+++ b/notebooks/responsibleaitoolbox-dashboard/responsibleaitoolbox-regression-model-assessment.ipynb
@@ -133,17 +133,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets import ModelAnalysisDashboard\n",
-    "from responsibleai import ModelAnalysis"
+    "from raiwidgets import ResponsibleAIDashboard\n",
+    "from responsibleai import RAIInsights"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To use Responsible AI Toolbox, initialize a ModelAnalysis object upon which different components can be loaded.\n",
+    "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "ModelAnalysis accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
    ]
   },
   {
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis = ModelAnalysis(model, train_data, test_data, target_feature, 'regression',\n",
+    "rai_insights = RAIInsights(model, train_data, test_data, target_feature, 'regression',\n",
     "                               categorical_features=[])"
    ]
   },
@@ -170,12 +170,12 @@
    "outputs": [],
    "source": [
     "# Interpretability\n",
-    "model_analysis.explainer.add()\n",
+    "rai_insights.explainer.add()\n",
     "# Error Analysis\n",
-    "model_analysis.error_analysis.add()\n",
+    "rai_insights.error_analysis.add()\n",
     "# Counterfactuals: accepts total number of counterfactuals to generate, the range that their label should fall under, \n",
     "# and a list of strings of categorical feature names\n",
-    "model_analysis.counterfactual.add(total_CFs=20, desired_range=[50, 120])"
+    "rai_insights.counterfactual.add(total_CFs=20, desired_range=[50, 120])"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_analysis.compute()"
+    "rai_insights.compute()"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ModelAnalysisDashboard(model_analysis)"
+    "ResponsibleAIDashboard(rai_insights)"
    ]
   },
   {


### PR DESCRIPTION
Update the sample notebooks to:
1.) Use RAIInsights instead of ModelAnalysis
2.) Use ResponsibleAIDashboard instead of ModelAnalysisDashboard

Note users using old notebooks should still be able to use the old deprecated classes, but they will see a warning.  Note users will need to be on the latest 0.15.0 release of raiwidgets and responsibleai packages to run the new notebooks.