### PR TITLE
fix coverage calculation for cell tooltips in heatmap for recall, precision and f1 score metrics

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixCells/MatrixCells.tsx
@@ -143,7 +143,14 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
               baseError = falseCount;
             } else {
               metricValue = value.metricValue;
-              error = value.metricValue * value.count;
+              if (
+                metricName === Metrics.MeanSquaredError ||
+                metricName === Metrics.MeanAbsoluteError
+              ) {
+                error = value.metricValue * value.count;
+              } else {
+                error = value.error;
+              }
               baseError = totalError;
             }
             const filterProps = new FilterProps(


### PR DESCRIPTION
A customer discovered an issue where the error coverage was being calculated incorrectly for the recall metric, but only on the tooltip.  It looks like for several new metrics (recall, precision and f1-score) the tooltip error coverage calculation code was not updated in the UI.  The python backend calculation is correct, and the global aggregate calculation at top of heatmap is also correct, just the UI code is not calculating the error coverage values correctly for the tooltip in the heatmap for these metrics.