### PR TITLE
fix mutating predict function scenario for model analysis

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -409,6 +409,8 @@ class RAIInsights(object):
         dataset: pd.DataFrame = self.test.drop(
             [self.target_column], axis=1)
 
+        features = dataset.columns
+
         if isinstance(dataset, pd.DataFrame) and hasattr(dataset, 'columns'):
             self._dataframeColumns = dataset.columns
         try:
@@ -423,6 +425,14 @@ class RAIInsights(object):
                 msg = "Model does not support predict method for given"
                 "dataset type"
                 raise ValueError(msg) from ex
+            post_pred_features = dataset.columns
+            if len(post_pred_features) != len(features):
+                warnings.warn(
+                    'INVALID-MODEL-WARNING: Calling model predict '
+                    'function modifies input dataset features. '
+                    'Please check if predict function is defined correctly.')
+                # reset dataset back to original
+                dataset = self.test.drop([self.target_column], axis=1)
             try:
                 predicted_y = _convert_to_list(predicted_y)
             except Exception as ex:
@@ -458,8 +468,6 @@ class RAIInsights(object):
                 true_y = [dashboard_dataset.class_names.index(
                     y) for y in true_y]
             dashboard_dataset.true_y = _convert_to_list(true_y)
-
-        features = dataset.columns
 
         if features is not None:
             features = _convert_to_list(features)

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -15,6 +15,8 @@ from .common_utils import (create_binary_classification_dataset,
                            create_cancer_data, create_iris_data,
                            create_lightgbm_classifier)
 
+TARGET = 'target'
+
 
 class TestRAIInsightsValidations:
     def test_validate_unsupported_task_type(self):
@@ -22,8 +24,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         message = ("Unsupported task type 'regre'. "
                    "Should be one of \\['classification', 'regression'\\]")
@@ -32,7 +34,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='regre')
 
     def test_validate_test_data_size(self):
@@ -40,8 +42,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
@@ -62,8 +64,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
@@ -80,17 +82,17 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
-                categorical_features=['target'])
+                categorical_features=[TARGET])
         assert 'Found target name target in categorical feature list' in \
             str(ucve.value)
 
@@ -99,8 +101,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         message = ("Feature names in categorical_features "
                    "do not exist in train data: \\['not_a_feature'\\]")
@@ -109,7 +111,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 categorical_features=['not_a_feature'])
 
@@ -118,8 +120,8 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             class LoadOnlySerializer:
@@ -134,7 +136,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -153,7 +155,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -176,7 +178,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -187,8 +189,8 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         model = MagicMock()
         model.predict.side_effect = Exception()
@@ -197,7 +199,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
 
         assert 'The model passed cannot be used for getting predictions ' + \
@@ -207,8 +209,8 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         model = MagicMock()
         model.predict.return_value = [0]
@@ -219,7 +221,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
 
         assert 'The model passed cannot be used for getting predictions ' + \
@@ -230,8 +232,8 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         err_msg = ('INVALID-TASK-TYPE-WARNING: The regression model'
                    'provided has a predict_proba function. '
@@ -241,7 +243,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='regression')
 
     def test_mismatch_train_test_features(self):
@@ -249,7 +251,7 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
+        X_train[TARGET] = y_train
         X_test['bad_target'] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
@@ -257,7 +259,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
         assert 'The features in train and test data do not match' in \
             str(ucve.value)
@@ -267,7 +269,7 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
+        X_train[TARGET] = y_train
         X_test['bad_target'] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
@@ -275,7 +277,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train.values,
                 test=X_test.values,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
         assert "Unsupported data type for either train or test. " + \
             "Expecting pandas Dataframe for train and test." in str(ucve.value)
@@ -285,30 +287,30 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1, 2])
         assert 'The train labels and distinct values in ' + \
             'target (train data) do not match' in str(ucve.value)
 
         y_train[0] = 2
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
         assert 'The train labels and distinct values in target ' + \
@@ -316,15 +318,15 @@ class TestRAIInsightsValidations:
 
         y_train[0] = 0
         y_test[0] = 2
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
 
@@ -336,14 +338,14 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
         # validate classes are always sorted
         classes = rai._classes
@@ -357,14 +359,14 @@ class TestCausalUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in treatment_features "
@@ -380,14 +382,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in features_to_vary do "
@@ -401,14 +403,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in permitted_range do "
@@ -422,14 +424,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
         with pytest.raises(
                 UserConfigValidationException,
@@ -445,14 +447,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='regression')
         with pytest.raises(
                 UserConfigValidationException,
@@ -466,14 +468,14 @@ class TestCounterfactualUserConfigValidations:
         X_train, X_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         with pytest.raises(
@@ -490,14 +492,14 @@ class TestCounterfactualUserConfigValidations:
         X_train, X_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         with pytest.raises(
@@ -516,22 +518,22 @@ class TestCounterfactualUserConfigValidations:
             data=[[1, 2, 0],
                   [2, 3, 1],
                   [3, 3, 0]],
-            columns=['c1', 'c2', 'target']
+            columns=['c1', 'c2', TARGET]
         )
         test_data = pd.DataFrame(
             data=[[1, 1, 0]],
-            columns=['c1', 'c2', 'target']
+            columns=['c1', 'c2', TARGET]
         )
 
-        X_train = train_data.drop(['target'], axis=1)
-        y_train = train_data['target']
+        X_train = train_data.drop([TARGET], axis=1)
+        y_train = train_data[TARGET]
         model = create_lightgbm_classifier(X_train, y_train)
 
         rai_insights = RAIInsights(
             model=model,
             train=train_data,
             test=test_data,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification',
             categorical_features=['c2'])
 
@@ -547,3 +549,48 @@ class TestCounterfactualUserConfigValidations:
                 total_CFs=10,
                 method='random',
                 desired_class='opposite')
+
+    def test_weird_predict_function(self):
+        X_train, X_test, y_train, y_test, _, _ = create_iris_data()
+
+        # A weird model that modifies the input dataset by
+        # adding back the target column
+        class WeirdModelWrapper():
+            def __init__(self, model):
+                self.model = model
+
+            def predict(self, test_data_pandas):
+                if TARGET not in test_data_pandas.columns:
+                    test_data_pandas[TARGET] = 0
+                return self.model.predict(
+                    test_data_pandas.drop(columns=TARGET))
+
+            def predict_proba(self, test_data_pandas):
+                if TARGET not in test_data_pandas.columns:
+                    test_data_pandas[TARGET] = 0
+                return self.model.predict_proba(
+                    test_data_pandas.drop(columns=TARGET))
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        model = WeirdModelWrapper(model)
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        rai_insights = RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column=TARGET,
+            task_type='classification')
+        # Interpretability
+        rai_insights.explainer.add()
+        # Error Analysis
+        rai_insights.error_analysis.add()
+        rai_insights.compute()
+        err_msg = ('INVALID-MODEL-WARNING: Calling model predict '
+                   'function modifies input dataset features. '
+                   'Please check if predict function is defined correctly.')
+        with pytest.warns(UserWarning, match=err_msg):
+            rai_insights.get_data()


### PR DESCRIPTION
A customer had an issue where RAIInsights was failing, and after investigating the issue it was discovered that the predict function was mutating the input dataset and adding back the label column.  This PR adds a warning to auto-discover such mutations on behalf of the user but still intelligently allows them to occur and run RAIInsights successfully regardless.