### PR TITLE
refactor tree view state to be private static in tree view renderer and not in parent

### DIFF
--- a/libs/error-analysis/src/index.ts
+++ b/libs/error-analysis/src/index.ts
@@ -6,7 +6,7 @@ export * from "./lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.styles";
 export * from "./lib/ErrorAnalysisDashboard/ErrorAnalysisEnums";
 export * from "./lib/ErrorAnalysisDashboard/ModelExplanationUtils";
 export * from "./lib/ErrorAnalysisDashboard/MatrixFilterState";
-export * from "./lib/ErrorAnalysisDashboard/TreeViewState";
+export * from "./lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewState";
 export * from "./lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardProps";
 export * from "./lib/ErrorAnalysisDashboard/Interfaces/IFilter";
 export * from "./lib/ErrorAnalysisDashboard/Interfaces/IStringsParam";

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
@@ -17,7 +17,6 @@ import React from "react";
 import { ErrorAnalysisOptions } from "../../ErrorAnalysisEnums";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
 import { IMatrixAreaState, IMatrixFilterState } from "../../MatrixFilterState";
-import { ITreeViewRendererState } from "../../TreeViewState";
 import { MatrixFilter } from "../Matrix/MatrixFilter/MatrixFilter";
 import { TreeViewRenderer } from "../TreeViewRenderer/TreeViewRenderer";
 
@@ -47,8 +46,6 @@ export interface IErrorAnalysisViewProps {
   ) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;
-  treeViewState: ITreeViewRendererState;
-  setTreeViewState: (treeViewState: ITreeViewRendererState) => void;
   matrixFilterState: IMatrixFilterState;
   matrixAreaState: IMatrixAreaState;
   setMatrixAreaState: (matrixAreaState: IMatrixAreaState) => void;
@@ -76,8 +73,6 @@ export class ErrorAnalysisView extends React.Component<IErrorAnalysisViewProps> 
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}
-            state={this.props.treeViewState}
-            setTreeViewState={this.props.setTreeViewState}
             showCohortName={this.props.showCohortName}
             disabledView={this.props.disabledView}
           />
@@ -107,7 +102,6 @@ export class ErrorAnalysisView extends React.Component<IErrorAnalysisViewProps> 
   public componentDidUpdate(prevProps: IErrorAnalysisViewProps): void {
     if (
       this.props.selectedFeatures !== prevProps.selectedFeatures ||
-      this.props.treeViewState !== prevProps.treeViewState ||
       this.props.matrixFilterState !== prevProps.matrixFilterState ||
       this.props.matrixAreaState !== prevProps.matrixAreaState
     ) {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
@@ -118,8 +118,6 @@ export class ErrorAnalysisViewTab extends React.Component<
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}
-            treeViewState={this.props.treeViewState}
-            setTreeViewState={this.props.setTreeViewState}
             matrixFilterState={this.props.matrixFilterState}
             matrixAreaState={this.props.matrixAreaState}
             setMatrixAreaState={this.props.setMatrixAreaState}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
@@ -8,10 +8,10 @@ import React from "react";
 
 import { ColorPalette } from "../../ColorPalette";
 import { MetricUtils, MetricLocalizationType } from "../../MetricUtils";
-import { INodeDetail } from "../../TreeViewState";
 import { Gradient } from "../Gradient/Gradient";
 import { InfoCallout } from "../InfoCallout/InfoCallout";
 import { MetricSelector } from "../MetricSelector/MetricSelector";
+import { INodeDetail } from "../TreeViewRenderer/TreeViewState";
 
 import { treeLegendStyles } from "./TreeLegend.styles";
 

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewNode.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewNode.tsx
@@ -7,13 +7,13 @@ import { getTheme, IProcessedStyleSet } from "office-ui-fabric-react";
 import React from "react";
 
 import { isColorDark } from "../../ColorPalette";
-import { ITreeNode } from "../../TreeViewState";
 import { FilterTooltip } from "../FilterTooltip/FilterTooltip";
 
 import {
   ITreeViewRendererStyles,
   treeViewRendererStyles
 } from "./TreeViewRenderer.styles";
+import { ITreeNode } from "./TreeViewState";
 
 export interface ITreeViewNodeProps {
   disabledView: boolean;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewProps.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewProps.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  ICompositeFilter,
+  IFilter,
+  CohortSource,
+  ErrorCohort,
+  MetricCohortStats,
+  IErrorAnalysisTreeNode
+} from "@responsible-ai/core-ui";
+import { ITheme } from "office-ui-fabric-react";
+
+import { HelpMessageDict } from "../../Interfaces/IStringsParam";
+
+export interface ITreeViewRendererProps {
+  disabledView: boolean;
+  theme?: ITheme;
+  messages?: HelpMessageDict;
+  features: string[];
+  selectedFeatures: string[];
+  getTreeNodes?: (
+    request: any[],
+    abortSignal: AbortSignal
+  ) => Promise<IErrorAnalysisTreeNode[]>;
+  tree?: IErrorAnalysisTreeNode[];
+  updateSelectedCohort: (
+    filters: IFilter[],
+    compositeFilters: ICompositeFilter[],
+    source: CohortSource,
+    cells: number,
+    cohortStats: MetricCohortStats | undefined
+  ) => void;
+  selectedCohort: ErrorCohort;
+  baseCohort: ErrorCohort;
+  showCohortName: boolean;
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import {
-  ICompositeFilter,
   IFilter,
   FilterMethods,
   CohortSource,
@@ -30,7 +29,6 @@ import { linkVertical as d3linkVertical } from "d3-shape";
 import {
   getTheme,
   IProcessedStyleSet,
-  ITheme,
   mergeStyles,
   MessageBar,
   MessageBarType,
@@ -41,50 +39,26 @@ import React from "react";
 
 import { ColorPalette } from "../../ColorPalette";
 import { FilterProps } from "../../FilterProps";
-import { HelpMessageDict } from "../../Interfaces/IStringsParam";
-import {
-  INodeDetail,
-  ITreeNode,
-  ITreeViewRendererState
-} from "../../TreeViewState";
 import { TreeLegend } from "../TreeLegend/TreeLegend";
 
 import { TreeViewNode } from "./TreeViewNode";
+import { ITreeViewRendererProps } from "./TreeViewProps";
 import {
   ITreeViewRendererStyles,
   treeViewRendererStyles
 } from "./TreeViewRenderer.styles";
+import {
+  createInitialTreeViewState,
+  INodeDetail,
+  ITreeNode,
+  ITreeViewRendererState
+} from "./TreeViewState";
 
 // Importing this solely to set the selectedPanelId. This component is NOT a statefulContainer
 // import StatefulContainer from '../../ap/mixins/statefulContainer.js'
 
 const viewerHeight = 300;
 const viewerWidth = 800;
-
-export interface ITreeViewRendererProps {
-  disabledView: boolean;
-  theme?: ITheme;
-  messages?: HelpMessageDict;
-  features: string[];
-  selectedFeatures: string[];
-  getTreeNodes?: (
-    request: any[],
-    abortSignal: AbortSignal
-  ) => Promise<IErrorAnalysisTreeNode[]>;
-  tree?: IErrorAnalysisTreeNode[];
-  updateSelectedCohort: (
-    filters: IFilter[],
-    compositeFilters: ICompositeFilter[],
-    source: CohortSource,
-    cells: number,
-    cohortStats: MetricCohortStats | undefined
-  ) => void;
-  selectedCohort: ErrorCohort;
-  baseCohort: ErrorCohort;
-  state: ITreeViewRendererState;
-  setTreeViewState: (treeViewState: ITreeViewRendererState) => void;
-  showCohortName: boolean;
-}
 
 export interface ISVGDatum {
   width: number;
@@ -102,12 +76,19 @@ export class TreeViewRenderer extends React.PureComponent<
   ITreeViewRendererState
 > {
   public static contextType = ModelAssessmentContext;
+  private static savedState: ITreeViewRendererState | undefined;
   public context: React.ContextType<typeof ModelAssessmentContext> =
     defaultModelAssessmentContext;
   public constructor(props: ITreeViewRendererProps) {
     super(props);
-    // Note: we take state from props in case
-    this.state = this.props.state;
+    if (
+      this.props.selectedCohort !== this.props.baseCohort &&
+      TreeViewRenderer.savedState
+    ) {
+      this.state = TreeViewRenderer.savedState;
+    } else {
+      this.state = createInitialTreeViewState(this.context.errorAnalysisData);
+    }
   }
 
   public componentDidMount(): void {
@@ -124,12 +105,12 @@ export class TreeViewRenderer extends React.PureComponent<
     if (
       this.props.selectedFeatures !== prevProps.selectedFeatures ||
       this.props.baseCohort !== prevProps.baseCohort ||
-      this.props.state !== prevProps.state ||
-      this.context.errorAnalysisData!.maxDepth !== this.state.maxDepth ||
-      this.context.errorAnalysisData!.numLeaves !== this.state.numLeaves ||
-      this.context.errorAnalysisData!.minChildSamples !==
-        this.state.minChildSamples ||
-      this.context.errorAnalysisData!.metric !== this.state.metric
+      (this.context.errorAnalysisData &&
+        (this.context.errorAnalysisData.maxDepth !== this.state.maxDepth ||
+          this.context.errorAnalysisData.numLeaves !== this.state.numLeaves ||
+          this.context.errorAnalysisData.minChildSamples !==
+            this.state.minChildSamples ||
+          this.context.errorAnalysisData.metric !== this.state.metric))
     ) {
       this.fetchTreeNodes();
     }
@@ -137,7 +118,7 @@ export class TreeViewRenderer extends React.PureComponent<
 
   public componentWillUnmount(): void {
     window.removeEventListener("resize", this.onResize);
-    this.props.setTreeViewState(this.state);
+    TreeViewRenderer.savedState = this.state;
   }
 
   public render(): React.ReactNode {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewState.ts
@@ -9,7 +9,7 @@ import {
 import { Property } from "csstype";
 import { HierarchyPointNode } from "d3-hierarchy";
 
-import { FilterProps } from "./FilterProps";
+import { FilterProps } from "../../FilterProps";
 
 export interface IErrorColorStyle {
   fill: string | undefined;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -73,10 +73,6 @@ import {
   IMatrixAreaState,
   IMatrixFilterState
 } from "./MatrixFilterState";
-import {
-  ITreeViewRendererState,
-  createInitialTreeViewState
-} from "./TreeViewState";
 
 export class ErrorAnalysisDashboard extends React.PureComponent<
   IErrorAnalysisDashboardProps,
@@ -335,7 +331,6 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
           : 0,
       selectedWhatIfIndex: undefined,
       showMessageBar: false,
-      treeViewState: createInitialTreeViewState(props.errorAnalysisData),
       viewType: ViewTypeKeys.ErrorAnalysisView,
       weightVectorLabels,
       weightVectorOptions,
@@ -453,10 +448,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                   matrixAreaState: createInitialMatrixAreaState(),
                   matrixFilterState: createInitialMatrixFilterState(),
                   openMapShift: false,
-                  selectedCohort: this.state.baseCohort,
-                  treeViewState: createInitialTreeViewState(
-                    this.props.errorAnalysisData
-                  )
+                  selectedCohort: this.state.baseCohort
                 });
               }}
             />
@@ -541,8 +533,6 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                         ? this.props.errorAnalysisData.tree
                         : undefined
                     }
-                    treeViewState={this.state.treeViewState}
-                    setTreeViewState={this.setTreeViewState}
                     matrixAreaState={this.state.matrixAreaState}
                     matrixFilterState={this.state.matrixFilterState}
                     setMatrixAreaState={this.setMatrixAreaState}
@@ -682,11 +672,6 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       </ModelAssessmentContext.Provider>
     );
   }
-  private setTreeViewState = (treeViewState: ITreeViewRendererState): void => {
-    if (this.state.selectedCohort !== this.state.baseCohort) {
-      this.setState({ treeViewState });
-    }
-  };
   private setMatrixAreaState = (matrixAreaState: IMatrixAreaState): void => {
     if (this.state.selectedCohort !== this.state.baseCohort) {
       this.setState({ matrixAreaState });

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
@@ -17,7 +17,6 @@ import {
   PredictionTabKeys
 } from "../ErrorAnalysisEnums";
 import { IMatrixAreaState, IMatrixFilterState } from "../MatrixFilterState";
-import { ITreeViewRendererState } from "../TreeViewState";
 
 export interface IErrorAnalysisDashboardState
   extends ICohortBasedComponentState {
@@ -49,7 +48,6 @@ export interface IErrorAnalysisDashboardState
   editedCohort: ErrorCohort;
   selectedFeatures: string[];
   showMessageBar: boolean;
-  treeViewState: ITreeViewRendererState;
   matrixAreaState: IMatrixAreaState;
   matrixFilterState: IMatrixFilterState;
   errorAnalysisOption: ErrorAnalysisOptions;

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -17,12 +17,10 @@ import { DatasetExplorerTab } from "@responsible-ai/dataset-explorer";
 import {
   createInitialMatrixAreaState,
   createInitialMatrixFilterState,
-  createInitialTreeViewState,
   ErrorAnalysisOptions,
   ErrorAnalysisViewTab,
   IMatrixAreaState,
   IMatrixFilterState,
-  ITreeViewRendererState,
   MapShift
 } from "@responsible-ai/error-analysis";
 import { localization } from "@responsible-ai/localization";
@@ -168,17 +166,6 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                           errorAnalysisOption={this.state.errorAnalysisOption}
                           selectedCohort={this.state.selectedCohort}
                           baseCohort={this.state.baseCohort}
-                          treeViewState={this.state.treeViewState}
-                          setTreeViewState={(
-                            treeViewState: ITreeViewRendererState
-                          ): void => {
-                            if (
-                              this.state.selectedCohort !==
-                              this.state.baseCohort
-                            ) {
-                              this.setState({ treeViewState });
-                            }
-                          }}
                           matrixAreaState={this.state.matrixAreaState}
                           matrixFilterState={this.state.matrixFilterState}
                           setMatrixAreaState={(
@@ -311,10 +298,7 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                   mapShiftVisible: false,
                   matrixAreaState: createInitialMatrixAreaState(),
                   matrixFilterState: createInitialMatrixFilterState(),
-                  selectedCohort: this.state.baseCohort,
-                  treeViewState: createInitialTreeViewState(
-                    this.props.errorAnalysisData?.[0]
-                  )
+                  selectedCohort: this.state.baseCohort
                 });
               }}
             />


### PR DESCRIPTION
## Description

This PR is a refactor of the TreeViewRendered, there is no new functionality.
The PR moves the state to be within TreeViewRendered as a private static property, and hence the parent error analysis and model analysis dashboards don't need to keep track of it.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment
- [x] responsibleai/error-analysis

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
