### PR TITLE
Change logic to walk categorical columns in validate_train_test_categories()

### DIFF
--- a/responsibleai/responsibleai/_data_validations.py
+++ b/responsibleai/responsibleai/_data_validations.py
@@ -19,8 +19,8 @@ def validate_train_test_categories(
     if categoricals is None:
         return
     discovered = {}
-    for column in train_data.columns:
-        if column in categoricals:
+    for column in categoricals:
+        if column in train_data.columns:
             train_unique = np.unique(train_data[column])
             test_unique = np.unique(test_data[column])
             difference = np.setdiff1d(test_unique, train_unique)


### PR DESCRIPTION


## Description

It seems the logic walks all columns in training data and then looks up if the column is in categorical feature name list. This may be inefficient in case the number of columns is large but there are less small number of categorical columns. So changing the logic to walking categorical columns instead and then looking up if the column exists in training data.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
