### PR TITLE
[E2E] Data Explorer - diabetes-regression-model-debugging notebook

### DIFF
--- a/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
@@ -75,7 +75,7 @@ export enum Locators {
   DEDropdownOptions = "div[class^='dropdownItemsWrapper'] button:contains('CohortCreateE2E')",
   DEIndividualDatapoints = "#ChartTypeSelection label:contains('Individual datapoints')",
   DEAggregatePlots = "#ChartTypeSelection label:contains('Aggregate plots')",
-  DEYAxisPoints = "#DatasetExplorerChart g[class^='cartesianlayer'] g[class^='ytick']",
+  DEYAxisPoints = "#DatasetExplorerChart g[class^='cartesianlayer'] g[class^='ytick'] text",
   MSCRotatedVerticalBox = "#OverallMetricChart div[class*='rotatedVerticalBox']", // MSC- Model statistics chart
   MSCHorizontalAxis = "#OverallMetricChart div[class*='horizontalAxis']",
   CausalAnalysisHeader = "#ModelAssessmentDashboard #causalAnalysisHeader",

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
@@ -22,7 +22,7 @@ export function describeCohortFunctionality(
       cy.get(Locators.CohortFilterSelection).eq(1).check(); // select Dataset
       cy.get(Locators.CohortDatasetValueInput)
         .clear()
-        .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || ""); // input age as 40
+        .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || "");
       cy.get(Locators.CohortAddFilterButton).click();
       cy.get(Locators.CohortSaveAndSwitchButton).eq(0).click({ force: true });
       cy.get(Locators.NewCohortSpan).should("exist");

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
@@ -53,7 +53,7 @@ export function describeCohortFunctionality(
         .invoke("text")
         .then((text) => {
           const valueInInt = Number(text);
-          expect(valueInInt).to.be.lessThan(
+          expect(valueInInt).lte(
             Number(dataShape.datasetExplorerData?.cohortDatasetNewValue || "")
           );
         });

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
@@ -22,7 +22,7 @@ export function describeCohortFunctionality(
       cy.get(Locators.CohortFilterSelection).eq(1).check(); // select Dataset
       cy.get(Locators.CohortDatasetValueInput)
         .clear()
-        .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || "40"); // input age as 40
+        .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || ""); // input age as 40
       cy.get(Locators.CohortAddFilterButton).click();
       cy.get(Locators.CohortSaveAndSwitchButton).eq(0).click({ force: true });
       cy.get(Locators.NewCohortSpan).should("exist");
@@ -50,10 +50,13 @@ export function describeCohortFunctionality(
       cy.get(Locators.DEDropdownOptions).should("exist").click();
       cy.get(Locators.DEYAxisPoints)
         .last()
-        .should(
-          "contain",
-          dataShape.datasetExplorerData?.cohortDatasetNewValue || "40"
-        );
+        .invoke("text")
+        .then((text) => {
+          const valueInInt = Number(text);
+          expect(valueInInt).to.be.lessThan(
+            Number(dataShape.datasetExplorerData?.cohortDatasetNewValue || "")
+          );
+        });
     });
   });
 }

--- a/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
@@ -121,6 +121,14 @@ const modelAssessmentDatasets = {
     }
   },
   DiabetesRegressionModelDebugging: {
+    cohortDefaultName: "All data",
+    datasetExplorerData: {
+      cohortDatasetNewValue: "0.05",
+      colorValueButton: "Predicted Y",
+      datasetBarLabel: ["0 - 17", "18 - 35", "36 - 52", "53 - 70", "71 - 88"],
+      defaultXAxis: "Index",
+      defaultYAxis: "age"
+    },
     featureImportanceData: {
       dropdownRowName: "Row 4",
       hasCorrectIncorrectDatapoints: false,

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesDecisionMaking/datasetExplorer.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesDecisionMaking/datasetExplorer.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeDatasetExplorer } from "../../../describer/modelAssessment/dataExplorer/describeDatasetExplorer";
+
+describeDatasetExplorer("DiabetesRegressionModelDebugging");


### PR DESCRIPTION
[E2E] Data Explorer - diabetes-regression-model-debugging notebook 

## Description

Add e2e tests for data explorerer for https://github.com/microsoft/responsible-ai-toolbox/blob/main/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb notebook.

![image](https://user-images.githubusercontent.com/33799331/149003136-7d271c0b-f87b-45dd-9037-1cb86daffe47.png)
![image](https://user-images.githubusercontent.com/33799331/149003222-240cf65c-f5f4-4532-8d11-d50d6ba2c0f1.png)

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
