### PR TITLE
Catch dirty data condition in RAI insights validation

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -270,6 +270,23 @@ class RAIInsights(object):
                                f"{list(difference_set)}")
                     raise UserConfigValidationException(message)
 
+                for column in categorical_features:
+                    try:
+                        np.unique(train[column])
+                    except Exception:
+                        raise UserConfigValidationException(
+                            "Error finding unique values in column {0}. "
+                            "Please check your train data.".format(column)
+                        )
+
+                    try:
+                        np.unique(test[column])
+                    except Exception:
+                        raise UserConfigValidationException(
+                            "Error finding unique values in column {0}. "
+                            "Please check your test data.".format(column)
+                        )
+
             if classes is not None and task_type == \
                     ModelTask.CLASSIFICATION:
                 if len(set(train[target_column].unique()) -

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -4,6 +4,7 @@
 import logging
 from unittest.mock import MagicMock
 
+from lightgbm import LGBMClassifier
 import numpy as np
 import pandas as pd
 import pytest
@@ -264,13 +265,52 @@ class TestRAIInsightsValidations:
         assert 'The features in train and test data do not match' in \
             str(ucve.value)
 
+    def test_dirty_train_test_data(self):
+        X_train = pd.DataFrame(data=[['1', np.nan], ['2', '3']],
+                               columns=['c1', 'c2'])
+        y_train = np.array([1, 0])
+        X_test = pd.DataFrame(data=[['1', '2'], ['2', '3']],
+                              columns=['c1', 'c2'])
+        y_test = np.array([1, 0])
+
+        model = LGBMClassifier(boosting_type='gbdt', learning_rate=0.1,
+                               max_depth=5, n_estimators=200, n_jobs=1,
+                               random_state=777)
+
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                categorical_features=['c2'],
+                task_type='classification')
+
+        assert 'Error finding unique values in column c2. ' + \
+            'Please check your train data.' in str(ucve.value)
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_test,
+                test=X_train,
+                target_column=TARGET,
+                categorical_features=['c2'],
+                task_type='classification')
+
+        assert 'Error finding unique values in column c2. ' + \
+            'Please check your test data.' in str(ucve.value)
+
     def test_unsupported_train_test_types(self):
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
 
         X_train[TARGET] = y_train
-        X_test['bad_target'] = y_test
+        X_test[TARGET] = y_test
 
         with pytest.raises(UserConfigValidationException) as ucve:
             RAIInsights(
@@ -279,6 +319,7 @@ class TestRAIInsightsValidations:
                 test=X_test.values,
                 target_column=TARGET,
                 task_type='classification')
+
         assert "Unsupported data type for either train or test. " + \
             "Expecting pandas Dataframe for train and test." in str(ucve.value)
 

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -4,10 +4,10 @@
 import logging
 from unittest.mock import MagicMock
 
-from lightgbm import LGBMClassifier
 import numpy as np
 import pandas as pd
 import pytest
+from lightgbm import LGBMClassifier
 
 from responsibleai import RAIInsights
 from responsibleai.exceptions import UserConfigValidationException


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we check for unique values for categorical values in causal and counterfactual managers, the failure in computing unique values do not give any meaningful information to help the users. Hence, catching the error while computing unique values in categorical columns upfront and then logging which user column caused that error.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
