### PR TITLE
add new interpret-text library skeleton

### DIFF
--- a/libs/interpret-text/.babelrc
+++ b/libs/interpret-text/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@nrwl/react/babel"],
+  "plugins": []
+}

--- a/libs/interpret-text/.eslintrc.json
+++ b/libs/interpret-text/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/interpret-text/README.md
+++ b/libs/interpret-text/README.md
@@ -1,0 +1,7 @@
+# interpret-text
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test interpret-text` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/interpret-text/babel-jest.config.json
+++ b/libs/interpret-text/babel-jest.config.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ]
+}

--- a/libs/interpret-text/jest.config.js
+++ b/libs/interpret-text/jest.config.js
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+module.exports = {
+  coverageDirectory: "../../coverage/libs/interpret-text",
+  displayName: "interpret-text",
+
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "html"],
+  preset: "../../jest.preset.js",
+  transform: {
+    "^.+\\.[tj]sx?$": [
+      "babel-jest",
+      { configFile: "./babel-jest.config.json", cwd: __dirname }
+    ]
+  }
+};

--- a/libs/interpret-text/package.json
+++ b/libs/interpret-text/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@responsible-ai/interpret-text",
+  "version": "0.0.0",
+  "license": "MIT"
+}

--- a/libs/interpret-text/src/index.ts
+++ b/libs/interpret-text/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export * from "./lib/TextExplanationDashboard";

--- a/libs/interpret-text/src/lib/TextExplanationDashboard.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from "react";
+
+export class TextExplanationDashboard extends React.PureComponent {
+  public render(): React.ReactNode {
+    return (
+      <div>
+        <h1>Welcome to interpret-text!</h1>
+      </div>
+    );
+  }
+}

--- a/libs/interpret-text/tsconfig.json
+++ b/libs/interpret-text/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {},
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/interpret-text/tsconfig.lib.json
+++ b/libs/interpret-text/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/interpret-text/tsconfig.spec.json
+++ b/libs/interpret-text/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -49,6 +49,9 @@
     "interpret": {
       "tags": []
     },
+    "interpret-text": {
+      "tags": []
+    },
     "localization": {
       "tags": []
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@fluentui/react": "8.13.1",
+    "core-js": "^3.6.5",
     "d3-array": "^2.8.0",
     "d3-color": "^2.0.0",
     "d3-hierarchy": "^2.0.0",
@@ -48,6 +49,7 @@
     "d3-selection": "^2.0.0",
     "d3-shape": "^2.0.0",
     "d3-zoom": "^2.0.0",
+    "document-register-element": "1.13.1",
     "eslint-plugin-sort-keys-fix": "^1.1.1",
     "jmespath": "^0.15.0",
     "json5": "^2.2.0",
@@ -61,6 +63,7 @@
     "react-dom": "17.0.2",
     "react-plotly.js": "^2.5.0",
     "react-router-dom": "^5.0.0",
+    "regenerator-runtime": "0.13.7",
     "tslib": "^2.2.0",
     "uuid": "^8.3.0"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -44,6 +44,7 @@
       "@responsible-ai/error-analysis": ["libs/error-analysis/src/index.ts"],
       "@responsible-ai/fairness": ["libs/fairness/src/index.ts"],
       "@responsible-ai/interpret": ["libs/interpret/src/index.ts"],
+      "@responsible-ai/interpret-text": ["libs/interpret-text/src/index.ts"],
       "@responsible-ai/localization": ["libs/localization/src/index.ts"],
       "@responsible-ai/mlchartlib": ["libs/mlchartlib/src/index.ts"],
       "@responsible-ai/model-assessment": ["libs/model-assessment/src/index.ts"]

--- a/workspace.json
+++ b/workspace.json
@@ -611,6 +611,46 @@
         }
       }
     },
+    "interpret-text": {
+      "root": "libs/interpret-text",
+      "sourceRoot": "libs/interpret-text/src",
+      "projectType": "library",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/web:package",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/interpret-text",
+            "tsConfig": "libs/interpret-text/tsconfig.lib.json",
+            "project": "libs/interpret-text/package.json",
+            "entryFile": "libs/interpret-text/src/index.ts",
+            "external": ["react/jsx-runtime"],
+            "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+            "assets": [
+              {
+                "glob": "libs/interpret-text/README.md",
+                "input": ".",
+                "output": "."
+              }
+            ]
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/interpret-text/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/interpret-text"],
+          "options": {
+            "jestConfig": "libs/interpret-text/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "localization": {
       "root": "libs/localization",
       "sourceRoot": "libs/localization/src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7732,6 +7732,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+document-register-element@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-1.13.1.tgz#dad8cb7be38e04ee3f56842e6cf81af46c1249ba"
+  integrity sha512-92ZyLDKg9j4rOll//NNXj25f+8rAzOkYsGJonhugKwXfeqH7bzs8Ucpvey0WzZ2ZzKdrvW9RnUw3UyOZ/uhBFw==
+  dependencies:
+    lightercollective "^0.1.0"
+
 dom-accessibility-api@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
@@ -12216,6 +12223,11 @@ license-webpack-plugin@2.3.15:
     "@types/webpack-sources" "^0.1.5"
     webpack-sources "^1.2.0"
 
+lightercollective@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lightercollective/-/lightercollective-0.1.0.tgz#70df102c530dcb8d0ccabfe6175a8d00d5f61300"
+  integrity sha512-J9tg5uraYoQKaWbmrzDDexbG6hHnMcWS1qLYgJSWE+mpA3U5OCSeMUhb+K55otgZJ34oFdR0ECvdIb3xuO5JOQ==
+
 lilconfig@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.3.tgz#68f3005e921dafbd2a2afb48379986aa6d2579fd"
@@ -15410,7 +15422,7 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
   integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
 
-regenerator-runtime@^0.13.4:
+regenerator-runtime@0.13.7, regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==


### PR DESCRIPTION
## Description

Add skeleton library for interpret-text component.
This component is being moved from https://github.com/interpretml/interpret-text and updated to latest.
It will be part of the RAI text dashboard.

This PR just sets up the skeleton framework.  Most of the code was generated via:

```
nx generate @nrwl/react:library interpret-text --publishable --importPath @responsible-ai/interpret-text
```

and then files were overwritten based on other projects to be as similar as possible, after which yarn lintfix was applied.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment
- [x] responsibleai/interpret-text

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

Future dashboard (not yet fully integrated):
![image](https://user-images.githubusercontent.com/24683184/150159240-9fb2b477-4f24-4995-8e6e-89b92968e6ae.png)


## Documentation:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
