### PR TITLE
Update setup.py files to carry python 3.9 classifiers

### DIFF
--- a/erroranalysis/README.md
+++ b/erroranalysis/README.md
@@ -1,6 +1,6 @@
 # Error Analysis SDK for Python
 
-### This package has been tested with Python 3.6, 3.7 and 3.8
+### This package has been tested with Python 3.6, 3.7, 3.8 and 3.9
 
 The error analysis sdk enables users to get a deeper understanding of machine learning model errors. When evaluating a machine learning model, aggregate accuracy is not sufficient and single-score evaluation may hide important conditions of inaccuracies. Use Error Analysis to identify cohorts with higher error rates and diagnose the root causes behind these errors.
 

--- a/erroranalysis/setup.py
+++ b/erroranalysis/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"

--- a/rai_core_flask/setup.py
+++ b/rai_core_flask/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/raiwidgets/setup.py
+++ b/raiwidgets/setup.py
@@ -38,6 +38,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"

--- a/responsibleai/README.md
+++ b/responsibleai/README.md
@@ -1,6 +1,6 @@
 # Responsible AI Model Analysis SDK for Python
 
-### This package has been tested with Python 3.6, 3.7 and 3.8
+### This package has been tested with Python 3.6, 3.7, 3.8 and 3.9
 
 The Responsible AI Model Analysis SDK enables users to analyze their machine learning models in one API. Users will be able to analyze errors, explain the most important features, compute counterfactuals and run causal analysis using a single API.
 

--- a/responsibleai/setup.py
+++ b/responsibleai/setup.py
@@ -46,6 +46,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"


### PR DESCRIPTION
## Description

Update setup.py for responsibleai, rai_core_flask, erroranalysis and raiwidgets to carry python 3.9 classifier

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [x] responsibleai
- [x] erroranalysis
- [x] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
