### PR TITLE
add notebook test for pytorch example notebook and add pytorch to CI

### DIFF
--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.pythonVersion }}
-        uses: actions/setup-python@v2
+      - uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.pythonVersion }}
 
       - name: build typescript
@@ -29,34 +29,51 @@ jobs:
           yarn install
           yarn buildall
 
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+        name: Install pytorch on non-MacOS
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+
+      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
+        name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum -c pytorch
+
       - name: Setup tools
+        shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
           pip install --upgrade pip-tools
 
-      - name: Pip compile
+      - name: Install dependencies
+        shell: bash -l {0}
         run: |
-          pip-compile requirements-dev.txt
-          cat requirements-dev.txt
+          pip install -r requirements-dev.txt
+          pip install .
+        working-directory: raiwidgets
+
+      - name: Pip freeze
+        shell: bash -l {0}
+        run: |
+          pip freeze > installed-requirements-dev.txt
+          cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
       - name: Upload requirements
         uses: actions/upload-artifact@v2
         with:
           name: requirements-dev.txt
-          path: raiwidgets/requirements-dev.txt
-
-      - name: Install dependencies
-        run: |
-          pip-sync requirements-dev.txt
-          pip install .
-        working-directory: raiwidgets
+          path: raiwidgets/installed-requirements-dev.txt
 
       - name: Run notebook tests
+        shell: bash -l {0}
         run: python -m pytest notebooks
 
       - name: Run widget tests
+        shell: bash -l {0}
         run: yarn e2e-widget
 
       - name: Upload notebook test result

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -246,3 +246,12 @@ def test_responsibleaidashboard_housing_decision_making():
 
     test_values = {}
     assay_one_notebook(nb_path, nb_name, test_values)
+
+
+@pytest.mark.notebooks
+def test_responsibleaidashboard_multiclass_dnn_model_debugging():
+    nb_path = RESPONSIBLEAIDASHBOARD
+    nb_name = "responsibleaidashboard-multiclass-dnn-model-debugging"
+
+    test_values = {}
+    assay_one_notebook(nb_path, nb_name, test_values)


### PR DESCRIPTION
## Description

This PR adds a notebook test for the pytorch example notebook responsibleaidashboard-multiclass-dnn-model-debugging.ipynb.  Note that this also requires adding pytorch to the CI.  This PR adds pytorch via conda (and changes the notebooks build to install and use conda).  Note pytorch is much faster when installed via conda, and the command for linux install is also more similar to the others and doesn't require you to specify a version in that case too (see https://pytorch.org/).

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
