### PR TITLE
replace boston housing dataset with california housing dataset in tests and example notebook

### DIFF
--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -9,8 +9,8 @@ from lightgbm import LGBMClassifier
 from pandas import read_csv
 from sklearn import svm
 from sklearn.compose import ColumnTransformer
-from sklearn.datasets import (load_boston, load_breast_cancer, load_iris,
-                              load_wine, make_classification)
+from sklearn.datasets import (fetch_california_housing, load_breast_cancer,
+                              load_iris, load_wine, make_classification)
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
@@ -174,14 +174,15 @@ def create_simple_titanic_data():
     return X_train, X_test, y_train, y_test, num_features, cat_features
 
 
-def create_boston_data(test_size=0.2):
-    # Import Boston housing dataset
-    boston = load_boston()
+def create_housing_data(test_size=0.2):
+    # Import California housing dataset
+    housing = fetch_california_housing()
     # Split data into train and test
-    X_train, X_test, y_train, y_test = train_test_split(
-        boston.data, boston.target,
-        test_size=test_size, random_state=7)
-    return X_train, X_test, y_train, y_test, boston.feature_names
+    x_train, x_test, y_train, y_test = train_test_split(housing.data,
+                                                        housing.target,
+                                                        test_size=test_size,
+                                                        random_state=7)
+    return x_train, x_test, y_train, y_test, housing.feature_names
 
 
 def create_models_classification(X_train, y_train):

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -6,8 +6,8 @@ import uuid
 import numpy as np
 import pandas as pd
 import pytest
-from common_utils import (create_boston_data, create_cancer_data,
-                          create_dataframe, create_iris_data,
+from common_utils import (create_cancer_data, create_dataframe,
+                          create_housing_data, create_iris_data,
                           create_models_classification,
                           create_models_regression)
 
@@ -41,9 +41,9 @@ class TestErrorReport(object):
             run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
-    def test_error_report_boston(self):
+    def test_error_report_housing(self):
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data()
+            create_housing_data()
         models = create_models_regression(X_train, y_train)
 
         for model in models:
@@ -51,9 +51,9 @@ class TestErrorReport(object):
             run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
-    def test_error_report_boston_pandas(self):
+    def test_error_report_housing_pandas(self):
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data()
+            create_housing_data()
         X_train = create_dataframe(X_train, feature_names)
         X_test = create_dataframe(X_test, feature_names)
         models = create_models_regression(X_train, y_train)

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -4,7 +4,7 @@
 import time
 
 from common_utils import (create_binary_classification_dataset,
-                          create_boston_data, create_cancer_data,
+                          create_cancer_data, create_housing_data,
                           create_iris_data, create_models_classification,
                           create_models_regression, create_simple_titanic_data,
                           create_sklearn_random_forest_regressor,
@@ -59,9 +59,9 @@ class TestImportances(object):
         run_error_analyzer(clf, X_test, y_test, feature_names,
                            categorical_features)
 
-    def test_importances_boston(self):
+    def test_importances_housing(self):
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data()
+            create_housing_data()
         models = create_models_regression(X_train, y_train)
 
         for model in models:

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from common_utils import (create_adult_census_data,
                           create_binary_classification_dataset,
-                          create_boston_data, create_cancer_data,
+                          create_cancer_data, create_housing_data,
                           create_iris_data, create_kneighbors_classifier,
                           create_models_classification,
                           create_models_regression, create_simple_titanic_data,
@@ -246,8 +246,8 @@ class TestMatrixFilter(object):
                            categorical_features,
                            model_task=ModelTask.CLASSIFICATION)
 
-    def test_matrix_filter_boston(self):
-        X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+    def test_matrix_filter_housing(self):
+        X_train, X_test, y_train, y_test, feature_names = create_housing_data()
 
         metrics = [Metrics.MEAN_SQUARED_ERROR,
                    Metrics.MEAN_ABSOLUTE_ERROR]
@@ -270,14 +270,14 @@ class TestMatrixFilter(object):
                                          matrix_features=[feature_names[3]],
                                          metric=metric)
 
-    def test_matrix_filter_boston_filters(self):
-        X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+    def test_matrix_filter_housing_filters(self):
+        X_train, X_test, y_train, y_test, feature_names = create_housing_data()
 
-        filters = [{'arg': [0.675],
-                    'column': 'NOX',
+        filters = [{'arg': [600],
+                    'column': 'Population',
                     'method': 'less and equal'},
-                   {'arg': [7.141000000000001],
-                    'column': 'RM',
+                   {'arg': [6],
+                    'column': 'AveRooms',
                     'method': 'greater'}]
 
         model_task = ModelTask.REGRESSION
@@ -285,14 +285,14 @@ class TestMatrixFilter(object):
                                      y_test, feature_names,
                                      model_task, filters=filters)
 
-    def test_matrix_filter_boston_quantile_binning(self):
-        # Test quantile binning on CRIM feature in boston dataset,
+    def test_matrix_filter_housing_quantile_binning(self):
+        # Test quantile binning on CRIM feature in california housing dataset,
         # which errored out due to first category not fitting into bins
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data(test_size=0.5)
+            create_housing_data(test_size=0.5)
 
         model_task = ModelTask.REGRESSION
-        matrix_features = ['CRIM']
+        matrix_features = ['Population']
         run_error_analyzer_on_models(X_train, y_train, X_test,
                                      y_test, feature_names, model_task,
                                      matrix_features=matrix_features,

--- a/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-housing.ipynb
+++ b/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-housing.ipynb
@@ -7,7 +7,7 @@
     "\n",
     "# Analyze Errors and Explore Interpretability of Models\n",
     "\n",
-    "This notebook demonstrates how to use the Responsible AI Widget's Error Analysis dashboard to understand a model trained on the regression boston housing dataset. The goal of this sample notebook is to predict housing prices with scikit-learn and explore model errors and explanations:\n",
+    "This notebook demonstrates how to use the Responsible AI Widget's Error Analysis dashboard to understand a model trained on the regression california housing dataset. The goal of this sample notebook is to predict housing prices with scikit-learn and explore model errors and explanations:\n",
     "\n",
     "1. Train an SVM classification model using Scikit-learn\n",
     "2. Run Interpret-Community's 'explain_model' globally and locally to generate model explanations.\n",
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.datasets import load_boston\n",
+    "from sklearn.datasets import fetch_california_housing\n",
     "from sklearn import svm\n",
     "\n",
     "# Imports for SHAP MimicExplainer with LightGBM surrogate model\n",
@@ -65,10 +65,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "boston = load_boston()\n",
-    "X = boston['data']\n",
-    "y = boston['target']\n",
-    "feature_names = boston['feature_names']"
+    "housing = fetch_california_housing()\n",
+    "X = housing['data']\n",
+    "y = housing['target']\n",
+    "feature_names = housing['feature_names']"
    ]
   },
   {

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -195,9 +195,9 @@ def test_erroranalysis_dashboard_superconductor():
 
 
 @pytest.mark.notebooks
-def test_erroranalysis_dashboard_boston_housing():
+def test_erroranalysis_dashboard_housing():
     nb_path = ERROR_ANALYSIS_DASHBOARD
-    nb_name = "erroranalysis-dashboard-regression-boston-housing"
+    nb_name = "erroranalysis-dashboard-regression-housing"
 
     test_values = {}
     assay_one_notebook(nb_path, nb_name, test_values)

--- a/responsibleai/tests/causal/conftest.py
+++ b/responsibleai/tests/causal/conftest.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..common_utils import create_adult_income_dataset, create_boston_data
+from ..common_utils import create_adult_income_dataset, create_housing_data
 
 
 @pytest.fixture(scope='session')
@@ -22,9 +22,9 @@ def adult_data():
 
 
 @pytest.fixture(scope='session')
-def boston_data() -> Tuple[pd.DataFrame, pd.DataFrame, str]:
+def housing_data() -> Tuple[pd.DataFrame, pd.DataFrame, str]:
     target_feature = 'TARGET'
-    X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+    X_train, X_test, y_train, y_test, feature_names = create_housing_data()
     train_df = pd.DataFrame(X_train, columns=feature_names)
     train_df[target_feature] = y_train
     test_df = pd.DataFrame(X_test, columns=feature_names)
@@ -48,21 +48,22 @@ def _discretize_feature(
 
 
 @pytest.fixture(scope='session')
-def boston_data_categorical(boston_data):
-    train_df, test_df, target_feature = boston_data
+def housing_data_categorical(housing_data):
+    train_df, test_df, target_feature = housing_data
     train_df = copy.deepcopy(train_df)
     test_df = copy.deepcopy(test_df)
 
     for df in [train_df, test_df]:
-        cat_map = [(0, 'newest'), (40, 'newer'), (65, 'older'), (90, 'oldest')]
-        df['AGE_CAT'] = _discretize_feature(df['AGE'], cat_map)
-        cat_map = [(0, 'small'), (5, 'large')]
-        df['RM_CAT'] = _discretize_feature(df['RM'], cat_map)
-        cat_map = [(0, 'residential'), (10, 'mixed'), (18, 'commercial')]
-        df['INDUS_CAT'] = _discretize_feature(df['INDUS'], cat_map)
-        cat_map = [(0, 'no crime'), (5, 'low crime'),
-                   (10, 'medium crime'), (20, 'high crime')]
-        df['CRIM_CAT'] = _discretize_feature(df['CRIM'], cat_map)
+        cat_map = [(0, 'newest'), (15, 'new'), (25, 'mid'),
+                   (35, 'old'), (45, 'very-old')]
+        df['HouseAge_CAT'] = _discretize_feature(df['HouseAge'], cat_map)
+        cat_map = [(0, 'small'), (4, 'large')]
+        df['AveRooms_CAT'] = _discretize_feature(df['AveRooms'], cat_map)
+        cat_map = [(0, 'low'), (300, 'mid-low'), (500, 'mid'), (1000, 'high'),
+                   (1000, 'very-high'), (10000, 'highest')]
+        df['Population_CAT'] = _discretize_feature(df['Population'], cat_map)
+        cat_map = [(0, 'low'), (2, 'high')]
+        df['AveOccup_CAT'] = _discretize_feature(df['AveOccup'], cat_map)
 
     return train_df, test_df, target_feature
 

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -8,8 +8,8 @@ from dice_ml.utils import helpers
 from lightgbm import LGBMClassifier
 from sklearn import svm
 from sklearn.compose import ColumnTransformer
-from sklearn.datasets import (load_boston, load_breast_cancer, load_iris,
-                              make_classification)
+from sklearn.datasets import (fetch_california_housing, load_breast_cancer,
+                              load_iris, make_classification)
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
@@ -114,14 +114,15 @@ def create_binary_classification_dataset():
     return X_train, y_train, X_test, y_test, classes
 
 
-def create_boston_data():
-    # Import Boston housing dataset
-    boston = load_boston()
+def create_housing_data():
+    # Import California housing dataset
+    housing = fetch_california_housing()
     # Split data into train and test
-    X_train, X_test, y_train, y_validation = train_test_split(
-        boston.data, boston.target,
-        test_size=0.2, random_state=7)
-    return X_train, X_test, y_train, y_validation, boston.feature_names
+    x_train, x_test, y_train, y_test = train_test_split(housing.data,
+                                                        housing.target,
+                                                        test_size=0.2,
+                                                        random_state=7)
+    return x_train, x_test, y_train, y_test, housing.feature_names
 
 
 def create_adult_income_dataset():

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -20,9 +20,10 @@ from responsibleai._tools.shared.state_directory_management import \
 from .causal_manager_validator import validate_causal
 from .common_utils import (create_adult_income_dataset,
                            create_binary_classification_dataset,
-                           create_boston_data, create_cancer_data,
+                           create_cancer_data,
                            create_complex_classification_pipeline,
-                           create_iris_data, create_models_classification,
+                           create_housing_data, create_iris_data,
+                           create_models_classification,
                            create_models_regression)
 from .counterfactual_manager_validator import validate_counterfactual
 from .error_analysis_validator import (setup_error_analysis,
@@ -149,9 +150,9 @@ class TestModelAnalysis(object):
     @pytest.mark.parametrize('manager_type', [ManagerNames.CAUSAL,
                                               ManagerNames.COUNTERFACTUAL,
                                               ManagerNames.EXPLAINER])
-    def test_modelanalysis_boston(self, manager_type):
+    def test_modelanalysis_housing(self, manager_type):
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data()
+            create_housing_data()
         X_train = pd.DataFrame(X_train, columns=feature_names)
         X_test = pd.DataFrame(X_test, columns=feature_names)
         models = create_models_regression(X_train, y_train)
@@ -159,14 +160,14 @@ class TestModelAnalysis(object):
         X_test[LABELS] = y_test
 
         manager_args = {
-            ManagerParams.DESIRED_RANGE: [10, 20],
-            ManagerParams.TREATMENT_FEATURES: ['CHAS'],
+            ManagerParams.DESIRED_RANGE: [5, 10],
+            ManagerParams.TREATMENT_FEATURES: ['AveRooms'],
             ManagerParams.MAX_CAT_EXPANSION: 12,
             ManagerParams.FEATURE_IMPORTANCE: True
         }
 
         for model in models:
-            run_model_analysis(model, X_train, X_test, LABELS, ['CHAS'],
+            run_model_analysis(model, X_train, X_test, LABELS, [],
                                manager_type, manager_args)
 
 

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -19,9 +19,10 @@ from responsibleai._tools.shared.state_directory_management import \
 from .causal_manager_validator import validate_causal
 from .common_utils import (create_adult_income_dataset,
                            create_binary_classification_dataset,
-                           create_boston_data, create_cancer_data,
+                           create_cancer_data,
                            create_complex_classification_pipeline,
-                           create_iris_data, create_models_classification,
+                           create_housing_data, create_iris_data,
+                           create_models_classification,
                            create_models_regression)
 from .counterfactual_manager_validator import validate_counterfactual
 from .error_analysis_validator import (setup_error_analysis,
@@ -148,9 +149,9 @@ class TestRAIInsights(object):
     @pytest.mark.parametrize('manager_type', [ManagerNames.CAUSAL,
                                               ManagerNames.COUNTERFACTUAL,
                                               ManagerNames.EXPLAINER])
-    def test_rai_insights_boston(self, manager_type):
+    def test_rai_insights_housing(self, manager_type):
         X_train, X_test, y_train, y_test, feature_names = \
-            create_boston_data()
+            create_housing_data()
         X_train = pd.DataFrame(X_train, columns=feature_names)
         X_test = pd.DataFrame(X_test, columns=feature_names)
         models = create_models_regression(X_train, y_train)
@@ -158,14 +159,14 @@ class TestRAIInsights(object):
         X_test[LABELS] = y_test
 
         manager_args = {
-            ManagerParams.DESIRED_RANGE: [10, 20],
-            ManagerParams.TREATMENT_FEATURES: ['CHAS'],
+            ManagerParams.DESIRED_RANGE: [5, 10],
+            ManagerParams.TREATMENT_FEATURES: ['AveRooms'],
             ManagerParams.MAX_CAT_EXPANSION: 12,
             ManagerParams.FEATURE_IMPORTANCE: True
         }
 
         for model in models:
-            run_rai_insights(model, X_train, X_test, LABELS, ['CHAS'],
+            run_rai_insights(model, X_train, X_test, LABELS, [],
                              manager_type, manager_args)
 
 


### PR DESCRIPTION

## Description

This PR replaces the boston housing dataset with california housing dataset in tests and the error analysis example notebook.
The PR resolves issue:
https://github.com/microsoft/responsible-ai-toolbox/issues/1177

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
