### PR TITLE
Add .json extension to dtypes files and add tests

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -539,12 +539,14 @@ class RAIInsights(object):
         data_directory = Path(path) / _DATA
         data_directory.mkdir(parents=True, exist_ok=True)
         dtypes = self.train.dtypes.astype(str).to_dict()
-        self._write_to_file(data_directory / (_TRAIN + _DTYPES),
+        self._write_to_file(data_directory /
+                            (_TRAIN + _DTYPES + _JSON_EXTENSION),
                             json.dumps(dtypes))
         self._write_to_file(data_directory / (_TRAIN + _JSON_EXTENSION),
                             self.train.to_json())
         dtypes = self.test.dtypes.astype(str).to_dict()
-        self._write_to_file(data_directory / (_TEST + _DTYPES),
+        self._write_to_file(data_directory /
+                            (_TEST + _DTYPES + _JSON_EXTENSION),
                             json.dumps(dtypes))
         self._write_to_file(data_directory / (_TEST + _JSON_EXTENSION),
                             self.test.to_json())
@@ -588,12 +590,14 @@ class RAIInsights(object):
         top_dir = Path(path)
         # load current state
         data_directory = Path(path) / _DATA
-        with open(data_directory / (_TRAIN + _DTYPES), 'r') as file:
+        with open(data_directory /
+                  (_TRAIN + _DTYPES + _JSON_EXTENSION), 'r') as file:
             types = json.load(file)
         with open(data_directory / (_TRAIN + _JSON_EXTENSION), 'r') as file:
             train = pd.read_json(file, dtype=types)
         inst.__dict__[_TRAIN] = train
-        with open(data_directory / (_TEST + _DTYPES), 'r') as file:
+        with open(data_directory /
+                  (_TEST + _DTYPES + _JSON_EXTENSION), 'r') as file:
             types = json.load(file)
         with open(data_directory / (_TEST + _JSON_EXTENSION), 'r') as file:
             test = pd.read_json(file, dtype=types)

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -332,9 +332,12 @@ def run_rai_insights(model, train_data, test_data, target_column,
         # save the rai_insights
         rai_insights.save(path)
 
+        # Validate the common set of state produced when rai insights
+        # are saved on the disk.
+        validate_common_state_directories(path)
         # Validate the directory structure of the state saved
         # by the managers.
-        validate_state_directory(path, manager_type)
+        validate_component_state_directory(path, manager_type)
 
         # load the rai_insights
         rai_insights = RAIInsights.load(path)
@@ -355,7 +358,17 @@ def run_rai_insights(model, train_data, test_data, target_column,
             validate_explainer(rai_insights, train_data, test_data, classes)
 
 
-def validate_state_directory(path, manager_type, classes=None):
+def validate_common_state_directories(path):
+    data_path = path / "data"
+    assert data_path.exists()
+    all_data_files = os.listdir(data_path)
+    assert "train.json" in all_data_files
+    assert "traindtypes.json" in all_data_files
+    assert "test.json" in all_data_files
+    assert "testdtypes.json" in all_data_files
+
+
+def validate_component_state_directory(path, manager_type, classes=None):
     all_dirs = os.listdir(path)
     assert manager_type in all_dirs
     all_component_paths = os.listdir(path / manager_type)


### PR DESCRIPTION
It seems they don't carry any extensions right back carry json data. Hence, adding the .json extension and adding tests to make sure these files are produced during save() call of RAIInsights.