### PR TITLE
Remove mac from rai widgets step

### DIFF
--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -76,8 +76,8 @@ jobs:
           pip install -v .
         working-directory: ${{ matrix.packageDirectory }}
 
-      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
       - name: Run widget tests
+        if: ${{ matrix.operatingSystem != 'macos-latest' }}
         run: yarn e2e-widget
 
       - name: Run tests

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -76,6 +76,7 @@ jobs:
           pip install -v .
         working-directory: ${{ matrix.packageDirectory }}
 
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
       - name: Run widget tests
         with:
           exclude: macos-latest

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -78,8 +78,6 @@ jobs:
 
       - if: ${{ matrix.operatingSystem != 'macos-latest' }}
       - name: Run widget tests
-        with:
-          exclude: macos-latest
         run: yarn e2e-widget
 
       - name: Run tests

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -77,6 +77,8 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Run widget tests
+        with:
+          exclude: macos-latest
         run: yarn e2e-widget
 
       - name: Run tests


### PR DESCRIPTION
Remove mac from rai widgets step

## Description

All failures in [RAIwidgets pipeline](https://github.com/microsoft/responsible-ai-toolbox/actions/workflows/Ci-raiwigets-python-typescript.yml) were specific to macos
Cypress has limitation on mac
https://stackoverflow.com/questions/60909946/is-cypress-support-cross-browser-testing-like-selenium-or-are-there-any-limitati
I have created an work item to enable or to find a workaround to tests for macos.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
