### PR TITLE
Cover missing test scenario in state_directory_management.py

### DIFF
--- a/responsibleai/tests/test_state_directory_management.py
+++ b/responsibleai/tests/test_state_directory_management.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pytest
+
 from pathlib import Path
 
 from responsibleai._tools.shared.state_directory_management import \
@@ -45,8 +47,12 @@ class TestStateDirectoryManagement:
         assert generators_directory_path.exists()
         assert DirectoryManager.GENERATORS in str(generators_directory_path)
 
-    def test_directory_manager(self, tmpdir):
-        parent_directory = tmpdir.mkdir('parent_directory')
+    @pytest.mark.parametrize('create_parent_directory', [True, False])
+    def test_directory_manager(self, tmpdir, create_parent_directory):
+        if create_parent_directory:
+            parent_directory = tmpdir.mkdir('parent_directory')
+        else:
+            parent_directory = tmpdir / 'parent_directory'
         dm_one = DirectoryManager(
             parent_directory_path=parent_directory,
             sub_directory_name='known')

--- a/responsibleai/tests/test_state_directory_management.py
+++ b/responsibleai/tests/test_state_directory_management.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-import pytest
-
 from pathlib import Path
+
+import pytest
 
 from responsibleai._tools.shared.state_directory_management import \
     DirectoryManager


### PR DESCRIPTION
## Description

It seems one of the test scenarios where the parent directory doesn't exist was missing from the tests for state_directory_management.py.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
