### PR TITLE
throw error on mutating predict function in RAIInsights

### DIFF
--- a/responsibleai/responsibleai/_internal/constants.py
+++ b/responsibleai/responsibleai/_internal/constants.py
@@ -52,6 +52,7 @@ class SKLearn(object):
 
     EXAMPLES = 'examples'
     LABELS = 'labels'
+    PREDICT = 'predict'
     PREDICTIONS = 'predictions'
     PREDICT_PROBA = 'predict_proba'
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -291,6 +291,8 @@ class RAIInsights(object):
                 small_test_data = test.iloc[0:1].drop(
                     [target_column], axis=1)
 
+                small_train_features_before = list(small_train_data.columns)
+
                 # Run predict() of the model
                 try:
                     model.predict(small_train_data)
@@ -300,6 +302,9 @@ class RAIInsights(object):
                         'The model passed cannot be used for'
                         ' getting predictions via predict()'
                     )
+                self._validate_features_same(small_train_features_before,
+                                             small_train_data,
+                                             SKLearn.PREDICT)
 
                 # Run predict_proba() of the model
                 if task_type == ModelTask.CLASSIFICATION:
@@ -311,9 +316,12 @@ class RAIInsights(object):
                             'The model passed cannot be used for'
                             ' getting predictions via predict_proba()'
                         )
+                self._validate_features_same(small_train_features_before,
+                                             small_train_data,
+                                             SKLearn.PREDICT_PROBA)
 
                 if task_type == ModelTask.REGRESSION:
-                    if hasattr(model, 'predict_proba'):
+                    if hasattr(model, SKLearn.PREDICT_PROBA):
                         warnings.warn(
                             'INVALID-TASK-TYPE-WARNING: The regression model'
                             'provided has a predict_proba function. '
@@ -322,6 +330,27 @@ class RAIInsights(object):
             raise UserConfigValidationException(
                 "Unsupported data type for either train or test. "
                 "Expecting pandas Dataframe for train and test."
+            )
+
+    def _validate_features_same(self, small_train_features_before,
+                                small_train_data, function):
+        """
+        Validate the features are unmodified on the dataframe.
+
+        :param small_train_features_before: The features saved before
+            an operation was performed.
+        :type small_train_features_before: list[str]
+        :param small_train_data: The dataframe after the operation.
+        :type small_train_data: pandas.DataFrame
+        :param function: The name of the operation performed.
+        :type function: str
+        """
+        small_train_features_after = list(small_train_data.columns)
+        if small_train_features_before != small_train_features_after:
+            raise UserConfigValidationException(
+                ('Calling model {} function modifies '
+                 'input dataset features. Please check if '
+                 'predict function is defined correctly.').format(function)
             )
 
     @property

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -15,6 +15,8 @@ from .common_utils import (create_binary_classification_dataset,
                            create_cancer_data, create_iris_data,
                            create_lightgbm_classifier)
 
+TARGET = 'target'
+
 
 class TestRAIInsightsValidations:
     def test_validate_unsupported_task_type(self):
@@ -22,8 +24,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         message = ("Unsupported task type 'regre'. "
                    "Should be one of \\['classification', 'regression'\\]")
@@ -32,7 +34,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='regre')
 
     def test_validate_test_data_size(self):
@@ -40,8 +42,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
@@ -62,8 +64,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
@@ -80,17 +82,17 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
-                categorical_features=['target'])
+                categorical_features=[TARGET])
         assert 'Found target name target in categorical feature list' in \
             str(ucve.value)
 
@@ -99,8 +101,8 @@ class TestRAIInsightsValidations:
             create_iris_data()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         message = ("Feature names in categorical_features "
                    "do not exist in train data: \\['not_a_feature'\\]")
@@ -109,7 +111,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 categorical_features=['not_a_feature'])
 
@@ -118,8 +120,8 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             class LoadOnlySerializer:
@@ -134,7 +136,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -153,7 +155,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -176,7 +178,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 serializer=serializer
             )
@@ -187,8 +189,8 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         model = MagicMock()
         model.predict.side_effect = Exception()
@@ -197,7 +199,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
 
         assert 'The model passed cannot be used for getting predictions ' + \
@@ -207,8 +209,8 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         model = MagicMock()
         model.predict.return_value = [0]
@@ -219,7 +221,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
 
         assert 'The model passed cannot be used for getting predictions ' + \
@@ -230,8 +232,8 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         err_msg = ('INVALID-TASK-TYPE-WARNING: The regression model'
                    'provided has a predict_proba function. '
@@ -241,7 +243,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='regression')
 
     def test_mismatch_train_test_features(self):
@@ -249,7 +251,7 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
+        X_train[TARGET] = y_train
         X_test['bad_target'] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
@@ -257,7 +259,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
         assert 'The features in train and test data do not match' in \
             str(ucve.value)
@@ -267,7 +269,7 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
+        X_train[TARGET] = y_train
         X_test['bad_target'] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
@@ -275,7 +277,7 @@ class TestRAIInsightsValidations:
                 model=model,
                 train=X_train.values,
                 test=X_test.values,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification')
         assert "Unsupported data type for either train or test. " + \
             "Expecting pandas Dataframe for train and test." in str(ucve.value)
@@ -285,30 +287,30 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1, 2])
         assert 'The train labels and distinct values in ' + \
             'target (train data) do not match' in str(ucve.value)
 
         y_train[0] = 2
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
         assert 'The train labels and distinct values in target ' + \
@@ -316,15 +318,15 @@ class TestRAIInsightsValidations:
 
         y_train[0] = 0
         y_test[0] = 2
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
                 model=model,
                 train=X_train,
                 test=X_test,
-                target_column='target',
+                target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
 
@@ -336,14 +338,14 @@ class TestRAIInsightsValidations:
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
         # validate classes are always sorted
         classes = rai._classes
@@ -357,14 +359,14 @@ class TestCausalUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in treatment_features "
@@ -380,14 +382,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in features_to_vary do "
@@ -401,14 +403,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         message = ("Feature names in permitted_range do "
@@ -422,14 +424,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
         with pytest.raises(
                 UserConfigValidationException,
@@ -445,14 +447,14 @@ class TestCounterfactualUserConfigValidations:
             create_binary_classification_dataset()
 
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='regression')
         with pytest.raises(
                 UserConfigValidationException,
@@ -466,14 +468,14 @@ class TestCounterfactualUserConfigValidations:
         X_train, X_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         with pytest.raises(
@@ -490,14 +492,14 @@ class TestCounterfactualUserConfigValidations:
         X_train, X_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
 
         rai_insights = RAIInsights(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification')
 
         with pytest.raises(
@@ -516,22 +518,22 @@ class TestCounterfactualUserConfigValidations:
             data=[[1, 2, 0],
                   [2, 3, 1],
                   [3, 3, 0]],
-            columns=['c1', 'c2', 'target']
+            columns=['c1', 'c2', TARGET]
         )
         test_data = pd.DataFrame(
             data=[[1, 1, 0]],
-            columns=['c1', 'c2', 'target']
+            columns=['c1', 'c2', TARGET]
         )
 
-        X_train = train_data.drop(['target'], axis=1)
-        y_train = train_data['target']
+        X_train = train_data.drop([TARGET], axis=1)
+        y_train = train_data[TARGET]
         model = create_lightgbm_classifier(X_train, y_train)
 
         rai_insights = RAIInsights(
             model=model,
             train=train_data,
             test=test_data,
-            target_column='target',
+            target_column=TARGET,
             task_type='classification',
             categorical_features=['c2'])
 
@@ -547,3 +549,77 @@ class TestCounterfactualUserConfigValidations:
                 total_CFs=10,
                 method='random',
                 desired_class='opposite')
+
+    def test_weird_predict_function(self):
+        X_train, X_test, y_train, y_test, _, _ = create_iris_data()
+
+        # A weird model that modifies the input dataset by
+        # adding back the target column
+        class WeirdModelPredictWrapper():
+            def __init__(self, model):
+                self.model = model
+
+            def predict(self, test_data_pandas):
+                if TARGET not in test_data_pandas.columns:
+                    test_data_pandas[TARGET] = 0
+                return self.model.predict(
+                    test_data_pandas.drop(columns=TARGET))
+
+            def predict_proba(self, test_data_pandas):
+                return self.model.predict_proba(test_data_pandas)
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        model = WeirdModelPredictWrapper(model)
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        message = ('Calling model predict function modifies '
+                   'input dataset features. Please check if '
+                   'predict function is defined correctly.')
+        with pytest.raises(
+                UserConfigValidationException, match=message):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification')
+
+    def test_weird_predict_proba_function(self):
+        X_train, X_test, y_train, y_test, _, _ = create_iris_data()
+
+        # A weird model that modifies the input dataset by
+        # adding back the target column
+        class WeirdModelPredictProbaWrapper():
+            def __init__(self, model):
+                self.model = model
+
+            def predict(self, test_data_pandas):
+                return self.model.predict(test_data_pandas)
+
+            def predict_proba(self, test_data_pandas):
+                if TARGET not in test_data_pandas.columns:
+                    test_data_pandas[TARGET] = 0
+                return self.model.predict_proba(
+                    test_data_pandas.drop(columns=TARGET))
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        model = WeirdModelPredictProbaWrapper(model)
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        message = ('Calling model predict_proba function modifies '
+                   'input dataset features. Please check if '
+                   'predict function is defined correctly.')
+        with pytest.raises(
+                UserConfigValidationException, match=message):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification')


### PR DESCRIPTION
A customer had an issue where RAIInsights was failing, and after investigating the issue it was discovered that the predict function was mutating the input dataset and adding back the label column. This PR throws an error if it discovers such mutations on behalf of the user.