### PR TITLE
Make explanations save behavior similar to other managers

### DIFF
--- a/responsibleai/responsibleai/managers/explainer_manager.py
+++ b/responsibleai/responsibleai/managers/explainer_manager.py
@@ -308,18 +308,19 @@ class ExplainerManager(BaseManager):
         """
         top_dir = Path(path)
         top_dir.mkdir(parents=True, exist_ok=True)
-        directory_manager = DirectoryManager(parent_directory_path=path)
-        data_directory = directory_manager.create_data_directory()
+        if self._is_added:
+            directory_manager = DirectoryManager(parent_directory_path=path)
+            data_directory = directory_manager.create_data_directory()
 
-        # save the explanation
-        if self._explanation:
-            save_explanation(self._explanation,
-                             data_directory / ManagerNames.EXPLAINER)
+            # save the explanation
+            if self._explanation:
+                save_explanation(self._explanation,
+                                 data_directory / ManagerNames.EXPLAINER)
 
-        meta = {IS_RUN: self._is_run,
-                IS_ADDED: self._is_added}
-        with open(data_directory / META_JSON, 'w') as file:
-            json.dump(meta, file)
+            meta = {IS_RUN: self._is_run,
+                    IS_ADDED: self._is_added}
+            with open(data_directory / META_JSON, 'w') as file:
+                json.dump(meta, file)
 
     @staticmethod
     def _load(path, rai_insights):
@@ -337,22 +338,27 @@ class ExplainerManager(BaseManager):
         inst = ExplainerManager.__new__(ExplainerManager)
 
         all_cf_dirs = DirectoryManager.list_sub_directories(path)
-        directory_manager = DirectoryManager(
-            parent_directory_path=path,
-            sub_directory_name=all_cf_dirs[0])
-        data_directory = directory_manager.get_data_directory()
+        if len(all_cf_dirs) != 0:
+            directory_manager = DirectoryManager(
+                parent_directory_path=path,
+                sub_directory_name=all_cf_dirs[0])
+            data_directory = directory_manager.get_data_directory()
 
-        with open(data_directory / META_JSON, 'r') as meta_file:
-            meta = meta_file.read()
-        meta = json.loads(meta)
-        inst.__dict__['_' + IS_RUN] = meta[IS_RUN]
-        inst.__dict__['_' + IS_ADDED] = meta[IS_ADDED]
+            with open(data_directory / META_JSON, 'r') as meta_file:
+                meta = meta_file.read()
+            meta = json.loads(meta)
+            inst.__dict__['_' + IS_RUN] = meta[IS_RUN]
+            inst.__dict__['_' + IS_ADDED] = meta[IS_ADDED]
 
-        inst.__dict__[EXPLANATION] = None
-        explanation_path = data_directory / ManagerNames.EXPLAINER
-        if explanation_path.exists():
-            explanation = load_explanation(explanation_path)
-            inst.__dict__[EXPLANATION] = explanation
+            inst.__dict__[EXPLANATION] = None
+            explanation_path = data_directory / ManagerNames.EXPLAINER
+            if explanation_path.exists():
+                explanation = load_explanation(explanation_path)
+                inst.__dict__[EXPLANATION] = explanation
+        else:
+            inst.__dict__['_' + IS_RUN] = False
+            inst.__dict__['_' + IS_ADDED] = False
+            inst.__dict__[EXPLANATION] = None
 
         inst.__dict__['_' + MODEL] = rai_insights.model
         inst.__dict__['_' + CLASSES] = rai_insights._classes

--- a/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
+++ b/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
@@ -42,6 +42,10 @@ class TestRAIInsightsSaveAndLoadScenarios(object):
 
             # Save it
             rai_insights.save(save_1)
+            assert len(os.listdir(save_1 / ManagerNames.CAUSAL)) == 0
+            assert len(os.listdir(save_1 / ManagerNames.COUNTERFACTUAL)) == 0
+            assert len(os.listdir(save_1 / ManagerNames.ERROR_ANALYSIS)) == 0
+            assert len(os.listdir(save_1 / ManagerNames.EXPLAINER)) == 0
 
             # Load
             rai_2 = RAIInsights.load(save_1)
@@ -53,6 +57,10 @@ class TestRAIInsightsSaveAndLoadScenarios(object):
 
             # Save again (this is where Issue #1046 manifested)
             rai_2.save(save_2)
+            assert len(os.listdir(save_2 / ManagerNames.CAUSAL)) == 0
+            assert len(os.listdir(save_2 / ManagerNames.COUNTERFACTUAL)) == 0
+            assert len(os.listdir(save_2 / ManagerNames.ERROR_ANALYSIS)) == 0
+            assert len(os.listdir(save_2 / ManagerNames.EXPLAINER)) == 0
 
     @pytest.mark.parametrize('manager_type', [ManagerNames.CAUSAL,
                                               ManagerNames.ERROR_ANALYSIS,


### PR DESCRIPTION
## Description

It seems the explainer manager would create state even if no explain config is added by user. Other managers do not save any state in such a scenario. Hence making the behavior of explainer manager similar to other managers.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
