### PR TITLE
update dnn notebook example to give more interesting results

### DIFF
--- a/notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb
@@ -169,7 +169,7 @@
    "outputs": [],
    "source": [
     "# Train the model\n",
-    "epochs = 12\n",
+    "epochs = 10000\n",
     "criterion = nn.CrossEntropyLoss()\n",
     "optimizer = torch.optim.SGD(net.parameters(), lr=0.01)\n",
     "\n",


### PR DESCRIPTION
## Description

The notebook "notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb" had a DNN pytorch model that was only trained for 12 epochs, which ended up giving the same result during inference.
This PR updates the dnn notebook example to train the model for 10000 epochs, to give more interesting results.
Although it takes 13 seconds to train the model, instead of making training instantaneous, the model outputs several possible classes instead of just one class.


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

Model overview after increasing the number of iterations in the sample notebook:
![image](https://user-images.githubusercontent.com/24683184/152034675-ce8e93ba-b35f-4715-9dfc-24ccc4a917f1.png)

Previously it would just be:
![image](https://user-images.githubusercontent.com/24683184/152034861-c1fda7a2-cfb0-4e46-a568-0306f2ce6518.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
