### PR TITLE
add warning message for downsampled explanation data in ErrorAnalysis UI

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -35,16 +35,19 @@ import { localization } from "@responsible-ai/localization";
 import { ModelMetadata } from "@responsible-ai/mlchartlib";
 import _ from "lodash";
 import {
+  Customizer,
+  getId,
   IPivotItemProps,
   ISettings,
   Layer,
   LayerHost,
-  Customizer,
-  getId,
+  mergeStyleSets,
+  MessageBar,
+  MessageBarType,
   PivotItem,
   Pivot,
   PivotLinkSize,
-  mergeStyleSets
+  Text
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -560,6 +563,13 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                         <PivotItem key={props.itemKey} {...props} />
                       ))}
                     </Pivot>
+                    {this.props.rootStats &&
+                      this.state.jointDataset.datasetRowCount !==
+                        this.props.rootStats.totalSize && (
+                        <MessageBar messageBarType={MessageBarType.warning}>
+                          <Text>{localization.ErrorAnalysis.scaleWarning}</Text>
+                        </MessageBar>
+                      )}
                     {this.state.activeGlobalTab ===
                       GlobalTabKeys.DataExplorerTab && <DatasetExplorerTab />}
                     {this.state.activeGlobalTab ===

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -345,6 +345,7 @@
     "instanceView": "Instance View",
     "localExplanationView": "Local explanation",
     "noFeature": "No feature",
+    "scaleWarning": "For scale reasons of the UI explanations are randomly downsampled",
     "whatIfDatapoints": "What-If datapoints"
   },
   "Fairness": {


### PR DESCRIPTION
Resolves last remaining part of issue https://github.com/microsoft/responsible-ai-toolbox/issues/279

The last remaining piece was to add a warning message when the UI has fewer rows loaded than the tree view or heatmap.

![image](https://user-images.githubusercontent.com/24683184/147600940-169aad30-a0ca-4c99-99b6-a4bd496a7944.png)

![image](https://user-images.githubusercontent.com/24683184/147600980-a3ddfe33-da56-4a4f-91a9-ed7340965f0e.png)
