### PR TITLE
fix pypi releases by reverting back to pypi token per package

### DIFF
--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -52,7 +52,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN_RESPONSIBLEAI }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN_RAI_CORE_FLASK }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: rai_core_flask/dist/
       - name: Publish rai_core_flask package to PyPI
@@ -60,5 +60,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN_RESPONSIBLEAI }}
+          password: ${{ secrets.PYPI_API_TOKEN_RAI_CORE_FLASK }}
           packages_dir: rai_core_flask/dist/

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -77,7 +77,6 @@ jobs:
         working-directory: ${{ env.raiDirectory }}
       - name: pip freeze
         run: pip freeze
-
       - name: replace README for raiwidgets
         run: |
           sed -i 's/(.\/img\//(https:\/\/raw.githubusercontent.com\/microsoft\/responsible-ai-widgets\/main\/img\//g' README.md
@@ -86,7 +85,6 @@ jobs:
         run: |
           sed -i 's/(.\/img\//(https:\/\/raw.githubusercontent.com\/microsoft\/responsible-ai-widgets\/main\/img\//g' README.md
           cp ./README.md ./${{ env.raiDirectory }}/
-
       - name: build wheel for raiwidgets
         run: python setup.py sdist bdist_wheel
         working-directory: ${{ env.widgetDirectory }}
@@ -149,20 +147,35 @@ jobs:
           name: ${{ matrix.package }}
           path: ${{ matrix.package }}
 
-      - name: Publish package to Test PyPI
-        if: ${{ github.event.inputs.releaseType == 'Test' }}
+      - name: Publish responsibleai package to Test PyPI
+        if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'responsibleai' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN_RESPONSIBLEAI }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: ${{steps.download.outputs.download-path}}
-      - name: Publish package to Prod PyPI
-        if: ${{ github.event.inputs.releaseType == 'Prod' }}
+      - name: Publish responsibleai package to Prod PyPI
+        if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'responsibleai' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN_RESPONSIBLEAI }}
+          packages_dir: ${{steps.download.outputs.download-path}}
+      - name: Publish raiwidgets package to Test PyPI
+        if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'raiwidgets' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN_RAIWIDGETS }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: ${{steps.download.outputs.download-path}}
+      - name: Publish raiwidgets package to Prod PyPI
+        if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'raiwidgets' }}
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_RAIWIDGETS }}
           packages_dir: ${{steps.download.outputs.download-path}}
 
   release-typescript:


### PR DESCRIPTION
## Description

The release process seems to be broken with PR https://github.com/microsoft/responsible-ai-toolbox/pull/1106 since we are using tokens (not passwords) and these are scoped to a specific package.  We need to revert back to using tokens (specific tokens) for each package.  We could also have one token scoped to every package but that seems less secure, and since this functionality exists it seems like a good idea to use it.
