### PR TITLE
fix handling numpy types in heatmap for categories

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -389,7 +389,7 @@ def matrix_2d(categories1, categories2, matrix_counts,
             category1_max_interval.append(cat1.right)
             category1.append(str(cat1))
         else:
-            category1.append(cat1)
+            category1.append(get_py_value(cat1))
         for col_index in range(len(categories2)):
             cat2 = categories2[col_index]
             index_exists_err = cat1 in matrix_err_counts.index
@@ -454,7 +454,7 @@ def matrix_2d(categories1, categories2, matrix_counts,
             category2_max_interval.append(cat2.right)
             category2.append(str(cat2))
         else:
-            category2.append(cat2)
+            category2.append(get_py_value(cat2))
     category1 = {VALUES: category1,
                  INTERVAL_MIN: category1_min_interval,
                  INTERVAL_MAX: category1_max_interval}
@@ -528,7 +528,7 @@ def matrix_1d(categories, values_err, counts, counts_err,
             category_max_interval.append(cat.right)
             category.append(str(cat))
         else:
-            category.append(cat)
+            category.append(get_py_value(cat))
     category1 = {VALUES: category,
                  INTERVAL_MIN: category_min_interval,
                  INTERVAL_MAX: category_max_interval}
@@ -540,3 +540,9 @@ def fill_matrix_nulls(matrix, null_value):
     idx_tuples = list(zip(idx_arrays[0], idx_arrays[1]))
     for tuple in idx_tuples:
         matrix.iloc[tuple] = null_value
+
+
+def get_py_value(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    return value

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '28'
+_patch = '29'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -298,6 +298,21 @@ class TestMatrixFilter(object):
                                      matrix_features=matrix_features,
                                      quantile_binning=True)
 
+    def test_matrix_filter_iris_int64(self):
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+
+        X_train[feature_names[0]] = X_train[feature_names[0]].astype(np.int64)
+        X_test[feature_names[0]] = X_test[feature_names[0]].astype(np.int64)
+
+        model_task = ModelTask.CLASSIFICATION
+        matrix_features = [feature_names[0]]
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task,
+                                     matrix_features=matrix_features)
+
 
 def run_error_analyzer_on_models(X_train,
                                  y_train,
@@ -433,6 +448,9 @@ def validate_matrix(matrix, exp_total_count,
 
 def validate_matrix_category(category, reverse_order=True):
     assert VALUES in category
+    # Make sure categories are never numpy types but python types
+    for value in category[VALUES]:
+        assert not isinstance(value, np.generic)
     if INTERVAL_MIN in category:
         assert INTERVAL_MAX in category
         intervals = category[INTERVAL_MIN]


### PR DESCRIPTION
Resolves issue:
https://github.com/microsoft/responsible-ai-toolbox/issues/1091
Error:
TypeError: Object of type 'int64' is not JSON serializable
Fixes the error by ensuring categories are converted to python types if they are the corresponding numpy type in the matrix json.