### PR TITLE
Separate out raiwidgets and UI tests into its own workflow

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -12,8 +12,7 @@ jobs:
       node-version: 16.8
     strategy:
       matrix:
-        packageDirectory:
-          ["responsibleai", "rai_core_flask", "erroranalysis"]
+        packageDirectory: ["responsibleai", "rai_core_flask", "erroranalysis"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
         pythonVersion: [3.6, 3.7, 3.8]
         exclude:

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -1,4 +1,4 @@
-name: CI RAIWidgets Python Typescript 
+name: CI RAIWidgets Python Typescript
 
 on:
   push:

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -1,4 +1,4 @@
-name: CI Python
+name: CI RAIWidgets Python Typescript 
 
 on:
   push:
@@ -12,20 +12,9 @@ jobs:
       node-version: 16.8
     strategy:
       matrix:
-        packageDirectory:
-          ["responsibleai", "rai_core_flask", "erroranalysis"]
+        packageDirectory: ["raiwidgets"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
         pythonVersion: [3.6, 3.7, 3.8]
-        exclude:
-          # segfaults in rai_core_flask tests in most OS-Python version combinations
-          - packageDirectory: "rai_core_flask"
-            operatingSystem: ubuntu-latest
-          - packageDirectory: "rai_core_flask"
-            operatingSystem: macos-latest
-            pythonVersion: 3.7
-          - packageDirectory: "rai_core_flask"
-            operatingSystem: macos-latest
-            pythonVersion: 3.8
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -41,6 +30,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ env.node-version }}
+
+      - name: Install yarn
+        run: npm install yarn -g
+
+      - name: Install yarn dependencies
+        run: yarn install --frozen-lock-file
+
+      - name: Build Typescript
+        run: yarn buildall
 
       - if: ${{ matrix.operatingSystem == 'macos-latest' }}
         name: Use Homebrew to install libomp on MacOS for lightgbm
@@ -74,28 +72,10 @@ jobs:
           pip install -v .
         working-directory: ${{ matrix.packageDirectory }}
 
+      - name: Run widget tests
+        run: yarn e2e-widget
+
       - name: Run tests
         run: |
-          pytest --durations=10 --doctest-modules --junitxml=junit/test-results.xml --cov=${{ matrix.packageDirectory }} --cov-report=xml --cov-report=html
+          pytest --durations=10
         working-directory: ${{ matrix.packageDirectory }}
-
-      - name: Upload code coverage results
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.packageDirectory }}-code-coverage-results
-          path: ${{ matrix.packageDirectory }}/htmlcov
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ${{ matrix.packageDirectory }}
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          files: ./${{ matrix.packageDirectory }}/coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
-          verbose: true


### PR DESCRIPTION
## Description

It seems like the responsible-ai-toolbox/CI-python.yml at main · microsoft/responsible-ai-toolbox (github.com) file has a lot of custom code for raiwidgets. Also, because the widget tests uses yarn and run widget tests it is at times flaky. At times when the raiwidgets tests fail, we need to requeue all the other jobs (responsibleai, erroranalysis and rai_core_flask). This makes the PR merge time longer.
 
This PR separates the raiwidgets tests and UI tests into a separate workflow. This way we don't need to maintain custom code in the same yml for raiwidgets and we can isolate the flaky pipeline tests and prevent needless reruns of the stable tests.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
