### PR TITLE
Gracefully handle failure in loading model.pkl from disk

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -714,8 +714,11 @@ class RAIInsights(object):
             inst.__dict__[_MODEL] = serializer.load(top_dir)
         else:
             inst.__dict__['_' + _SERIALIZER] = None
-            with open(top_dir / _MODEL_PKL, 'rb') as file:
-                inst.__dict__[_MODEL] = pickle.load(file)
+            try:
+                with open(top_dir / _MODEL_PKL, 'rb') as file:
+                    inst.__dict__[_MODEL] = pickle.load(file)
+            except Exception:
+                inst.__dict__[_MODEL] = None
 
     @staticmethod
     def _load_managers(inst, path):

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -716,6 +716,10 @@ class RAIInsights(object):
                 with open(top_dir / _MODEL_PKL, 'rb') as file:
                     inst.__dict__[_MODEL] = pickle.load(file)
             except Exception:
+                warnings.warn(
+                    'ERROR-LOADING-USER-MODEL: '
+                    'There was an error loading the user model. '
+                    'Some of RAI dashboard features may not work.')
                 inst.__dict__[_MODEL] = None
 
     @staticmethod

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -21,9 +21,9 @@ from .common_utils import (create_adult_income_dataset,
                            create_binary_classification_dataset,
                            create_boston_data, create_cancer_data,
                            create_complex_classification_pipeline,
-                           create_iris_data, create_models_classification,
-                           create_models_regression,
-                           create_lightgbm_classifier)
+                           create_iris_data, create_lightgbm_classifier,
+                           create_models_classification,
+                           create_models_regression)
 from .counterfactual_manager_validator import validate_counterfactual
 from .error_analysis_validator import (setup_error_analysis,
                                        validate_error_analysis)


### PR DESCRIPTION
There could be a situation where pickle.load() cannot load the model. In such scenarios, the load() of the RAIInsights will fail. Adding additional logic to cover this scenario. 