### PR TITLE
fix importances taking too long to calculate for large data in error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/utils.py
+++ b/erroranalysis/erroranalysis/_internal/utils.py
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import random
+
+import numpy as np
+
+
+def generate_random_unique_indexes(count, nnz):
+    """Utility to generate a list of random unique indexes in memory.
+
+    Uses Knuth's n of k algorithm to generate the list in memory.
+
+    :param count: The range of values to choose from.
+    :type count: int
+    :param nnz: The number of unique values to choose.
+    :type nnz: int
+    :return: The list of unique indexes of length nnz.
+    :rtype: numpy.array
+    """
+    if nnz > count:
+        raise Exception("Knuth n-of-k algorithms requires 0 < n < k")
+    indexes = np.zeros(nnz, dtype=int)
+    current = 0
+    i = 0
+    while i < count and current < nnz:
+        probability = (nnz - current) / (count - i)
+        if random.random() < probability:
+            indexes[current] = i
+            current += 1
+        i += 1
+    return indexes

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -133,8 +133,8 @@ def create_cancer_data():
     return X_train, X_test, y_train, y_test, feature_names, classes
 
 
-def create_binary_classification_dataset():
-    X, y = make_classification(random_state=777)
+def create_binary_classification_dataset(n_samples=100):
+    X, y = make_classification(n_samples=n_samples, random_state=777)
 
     # Split data into train and test
     X_train, X_test, y_train, y_test = train_test_split(X,

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -1,10 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import time
+
+import numpy as np
+import pandas as pd
 from common_utils import (create_binary_classification_dataset,
                           create_boston_data, create_cancer_data,
                           create_iris_data, create_models_classification,
                           create_models_regression, create_simple_titanic_data,
+                          create_sklearn_random_forest_regressor,
                           create_titanic_pipeline)
 
 from erroranalysis._internal.constants import ModelTask
@@ -65,6 +70,30 @@ class TestImportances(object):
             categorical_features = []
             run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
+
+    def test_large_data_importances(self):
+        # mutual information can be very costly for large number of rows
+        # hence, assert we downsample to compute importances for large data
+        X_train, y_train, X_test, y_test, _ = \
+            create_binary_classification_dataset(100)
+        feature_names = list(X_train.columns)
+        model = create_sklearn_random_forest_regressor(X_train, y_train)
+        for _ in range(16):
+            X_test = pd.concat([X_test, X_test], ignore_index=True)
+            y_test = np.concatenate([y_test, y_test])
+        assert X_test.shape[0] > 1000000
+        t0 = time.time()
+        categorical_features = []
+        model_analyzer = ModelAnalyzer(model, X_test, y_test,
+                                       feature_names,
+                                       categorical_features)
+        model_analyzer.compute_importances()
+        t1 = time.time()
+        execution_time = t1 - t0
+        print(execution_time)
+        # assert we don't take too long and downsample the dataset
+        # note execution time is in seconds
+        assert execution_time < 20
 
 
 def run_error_analyzer(model, X_test, y_test, feature_names,


### PR DESCRIPTION
## Description

During performance profiling of error analysis on 2.5 million rows of data based on a customer's issue, I discovered that running mutual information was very slow for calculating importances, see related issue:

https://github.com/scikit-learn/scikit-learn/issues/6904

The suggestion is to downsample the data, which this PR does if the number of rows is very large.  Since the importances in features panel are an approximate guide anyway this should have limited impact on the user's experience.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
