### PR TITLE
add scrollbar area around matrix cells when there are many categories or bins

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.styles.ts
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 import {
+  IProcessedStyleSet,
   IStyle,
-  mergeStyleSets,
-  IProcessedStyleSet
+  mergeStyleSets
 } from "office-ui-fabric-react";
 
 export interface IMatrixAreaStyles {
   emptyLabelPadding: IStyle;
+  layerHost: IStyle;
   matrixLabelBottom: IStyle;
   matrixLabelTab: IStyle;
   matrixLabel: IStyle;
@@ -20,6 +21,11 @@ export const matrixAreaStyles: () => IProcessedStyleSet<IMatrixAreaStyles> =
     return mergeStyleSets<IMatrixAreaStyles>({
       emptyLabelPadding: {
         paddingTop: "60px"
+      },
+      layerHost: {
+        height: "500px",
+        overflow: "hidden",
+        position: "relative"
       },
       matrixArea: {
         paddingBottom: "50px",

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.tsx
@@ -10,11 +10,17 @@ import {
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
+  Customizer,
   DefaultButton,
+  getId,
   mergeStyles,
+  ISettings,
   IStackStyles,
   IStackTokens,
   IStyle,
+  Layer,
+  LayerHost,
+  ScrollablePane,
   Stack,
   Text
 } from "office-ui-fabric-react";
@@ -52,6 +58,7 @@ export class MatrixArea extends React.PureComponent<
   public static contextType = ModelAssessmentContext;
   public context: React.ContextType<typeof ModelAssessmentContext> =
     defaultModelAssessmentContext;
+  private layerHostId: string;
   public constructor(props: IMatrixAreaProps) {
     super(props);
     this.state = {
@@ -65,6 +72,7 @@ export class MatrixArea extends React.PureComponent<
       quantileBinning: this.props.state.quantileBinning,
       selectedCells: this.props.state.selectedCells
     };
+    this.layerHostId = getId("matrixAreaHost");
     if (this.props.state.selectedCells === undefined) {
       this.reloadData();
     }
@@ -160,65 +168,79 @@ export class MatrixArea extends React.PureComponent<
             isEnabled={this.props.isEnabled}
           />
         </Stack>
-        <Stack
-          horizontal
-          tokens={stackTokens}
-          className={classNames.matrixArea}
+        <Customizer
+          settings={(currentSettings): ISettings => ({
+            ...currentSettings,
+            hostId: this.layerHostId
+          })}
         >
-          <Stack.Item>
-            {this.props.selectedFeature2 && (
-              <div className={classNames.matrixLabelBottom}>
-                <div className={classNames.matrixLabelTab} />
-                <div>{this.props.selectedFeature2}</div>
-              </div>
-            )}
-            <Stack
-              horizontal
-              tokens={stackTokens}
-              className={classNames.matrixArea}
-            >
-              {this.props.selectedFeature1 && !sameFeatureSelected && (
+          <Layer>
+            <ScrollablePane>
+              <Stack
+                horizontal
+                tokens={stackTokens}
+                className={classNames.matrixArea}
+              >
                 <Stack.Item>
-                  <FeatureRowCategories
-                    jsonMatrix={this.state.jsonMatrix}
-                    selectedFeature1={this.props.selectedFeature1}
-                    selectedFeature2={this.props.selectedFeature2}
-                    category1Values={category1Values}
-                    sameFeatureSelected={sameFeatureSelected}
-                  />
+                  {this.props.selectedFeature2 && (
+                    <div className={classNames.matrixLabelBottom}>
+                      <div className={classNames.matrixLabelTab} />
+                      <div>{this.props.selectedFeature2}</div>
+                    </div>
+                  )}
+                  <Stack
+                    horizontal
+                    tokens={stackTokens}
+                    className={classNames.matrixArea}
+                  >
+                    {this.props.selectedFeature1 && !sameFeatureSelected && (
+                      <Stack.Item>
+                        <FeatureRowCategories
+                          jsonMatrix={this.state.jsonMatrix}
+                          selectedFeature1={this.props.selectedFeature1}
+                          selectedFeature2={this.props.selectedFeature2}
+                          category1Values={category1Values}
+                          sameFeatureSelected={sameFeatureSelected}
+                        />
+                      </Stack.Item>
+                    )}
+                    <Stack.Item>
+                      <MatrixCells
+                        jsonMatrix={this.state.jsonMatrix}
+                        selectedFeature1={this.props.selectedFeature1}
+                        selectedFeature2={this.props.selectedFeature2}
+                        selectedCells={this.state.selectedCells}
+                        category1Values={category1Values}
+                        sameFeatureSelected={sameFeatureSelected}
+                        selectedCellHandler={this.selectedCellHandler.bind(
+                          this
+                        )}
+                      />
+                      <MatrixFooter
+                        jsonMatrix={this.state.jsonMatrix}
+                        selectedFeature1={this.props.selectedFeature1}
+                        selectedFeature2={this.props.selectedFeature2}
+                        selectedCells={this.state.selectedCells}
+                        category1Values={category1Values}
+                        category2Values={category2Values}
+                        sameFeatureSelected={sameFeatureSelected}
+                        matrixLength={matrixLength}
+                      />
+                    </Stack.Item>
+                  </Stack>
                 </Stack.Item>
-              )}
-              <Stack.Item>
-                <MatrixCells
-                  jsonMatrix={this.state.jsonMatrix}
-                  selectedFeature1={this.props.selectedFeature1}
-                  selectedFeature2={this.props.selectedFeature2}
-                  selectedCells={this.state.selectedCells}
-                  category1Values={category1Values}
-                  sameFeatureSelected={sameFeatureSelected}
-                  selectedCellHandler={this.selectedCellHandler.bind(this)}
-                />
-                <MatrixFooter
-                  jsonMatrix={this.state.jsonMatrix}
-                  selectedFeature1={this.props.selectedFeature1}
-                  selectedFeature2={this.props.selectedFeature2}
-                  selectedCells={this.state.selectedCells}
-                  category1Values={category1Values}
-                  category2Values={category2Values}
-                  sameFeatureSelected={sameFeatureSelected}
-                  matrixLength={matrixLength}
-                />
-              </Stack.Item>
-            </Stack>
-          </Stack.Item>
-          <Stack.Item>
-            {this.props.selectedFeature1 && !sameFeatureSelected && (
-              <div className={styledMatrixLabel}>
-                {this.props.selectedFeature1}
-              </div>
-            )}
-          </Stack.Item>
-        </Stack>
+                <Stack.Item>
+                  {this.props.selectedFeature1 && !sameFeatureSelected && (
+                    <div className={styledMatrixLabel}>
+                      {this.props.selectedFeature1}
+                    </div>
+                  )}
+                </Stack.Item>
+              </Stack>
+            </ScrollablePane>
+          </Layer>
+        </Customizer>
+        <LayerHost id={this.layerHostId} className={classNames.layerHost} />
       </Stack>
     );
   }


### PR DESCRIPTION
Resolves issue https://github.com/microsoft/responsible-ai-toolbox/issues/1072
With high number of bins or categorical features users will see a scrollbar now instead of the heatmap cells being cut off.

High number of bins:
![image](https://user-images.githubusercontent.com/24683184/145289024-755feea2-a7ff-4934-9696-07be4f671249.png)

Categorical features with many categories (scrolled to bottom):
![image](https://user-images.githubusercontent.com/24683184/145289061-456065e0-c690-4fa6-b1c6-569f746152dd.png)

Note that user will not see scrollbar if matrix area is small.