### PR TITLE
remove unnecessary multiple calls to tree api

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -681,10 +681,10 @@ export class TreeViewRenderer extends React.PureComponent<
     }
     if (!this.props.getTreeNodes) {
       if (this.props.tree) {
+        this.reloadData(this.props.tree);
         // Use set timeout as reloadData state update needs to be done outside constructor similar to fetch call
         this.onResize();
         this.forceUpdate();
-        this.reloadData(this.props.tree);
       }
       return;
     }
@@ -711,9 +711,9 @@ export class TreeViewRenderer extends React.PureComponent<
         new AbortController().signal
       )
       .then((result) => {
+        this.reloadData(result);
         this.onResize();
         this.forceUpdate();
-        this.reloadData(result);
       });
   }
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -335,7 +335,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
           : 0,
       selectedWhatIfIndex: undefined,
       showMessageBar: false,
-      treeViewState: createInitialTreeViewState(),
+      treeViewState: createInitialTreeViewState(props.errorAnalysisData),
       viewType: ViewTypeKeys.ErrorAnalysisView,
       weightVectorLabels,
       weightVectorOptions,
@@ -454,7 +454,9 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                   matrixFilterState: createInitialMatrixFilterState(),
                   openMapShift: false,
                   selectedCohort: this.state.baseCohort,
-                  treeViewState: createInitialTreeViewState()
+                  treeViewState: createInitialTreeViewState(
+                    this.props.errorAnalysisData
+                  )
                 });
               }}
             />

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/TreeViewState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/TreeViewState.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IErrorAnalysisTreeNode, Metrics } from "@responsible-ai/core-ui";
+import {
+  IErrorAnalysisData,
+  IErrorAnalysisTreeNode,
+  Metrics
+} from "@responsible-ai/core-ui";
 import { Property } from "csstype";
 import { HierarchyPointNode } from "d3-hierarchy";
 
@@ -64,12 +68,14 @@ export interface INodeState {
   style: ITransform | undefined;
 }
 
-export function createInitialTreeViewState(): ITreeViewRendererState {
+export function createInitialTreeViewState(
+  errorAnalysisData: IErrorAnalysisData | undefined
+): ITreeViewRendererState {
   return {
     isErrorMetric: true,
-    maxDepth: 4,
-    metric: Metrics.ErrorRate,
-    minChildSamples: 20,
+    maxDepth: errorAnalysisData?.maxDepth ?? 4,
+    metric: errorAnalysisData?.metric ?? Metrics.ErrorRate,
+    minChildSamples: errorAnalysisData?.minChildSamples ?? 20,
     nodeDetail: {
       errorColor: "#eaeaea",
       maskDown: {
@@ -79,7 +85,7 @@ export function createInitialTreeViewState(): ITreeViewRendererState {
         transform: "translate(0px, 13px)"
       }
     },
-    numLeaves: 31,
+    numLeaves: errorAnalysisData?.numLeaves ?? 31,
     request: undefined,
     root: undefined,
     rootErrorSize: 0,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -128,7 +128,7 @@ export function buildInitialModelAssessmentContext(
         : 0,
     selectedWhatIfIndex: undefined,
     sortVector: undefined,
-    treeViewState: createInitialTreeViewState(),
+    treeViewState: createInitialTreeViewState(props.errorAnalysisData?.[0]),
     weightVectorLabels,
     weightVectorOptions,
     whatIfChartConfig: undefined

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -312,7 +312,9 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                   matrixAreaState: createInitialMatrixAreaState(),
                   matrixFilterState: createInitialMatrixFilterState(),
                   selectedCohort: this.state.baseCohort,
-                  treeViewState: createInitialTreeViewState()
+                  treeViewState: createInitialTreeViewState(
+                    this.props.errorAnalysisData?.[0]
+                  )
                 });
               }}
             />


### PR DESCRIPTION
## Description

This PR removes multiple calls to tree api that are unnecessary, and are particularly noticeable when running error analysis on large data.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment
- [x] responsibleai/error-analysis

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
