### PR TITLE
allow ExplanationDashboard to show limited view for more than 1k features instead of erroring

### DIFF
--- a/raiwidgets/raiwidgets/explanation_dashboard_input.py
+++ b/raiwidgets/raiwidgets/explanation_dashboard_input.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -124,14 +126,17 @@ class ExplanationDashboardInput:
                     "Exceeds maximum number of rows"
                     "for visualization (100000)")
             if feature_length > 1000:
-                raise ValueError("Exceeds maximum number of features for"
-                                 " visualization (1000). Please regenerate the"
-                                 " explanation using fewer features or"
-                                 " initialize the dashboard without passing a"
-                                 " dataset.")
-            self.dashboard_input[
-                ExplanationDashboardInterface.TRAINING_DATA
-            ] = serialize_json_safe(list_dataset)
+                warnings.warn("Exceeds maximum number of features for"
+                              " visualization (1000)."
+                              " Please regenerate the"
+                              " explanation using fewer features or"
+                              " initialize the dashboard without"
+                              " passing a dataset. Dashboard will"
+                              " show limited view.")
+            else:
+                self.dashboard_input[
+                    ExplanationDashboardInterface.TRAINING_DATA
+                ] = serialize_json_safe(list_dataset)
             self.dashboard_input[
                 ExplanationDashboardInterface.IS_CLASSIFIER
             ] = self._is_classifier
@@ -147,10 +152,6 @@ class ExplanationDashboardInput:
             try:
                 local_explanation["scores"] = _convert_to_list(
                     local_explanation["scores"], EXP_VIZ_ERR_MSG)
-                if np.shape(local_explanation["scores"])[-1] > 1000:
-                    raise ValueError("Exceeds maximum number of features for "
-                                     "visualization (1000). Please regenerate"
-                                     " the explanation using fewer features.")
                 local_explanation["intercept"] = _convert_to_list(
                     local_explanation["intercept"], EXP_VIZ_ERR_MSG)
                 # We can ignore perf explanation data.

--- a/raiwidgets/tests/test_explanation_dashboard.py
+++ b/raiwidgets/tests/test_explanation_dashboard.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import numpy as np
+import pandas as pd
+import sklearn
+from interpret.ext.blackbox import MimicExplainer
+from interpret.ext.glassbox import LGBMExplainableModel
+from interpret_community.common.constants import ModelTask
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+
+from raiwidgets import ExplanationDashboard
+
+
+class TestExplanationDashboardDashboard:
+    def test_explanation_dashboard_many_columns(self):
+        X, y = make_classification(n_features=2000)
+
+        # Split data into train and test
+        X_train, X_test, y_train, y_test = train_test_split(X,
+                                                            y,
+                                                            test_size=0.2,
+                                                            random_state=0)
+        classes = np.unique(y_train).tolist()
+        feature_names = ["col" + str(i) for i in list(range(X_train.shape[1]))]
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        knn = sklearn.neighbors.KNeighborsClassifier()
+        knn.fit(X_train, y_train)
+
+        model_task = ModelTask.Classification
+        explainer = MimicExplainer(knn,
+                                   X_train,
+                                   LGBMExplainableModel,
+                                   model_task=model_task)
+        global_explanation = explainer.explain_global(X_test)
+
+        ExplanationDashboard(explanation=global_explanation, model=knn,
+                             dataset=X_test, true_y=y_test, classes=classes)


### PR DESCRIPTION
## Description

A user wanted to run ExplanationDashboard on more >1k features, but it errors out, although it shows a more limited view in AML Studio.
This PR allows ExplanationDashboard to show a limited view for more than 1k features instead of erroring out.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
