### PR TITLE
add more docs for error analysis surrogate tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Model Debugging Examples:
 
 ## Supported Models
 
-This Responsible AI Toolbox API supports models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
+This Responsible AI Toolbox API supports models that are trained on datasets in Python `numpy.ndarray`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
 
 The explanation functions of [Interpret-Community](https://github.com/interpretml/interpret-community) accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the Scikit convention. If not compatible, you can wrap your model's prediction function into a wrapper function that transforms the output into the format that is supported (predict or predict_proba of Scikit), and pass that wrapper function to your selected interpretability techniques.
 

--- a/docs/erroranalysis-dashboard-README.md
+++ b/docs/erroranalysis-dashboard-README.md
@@ -79,7 +79,7 @@ After identifying cohorts with higher error rates, Error Analysis enables debugg
 
 ## Supported Models
 
-This interpretability and error analysis API supports regression and classification models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
+This interpretability and error analysis API supports regression and classification models that are trained on datasets in Python `numpy.ndarray`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
 
 The explanation functions of [Interpret-Community](https://github.com/interpretml/interpret-community) accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the Scikit convention. If not compatible, you can wrap your model's prediction function into a wrapper function that transforms the output into the format that is supported (predict or predict_proba of Scikit), and pass that wrapper function to your selected interpretability techniques.
 

--- a/docs/explanation-dashboard-README.md
+++ b/docs/explanation-dashboard-README.md
@@ -97,7 +97,7 @@ You can click on any individual data point on the scatter plot to view its local
 
 ## Supported Models
 
-This interpretability and error analysis API supports regression and classification models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
+This interpretability and error analysis API supports regression and classification models that are trained on datasets in Python `numpy.ndarray`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
 
 The explanation functions of [Interpret-Community](https://github.com/interpretml/interpret-community) accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the Scikit convention. If not compatible, you can wrap your model's prediction function into a wrapper function that transforms the output into the format that is supported (predict or predict_proba of Scikit), and pass that wrapper function to your selected interpretability techniques.
 

--- a/docs/fairness-dashboard-README.md
+++ b/docs/fairness-dashboard-README.md
@@ -70,7 +70,7 @@ As before, select the sensitive feature and the performance metric. The model co
 
 ## Supported Models
 
-This fairness API supports classification and regression models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
+This fairness API supports classification and regression models that are trained on datasets in Python `numpy.ndarray`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
 
 <a name="getting started"></a>
 

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -49,8 +49,31 @@ def compute_json_error_tree(analyzer,
                             max_depth=DEFAULT_MAX_DEPTH,
                             num_leaves=DEFAULT_NUM_LEAVES,
                             min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
-    # Note: this is for backcompat for older versions
-    # of raiwidgets pypi package
+    """Computes the error tree for the given dataset.
+
+    Note: this is for backcompat for older versions
+    of raiwidgets pypi package
+
+    :param analyzer: The error analyzer containing the categorical
+        features and categories for the full dataset.
+    :type analyzer: BaseAnalyzer
+    :param features: The features to train the surrogate model on.
+    :type features: numpy.ndarray or pandas.DataFrame
+    :param filters: The filters to apply to the dataset.
+    :type filters: numpy.ndarray or pandas.DataFrame
+    :param composite_filters: The composite filters to apply to the dataset.
+    :type composite_filters: numpy.ndarray or pandas.DataFrame
+    :param max_depth: The maximum depth of the surrogate tree trained
+        on errors.
+    :type max_depth: int
+    :param num_leaves: The number of leaves of the surrogate tree
+        trained on errors.
+    :type num_leaves: int
+    :param min_child_samples: The minimal number of data required to
+        create one leaf.
+    :return: The tree representation as a list of nodes.
+    :rtype: list[dict[str, str]]
+    """
     return compute_error_tree(analyzer,
                               features,
                               filters,
@@ -67,6 +90,28 @@ def compute_error_tree(analyzer,
                        max_depth=DEFAULT_MAX_DEPTH,
                        num_leaves=DEFAULT_NUM_LEAVES,
                        min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
+    """Computes the error tree for the given dataset.
+
+    :param analyzer: The error analyzer containing the categorical
+        features and categories for the full dataset.
+    :type analyzer: BaseAnalyzer
+    :param features: The features to train the surrogate model on.
+    :type features: numpy.ndarray or pandas.DataFrame
+    :param filters: The filters to apply to the dataset.
+    :type filters: numpy.ndarray or pandas.DataFrame
+    :param composite_filters: The composite filters to apply to the dataset.
+    :type composite_filters: numpy.ndarray or pandas.DataFrame
+    :param max_depth: The maximum depth of the surrogate tree trained
+        on errors.
+    :type max_depth: int
+    :param num_leaves: The number of leaves of the surrogate tree
+        trained on errors.
+    :type num_leaves: int
+    :param min_child_samples: The minimal number of data required to
+        create one leaf.
+    :return: The tree representation as a list of nodes.
+    :rtype: list[dict[str, str]]
+    """
     # Fit a surrogate model on errors
     if max_depth is None:
         max_depth = DEFAULT_MAX_DEPTH
@@ -162,9 +207,9 @@ def create_surrogate_model(analyzer,
     :type analyzer: BaseAnalyzer
     :param dataset_sub_features: The subset of features to train the
         surrogate model on.
-    :type dataset_sub_features: numpy.array or pandas.DataFrame
+    :type dataset_sub_features: numpy.ndarray or pandas.DataFrame
     :param diff: The difference between the true and predicted labels column.
-    :type diff: numpy.array
+    :type diff: numpy.ndarray
     :param max_depth: The maximum depth of the surrogate tree trained
         on errors.
     :type max_depth: int
@@ -224,6 +269,11 @@ def get_categorical_info(analyzer, dataset_sub_names):
 
 
 def get_max_split_index(tree):
+    """Gets the max split index for the tree recursively.
+
+    :param tree: The tree to get the max split index for.
+    :type tree: dict
+    """
     if SPLIT_INDEX in tree:
         max_index = tree[SPLIT_INDEX]
         index1 = get_max_split_index(tree[TreeSide.LEFT_CHILD])
@@ -243,6 +293,31 @@ def traverse(df,
              side=TreeSide.UNKNOWN,
              metric=None,
              classes=None):
+    """Traverses the current node in the tree to create a list of nodes.
+
+    :param df: The dataframe containing the features and labels.
+    :type df: pandas.DataFrame
+    :param tree: The current node in the tree to traverse.
+    :type tree: dict
+    :param max_split_index: The max split index for the tree.
+    :type max_split_index: int
+    :param categories: The list of categorical features and categories.
+    :type categories: list[tuple]
+    :param dict: The dictionary to store the nodes in.
+    :type dict: dict
+    :param feature_names: The list of feature names.
+    :type feature_names: list[str]
+    :param parent: The parent node of the current node.
+    :type parent: Node or None
+    :param side: The side of the parent node the current node is on.
+    :type side: TreeSide
+    :param metric: The metric to use for the current node.
+    :type metric: str
+    :param classes: The list of classes for the current node.
+    :type classes: list[str]
+    :return: The tree representation as a list of nodes.
+    :rtype: list[dict[str, str]]
+    """
     if SPLIT_INDEX in tree:
         nodeid = tree[SPLIT_INDEX]
     elif LEAF_INDEX in tree:
@@ -271,11 +346,37 @@ def traverse(df,
 
 
 def create_categorical_arg(parent_threshold):
+    """Create the categorical argument for given parent threshold.
+
+    The argument contains the categories to split on.
+
+    :param parent_threshold: The parent threshold to create the categorical.
+    :type parent_threshold: float
+    :return: The categorical argument.
+    :rtype: list[float]
+    """
     return [float(i) for i in parent_threshold.split('||')]
 
 
 def create_categorical_query(method, arg, p_node_name, p_node_query,
                              parent, categories):
+    """Create the categorical query for given method and argument.
+
+    :param method: The method to use for the categorical query.
+    :type method: str
+    :param arg: The argument to use for the categorical query.
+    :type arg: list[float]
+    :param p_node_name: The name of the node.
+    :type p_node_name: str
+    :param p_node_query: The reference to the node to be used in the query.
+    :type p_node_query: str
+    :param parent: The parent node.
+    :type parent: dict
+    :param categories: The list of categories for the current node.
+    :type categories: list[tuple]
+    :return: The categorical query and condition.
+    :rtype: tuple(str, str)
+    """
     if method == CohortFilterMethods.METHOD_INCLUDES:
         operation = "=="
     else:
@@ -421,6 +522,13 @@ def node_to_dict(df, tree, nodeid, categories, json,
 
 
 def get_regression_metric_data(df):
+    """Compute regression metric data from a dataframe.
+
+    :param df: dataframe
+    :type df: pandas.DataFrame
+    :return: pred_y, true_y, error
+    :rtype: numpy.ndarray, numpy.ndarray, int
+    """
     pred_y = df[PRED_Y]
     true_y = df[TRUE_Y]
     # total abs error at the node
@@ -429,6 +537,13 @@ def get_regression_metric_data(df):
 
 
 def get_classification_metric_data(df):
+    """Compute classification metric data from a dataframe.
+
+    :param df: dataframe
+    :type df: pandas.DataFrame
+    :return: pred_y, true_y, error
+    :rtype: numpy.ndarray, numpy.ndarray, int
+    """
     pred_y = df[PRED_Y]
     true_y = df[TRUE_Y]
     error = df[DIFF].values.sum()
@@ -436,6 +551,21 @@ def get_classification_metric_data(df):
 
 
 def compute_metric_value(func, classes, true_y, pred_y, metric):
+    """Compute metric from the given function, true and predicted values.
+
+    :param func: The metric function to evaluate.
+    :type func: function
+    :param classes: List of classes.
+    :type classes: list
+    :param true_y: True y values.
+    :type true_y: numpy.ndarray
+    :param pred_y: Predicted y values.
+    :type pred_y: numpy.ndarray
+    :param metric: Metric to compute.
+    :type metric: str
+    :return: The computed metric value.
+    :rtype: float
+    """
     requires_pos_label = (metric == Metrics.RECALL_SCORE or
                           metric == Metrics.PRECISION_SCORE or
                           metric == Metrics.F1_SCORE)

--- a/erroranalysis/erroranalysis/_internal/utils.py
+++ b/erroranalysis/erroranalysis/_internal/utils.py
@@ -16,7 +16,7 @@ def generate_random_unique_indexes(count, nnz):
     :param nnz: The number of unique values to choose.
     :type nnz: int
     :return: The list of unique indexes of length nnz.
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     if nnz > count:
         raise Exception("Knuth n-of-k algorithms requires 0 < n < k")

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -33,11 +33,11 @@ class BaseAnalyzer(ABC):
 
     :param dataset:  A matrix of feature vector examples
         (# examples x # features).
-    :type dataset: numpy.array or list[][] or pandas.DataFrame
+    :type dataset: numpy.ndarray or list[][] or pandas.DataFrame
     :param true_y: The true labels for the provided dataset.
-    :type true_y: numpy.array or list[] or pandas.Series
+    :type true_y: numpy.ndarray or list[] or pandas.Series
     :param feature_names: Feature names.
-    :type feature_names: numpy.array or list[]
+    :type feature_names: numpy.ndarray or list[]
     :param categorical_features: The categorical feature names.
     :type categorical_features: list[str]
     :param model_task: Optional parameter to specify whether the model
@@ -61,7 +61,7 @@ class BaseAnalyzer(ABC):
         'mean_squared_error', 'r2_score', and 'median_absolute_error'.
     :type metric: str
     :param classes: The class names.
-    :type classes: numpy.array or list[]
+    :type classes: numpy.ndarray or list[]
     """
     def __init__(self,
                  dataset,
@@ -147,7 +147,7 @@ class BaseAnalyzer(ABC):
         """Get the class names.
 
         :return: The class names.
-        :rtype: numpy.array or list[]
+        :rtype: numpy.ndarray or list[]
         """
         return self._classes
 
@@ -157,7 +157,7 @@ class BaseAnalyzer(ABC):
 
         :return: A matrix of feature vector examples
             (# examples x # features).
-        :rtype: numpy.array or list[][] or pandas.DataFrame
+        :rtype: numpy.ndarray or list[][] or pandas.DataFrame
         """
         return self._dataset
 
@@ -166,7 +166,7 @@ class BaseAnalyzer(ABC):
         """Get the feature names.
 
         :return: The feature names.
-        :rtype: numpy.array or list[]
+        :rtype: numpy.ndarray or list[]
         """
         return self._feature_names
 
@@ -175,7 +175,7 @@ class BaseAnalyzer(ABC):
         """Get the string indexed dataset for categorical features.
 
         :return: The string indexed dataset for categorical features.
-        :rtype: numpy.array or list[][] or pandas.DataFrame
+        :rtype: numpy.ndarray or list[][] or pandas.DataFrame
         """
         return self._string_ind_data
 
@@ -401,9 +401,9 @@ class BaseAnalyzer(ABC):
 
         :param dataset:  A matrix of feature vector examples
             (# examples x # features).
-        :type dataset: numpy.array or list[][] or pandas.DataFrame
+        :type dataset: numpy.ndarray or list[][] or pandas.DataFrame
         :return: The new dataset if a pandas dataframe or the original one.
-        :rtype: numpy.array or list[][] or pandas.DataFrame
+        :rtype: numpy.ndarray or list[][] or pandas.DataFrame
         """
         if isinstance(dataset, pd.DataFrame):
             return dataset.copy()
@@ -417,7 +417,7 @@ class BaseAnalyzer(ABC):
 
         :return: The difference between the predictions
             and true y labels.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         pass
 
@@ -438,11 +438,11 @@ class ModelAnalyzer(BaseAnalyzer):
     :type model: object
     :param dataset:  A matrix of feature vector examples
         (# examples x # features).
-    :type dataset: numpy.array or list[][] or pandas.DataFrame
+    :type dataset: numpy.ndarray or list[][] or pandas.DataFrame
     :param true_y: The true labels for the provided dataset.
-    :type true_y: numpy.array or list[] or pandas.Series
+    :type true_y: numpy.ndarray or list[] or pandas.Series
     :param feature_names: Feature names.
-    :type feature_names: numpy.array or list[]
+    :type feature_names: numpy.ndarray or list[]
     :param categorical_features: The categorical feature names.
     :type categorical_features: list[str]
     :param model_task: Optional parameter to specify whether the model
@@ -466,7 +466,7 @@ class ModelAnalyzer(BaseAnalyzer):
         'mean_squared_error', 'r2_score', and 'median_absolute_error'.
     :type metric: str
     :param classes: The class names.
-    :type classes: numpy.array or list[]
+    :type classes: numpy.ndarray or list[]
     """
     def __init__(self,
                  model,
@@ -517,7 +517,7 @@ class ModelAnalyzer(BaseAnalyzer):
 
         :return: The difference between the model's predictions
             and true y labels.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         if self._model_task == ModelTask.CLASSIFICATION:
             return self.model.predict(self.dataset) != self.true_y
@@ -536,11 +536,11 @@ class PredictionsAnalyzer(BaseAnalyzer):
     :type pred_y: numpy.ndarray or list[] or pandas.Series
     :param dataset:  A matrix of feature vector examples
         (# examples x # features).
-    :type dataset: numpy.array or list[][] or pandas.DataFrame
+    :type dataset: numpy.ndarray or list[][] or pandas.DataFrame
     :param true_y: The true labels for the provided dataset.
-    :type true_y: numpy.array or list[] or pandas.Series
+    :type true_y: numpy.ndarray or list[] or pandas.Series
     :param feature_names: Feature names.
-    :type feature_names: numpy.array or list[]
+    :type feature_names: numpy.ndarray or list[]
     :param categorical_features: The categorical feature names.
     :type categorical_features: list[str]
     :param model_task: Optional parameter to specify whether the model
@@ -564,7 +564,7 @@ class PredictionsAnalyzer(BaseAnalyzer):
         'mean_squared_error', 'r2_score', and 'median_absolute_error'.
     :type metric: str
     :param classes: The class names.
-    :type classes: numpy.array or list[]
+    :type classes: numpy.ndarray or list[]
     """
     def __init__(self,
                  pred_y,
@@ -606,6 +606,6 @@ class PredictionsAnalyzer(BaseAnalyzer):
 
         :return: The difference between the predictions
             and true y labels.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         return self.pred_y != self.true_y

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -58,7 +58,7 @@ class ErrorAnalysisDashboard(Dashboard):
         Only needed if providing a sample dataset for the UI while using
         the full dataset for the tree view and heatmap. Otherwise specify
         pred_y parameter only.
-    :type pred_y_dataset: numpy.array or list[] or pandas.Series
+    :type pred_y_dataset: numpy.ndarray or list[] or pandas.Series
     :param model_task: Optional parameter to specify whether the model
         is a classification or regression model. In most cases, the
         type of the model can be inferred based on the shape of the

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -62,20 +62,20 @@ class ErrorAnalysisDashboardInput:
         (# examples x # features), the same samples
             used to build the explanation.
             Will overwrite any set on explanation object already.
-        :type dataset: numpy.array or list[][] or pandas.DataFrame
+        :type dataset: numpy.ndarray or list[][] or pandas.DataFrame
         :param true_y: The true labels for the provided explanation.
             Will overwrite any set on explanation object already.
-        :type true_y: numpy.array or list[] or pandas.Series
+        :type true_y: numpy.ndarray or list[] or pandas.Series
         :param classes: The class names.
-        :type classes: numpy.array or list[]
+        :type classes: numpy.ndarray or list[]
         :param features: Feature names.
-        :type features: numpy.array or list[]
+        :type features: numpy.ndarray or list[]
         :param categorical_features: The categorical feature names.
         :type categorical_features: list[str]
         :param true_y_dataset: The true labels for the provided dataset.
         Only needed if the explanation has a sample of instances from the
         original dataset.  Otherwise specify true_y parameter only.
-        :type true_y_dataset: numpy.array or list[] or pandas.Series
+        :type true_y_dataset: numpy.ndarray or list[] or pandas.Series
         :param pred_y: The predicted y values, can be passed in as an
             alternative to the model and explanation for a more limited
             view.
@@ -84,7 +84,7 @@ class ErrorAnalysisDashboardInput:
             Only needed if providing a sample dataset for the UI while using
             the full dataset for the tree view and heatmap. Otherwise specify
             pred_y parameter only.
-        :type pred_y_dataset: numpy.array or list[] or pandas.Series
+        :type pred_y_dataset: numpy.ndarray or list[] or pandas.Series
         :param model_task: Optional parameter to specify whether the model
             is a classification or regression model. In most cases, the
             type of the model can be inferred based on the shape of the

--- a/raiwidgets/raiwidgets/explanation_dashboard_input.py
+++ b/raiwidgets/raiwidgets/explanation_dashboard_input.py
@@ -44,15 +44,15 @@ class ExplanationDashboardInput:
             Will overwrite any set on explanation object already.
             Must have fewer than
             10000 rows and fewer than 1000 columns.
-        :type dataset: numpy.array or list[][]
+        :type dataset: numpy.ndarray or list[][]
         :param true_y: The true labels for the provided dataset.
             Will overwrite any set on
             explanation object already.
-        :type true_y: numpy.array or list[]
+        :type true_y: numpy.ndarray or list[]
         :param classes: The class names.
-        :type classes: numpy.array or list[]
+        :type classes: numpy.ndarray or list[]
         :param features: Feature names.
-        :type features: numpy.array or list[]
+        :type features: numpy.ndarray or list[]
         """
         self._model = model
         self._is_classifier = _is_classifier(model)


### PR DESCRIPTION
## Description

Add more documentation to surrogate_error_tree.py.  This was actually mostly auto-generated by github copilot (amazing!).

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
