### PR TITLE
add filtering on index to error analysis backend for RAI dashboard cohort switch

### DIFF
--- a/erroranalysis/erroranalysis/_internal/constants.py
+++ b/erroranalysis/erroranalysis/_internal/constants.py
@@ -4,7 +4,7 @@
 from enum import Enum
 
 PRED_Y = 'pred_y'
-ROW_INDEX = 'row_index'
+ROW_INDEX = 'Index'
 TRUE_Y = 'true_y'
 DIFF = 'diff'
 SPLIT_INDEX = 'split_index'

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '29'
+_patch = '30'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_cohort_filter.py
+++ b/erroranalysis/tests/test_cohort_filter.py
@@ -184,6 +184,27 @@ class TestCohortFilter(object):
                            model_task,
                            filters=filters)
 
+    def test_cohort_filter_index(self):
+        X_train, X_test, y_train, y_test, feature_names = create_iris_pandas()
+        # filter on index, which can be done from the RAI dashboard
+        filters = [{'arg': [40],
+                    'column': ROW_INDEX,
+                    'method': 'less and equal'}]
+        validation_data = create_validation_data(X_test, y_test)
+        validation_data = validation_data.loc[validation_data[ROW_INDEX] <= 40]
+        model_task = ModelTask.CLASSIFICATION
+        model = create_sklearn_svm_classifier(X_train, y_train)
+        categorical_features = []
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer(validation_data,
+                           model,
+                           X_test,
+                           y_test,
+                           feature_names,
+                           categorical_features,
+                           model_task,
+                           filters=filters)
+
 
 def create_iris_pandas():
     X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()


### PR DESCRIPTION
## Description

- fixes issue https://github.com/microsoft/responsible-ai-toolbox/issues/1152
- allows to filter on index - we actually were already adding a 'row_index' column to the dataset prior to filtering, but simply renaming this to 'Index' resolved the issue
- adds a test for filtering on index
- improves the documentation for cohort_filter.py file (note it is currently in _internal anyway, so that wasn't really required, but I think it can help anyone reading the code to understand it)

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
