### PR TITLE
fix ipython dependency

### DIFF
--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -1,5 +1,5 @@
 Flask~=1.0.0
 Flask-Cors==3.0.9
-ipython==7.16.1
+ipython==7.16.3
 greenlet==0.4.17
 gevent==20.9.0

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -3,7 +3,6 @@ pandas>=0.25.1
 scipy>=1.4.1
 rai-core-flask==0.2.4
 jinja2==2.11.3
-ipython==7.16.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.1.29


### PR DESCRIPTION
## Description

fix ipython dependency for dependency bot PRs (https://github.com/microsoft/responsible-ai-toolbox/pull/1162, https://github.com/microsoft/responsible-ai-toolbox/pull/1161).  I updated the dependency in rai-core-flask and removed it in raiwidgets, since it's already installed from rai-core-flask anyway.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [x] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
