### PR TITLE
add a perf test for validating training the surrogate error tree on large data and a minor optimization for traversing the tree

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -313,16 +313,16 @@ def node_to_dict(df, tree, nodeid, categories, json,
     parentid = None
     if parent is not None:
         parentid = int(parent[SPLIT_INDEX])
-        p_node_name = feature_names[parent[SPLIT_FEATURE]]
+        p_node_name_val = feature_names[parent[SPLIT_FEATURE]]
         # use number.Integral to check for any numpy or python number type
-        if isinstance(p_node_name, numbers.Integral):
+        if isinstance(p_node_name_val, numbers.Integral):
             # for numeric column names, we can use @df[numeric_colname] syntax
-            p_node_query = "@df[" + str(p_node_name) + "]"
+            p_node_query = "@df[" + str(p_node_name_val) + "]"
         else:
             # for string column names, we can just use column name directly
             # with backticks
-            p_node_query = "`" + str(p_node_name) + "`"
-        p_node_name = str(p_node_name)
+            p_node_query = "`" + str(p_node_name_val) + "`"
+        p_node_name = str(p_node_name_val)
         parent_threshold = parent['threshold']
         parent_decision_type = parent['decision_type']
         if side == TreeSide.LEFT_CHILD:
@@ -331,8 +331,7 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} <= {:.2f}".format(p_node_name,
                                                   parent_threshold)
-                query = p_node_query + " <= " + str(parent_threshold)
-                df = df.query(query)
+                df = df[df[p_node_name_val] <= parent_threshold]
             elif parent_decision_type == '==':
                 method = METHOD_INCLUDES
                 arg = create_categorical_arg(parent_threshold)
@@ -349,8 +348,7 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} > {:.2f}".format(p_node_name,
                                                  parent_threshold)
-                query = p_node_query + " > " + str(parent_threshold)
-                df = df.query(query)
+                df = df[df[p_node_name_val] > parent_threshold]
             elif parent_decision_type == '==':
                 method = METHOD_EXCLUDES
                 arg = create_categorical_arg(parent_threshold)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -148,6 +148,13 @@ def create_binary_classification_dataset(n_samples=100):
     return X_train, y_train, X_test, y_test, classes
 
 
+def replicate_dataset(X, y, replications=16):
+    for _ in range(replications):
+        X = pd.concat([X, X], ignore_index=True)
+        y = np.concatenate([y, y])
+    return X, y
+
+
 def create_simple_titanic_data():
     titanic_url = ('https://raw.githubusercontent.com/amueller/'
                    'scipy-2017-sklearn/091d371/notebooks/'

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -3,14 +3,12 @@
 
 import time
 
-import numpy as np
-import pandas as pd
 from common_utils import (create_binary_classification_dataset,
                           create_boston_data, create_cancer_data,
                           create_iris_data, create_models_classification,
                           create_models_regression, create_simple_titanic_data,
                           create_sklearn_random_forest_regressor,
-                          create_titanic_pipeline)
+                          create_titanic_pipeline, replicate_dataset)
 
 from erroranalysis._internal.constants import ModelTask
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
@@ -78,9 +76,7 @@ class TestImportances(object):
             create_binary_classification_dataset(100)
         feature_names = list(X_train.columns)
         model = create_sklearn_random_forest_regressor(X_train, y_train)
-        for _ in range(16):
-            X_test = pd.concat([X_test, X_test], ignore_index=True)
-            y_test = np.concatenate([y_test, y_test])
+        X_test, y_test = replicate_dataset(X_test, y_test)
         assert X_test.shape[0] > 1000000
         t0 = time.time()
         categorical_features = []


### PR DESCRIPTION
## Description

- Add a performance test for validating training the surrogate error tree on large data (>1 million rows)
- In profiling, about half of the time is actually spent in traversal.  This PR adds a minor optimization for traversing the tree.

Note: I believe another optimization can be done for traversal by reducing the number of columns in the traversed dataset to only the features that the model splits on - or, possibly, even changing the dataset to numpy and doing the queries there, if that is more efficient.

There was another issue I found which was more concerning though.  It seems that we are calling the /tree API three times for some reason on initial load and twice when changing features when running on large data.  I will need to look into UX logic more to see why that is, my suspicion is that it is due to retry logic since the result only comes back after several seconds.

Note the optimization in this PR was very small.  On a 2.5 million row dataset the change in time was:
before:
5.826886177062988
after:
4.795517444610596
To traverse the model.  I still think the minor optimization is worth having though.  Removing not-needed columns will probably reduce this time much more though (hopefully!).


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
