### PR TITLE
Add onMatrixFeaturesUpdated prop in IModelAssessmentDashboardProps

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
@@ -45,6 +45,7 @@ export interface IErrorAnalysisViewProps {
     cells: number,
     cohortStats: MetricCohortStats | undefined
   ) => void;
+  updateSelectedMatrixFeatures?: (matrixFeatures: [string, string]) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;
   treeViewState: ITreeViewRendererState;
@@ -89,6 +90,9 @@ export class ErrorAnalysisView extends React.Component<IErrorAnalysisViewProps> 
             getMatrix={this.props.getMatrix}
             matrix={this.props.matrix}
             matrixFeatures={this.props.matrixFeatures}
+            updateSelectedMatrixFeatures={
+              this.props.updateSelectedMatrixFeatures
+            }
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
@@ -110,6 +110,9 @@ export class ErrorAnalysisViewTab extends React.Component<
             disabledView={this.props.disabledView}
             features={this.props.features}
             selectedFeatures={this.props.selectedFeatures}
+            updateSelectedMatrixFeatures={
+              this.props.updateSelectedMatrixFeatures
+            }
             getTreeNodes={this.props.getTreeNodes}
             getMatrix={this.props.getMatrix}
             matrix={this.props.matrix}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixFilter/MatrixFilter.tsx
@@ -53,6 +53,7 @@ export interface IMatrixFilterProps {
     cells: number,
     cohortStats: MetricCohortStats | undefined
   ) => void;
+  updateSelectedMatrixFeatures?: (selectedFeatures: [string, string]) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;
   state: IMatrixFilterState;
@@ -187,6 +188,10 @@ export class MatrixFilter extends React.PureComponent<
   ): void => {
     if (typeof item?.key == "string") {
       this.setState({ selectedFeature1: item.key });
+      this.props.updateSelectedMatrixFeatures?.([
+        item.key,
+        this.state.selectedFeature2 || ""
+      ]);
     }
   };
 
@@ -196,6 +201,10 @@ export class MatrixFilter extends React.PureComponent<
   ): void => {
     if (typeof item?.key == "string") {
       this.setState({ selectedFeature2: item.key });
+      this.props.updateSelectedMatrixFeatures?.([
+        this.state.selectedFeature1 || "",
+        item.key
+      ]);
     }
   };
 

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -159,6 +159,9 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                           messages={this.props.stringParams?.contextualHelp}
                           getTreeNodes={this.props.requestDebugML}
                           getMatrix={this.props.requestMatrix}
+                          updateSelectedMatrixFeatures={
+                            this.props.onMatrixFeaturesUpdated
+                          }
                           updateSelectedCohort={this.updateSelectedCohort}
                           features={
                             this.props.errorAnalysisData[0].tree_features ||

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboardProps.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboardProps.ts
@@ -31,6 +31,7 @@ export interface IModelAssessmentDashboardProps
   locale?: string;
   stringParams?: IStringsParam;
   classDimension?: 1 | 2 | 3;
+  onMatrixFeaturesUpdated?: (matrixFeatures: [string, string]) => void;
   requestPredictions?: (
     request: any[],
     abortSignal: AbortSignal


### PR DESCRIPTION
This pull request adds onMatrixFeaturesUpdated  props to IModelAssessmentDashboardProps. The goal is to be able to trigger new matrix API call when selected feature 1 or feature 2 is updated.
![image](https://user-images.githubusercontent.com/91754176/145916256-98011efd-eb83-49c4-9a0d-f152fe771a03.png)
