### PR TITLE
integrate codecov into rai toolbox repository

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -107,3 +107,16 @@ jobs:
           path: ${{ matrix.packageDirectory }}/htmlcov
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() && matrix.packageDirectory != 'raiwidgets'}}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ matrix.packageDirectory }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./${{ matrix.packageDirectory }}/coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          path_to_write_report: ./coverage/codecov_report.txt
+          verbose: true
+        if: ${{ matrix.packageDirectory != 'raiwidgets'}}


### PR DESCRIPTION
## Description

This PR integrates codecov (https://about.codecov.io/) into the repository.  Once this is merged, users will be able to see reports here:
https://app.codecov.io/gh/microsoft/responsible-ai-toolbox
Similar to:
https://app.codecov.io/gh/microsoft/ml-wrappers
which I recently added, or:
https://app.codecov.io/gh/microsoft/synapseml
as another example

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
