### PR TITLE
fix broken builds due to pip upgrade which broke pip-tools

### DIFF
--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup tools
         shell: bash -l {0}
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip~=21.3
           pip install --upgrade setuptools
           pip install --upgrade pip-tools
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip~=21.3
           pip install --upgrade setuptools
           pip install --upgrade pip-tools
 

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip~=21.3
           pip install --upgrade setuptools
           pip install --upgrade pip-tools
 


### PR DESCRIPTION
## Description

Fix broken builds due to pip upgrade which broke pip-tools by pinning to older version of pip for now
See issue:
https://github.com/jazzband/pip-tools/issues/1558
and fix currently as an open PR:
https://github.com/jazzband/pip-tools/pull/1559

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
