### PR TITLE
Replace existing user token with shared account token

### DIFF
--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       type:
-        description: "Test or Prod?"
+        description: "Test or Prod PyPI?"
         required: true
         default: "Test"
 
@@ -46,13 +46,13 @@ jobs:
         run: pytest ./tests/
         working-directory: rai_core_flask
 
-      ####### publish to PyPI
+      # publish to PyPI
       - name: Publish rai_core_flask package to Test PyPI
         if: ${{ github.event.inputs.type == 'Test' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN_RAI_CORE_FLASK }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN_RESPONSIBLEAI }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: rai_core_flask/dist/
       - name: Publish rai_core_flask package to PyPI
@@ -60,5 +60,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN_RAI_CORE_FLASK }}
+          password: ${{ secrets.PYPI_API_TOKEN_RESPONSIBLEAI }}
           packages_dir: rai_core_flask/dist/

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -77,7 +77,7 @@ jobs:
         working-directory: ${{ env.raiDirectory }}
       - name: pip freeze
         run: pip freeze
-      #
+
       - name: replace README for raiwidgets
         run: |
           sed -i 's/(.\/img\//(https:\/\/raw.githubusercontent.com\/microsoft\/responsible-ai-widgets\/main\/img\//g' README.md
@@ -86,7 +86,7 @@ jobs:
         run: |
           sed -i 's/(.\/img\//(https:\/\/raw.githubusercontent.com\/microsoft\/responsible-ai-widgets\/main\/img\//g' README.md
           cp ./README.md ./${{ env.raiDirectory }}/
-      # =====
+
       - name: build wheel for raiwidgets
         run: python setup.py sdist bdist_wheel
         working-directory: ${{ env.widgetDirectory }}
@@ -149,35 +149,20 @@ jobs:
           name: ${{ matrix.package }}
           path: ${{ matrix.package }}
 
-      - name: Publish responsibleai package to Test PyPI
-        if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'responsibleai' }}
+      - name: Publish package to Test PyPI
+        if: ${{ github.event.inputs.releaseType == 'Test' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN_RESPONSIBLEAI }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: ${{steps.download.outputs.download-path}}
-      - name: Publish responsibleai package to Prod PyPI
-        if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'responsibleai' }}
+      - name: Publish package to Prod PyPI
+        if: ${{ github.event.inputs.releaseType == 'Prod' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_RESPONSIBLEAI }}
-          packages_dir: ${{steps.download.outputs.download-path}}
-      - name: Publish raiwidgets package to Test PyPI
-        if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'raiwidgets' }}
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN_RAIWIDGETS }}
-          repository_url: https://test.pypi.org/legacy/
-          packages_dir: ${{steps.download.outputs.download-path}}
-      - name: Publish raiwidgets package to Prod PyPI
-        if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'raiwidgets' }}
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN_RAIWIDGETS }}
           packages_dir: ${{steps.download.outputs.download-path}}
 
   release-typescript:


### PR DESCRIPTION
Some of the packages currently use my personal PyPI access token rather than the token from the owning account interpret-community. This PR changes this by using the same token for all release definitions and removing all occurrences of my personal PyPI access token.

When the PR is merged I can delete my token from the GitHub Secrets store.

Note: There is no release definition for `erroranalysis` at this point, but when we create one we can reuse the same token.