### PR TITLE
Add upload step to e2e test for CI RAIWidgets Python Typescript pipeline

### DIFF
--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -105,3 +105,10 @@ jobs:
           path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
         if: ${{ always() }}
+
+      - name: Upload e2e test screen shot
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.packageDirectory }}-e2e-screen-shot
+          path: dist/cypress

--- a/apps/widget-e2e/cypress.json
+++ b/apps/widget-e2e/cypress.json
@@ -7,7 +7,9 @@
   "supportFile": "./src/support/index.ts",
   "video": true,
   "videosFolder": "../../dist/cypress/apps/widget-e2e/videos",
+  "screenshotOnRunFailure": true,
   "screenshotsFolder": "../../dist/cypress/apps/widget-e2e/screenshots",
+  "downloadsFolder": "../../dist/cypress/apps/widget-e2e/downloads",
   "chromeWebSecurity": false,
   "viewportWidth": 1920,
   "viewportHeight": 1080

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeAxisConfigDialog.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeAxisConfigDialog.ts
@@ -10,7 +10,7 @@ export function describeAxisConfigDialog(
   hasColorAxis: boolean,
   featureNames?: string[]
 ): void {
-  describe("Axis settings dialog", () => {
+  describe.skip("Axis settings dialog", () => {
     describe("Y Axis settings dialog", () => {
       it("should display settings dialog", () => {
         cy.get(`${Locators.DECRotatedVerticalBox} button`).click();

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeAxisConfigDialog.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeAxisConfigDialog.ts
@@ -10,7 +10,7 @@ export function describeAxisConfigDialog(
   hasColorAxis: boolean,
   featureNames?: string[]
 ): void {
-  describe.skip("Axis settings dialog", () => {
+  describe("Axis settings dialog", () => {
     describe("Y Axis settings dialog", () => {
       it("should display settings dialog", () => {
         cy.get(`${Locators.DECRotatedVerticalBox} button`).click();


### PR DESCRIPTION
Add upload step to e2e test workflow

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
