### PR TITLE
[E2E] Add aggregate feature importance tests to multiclass wine data and housing decision making notebook and adding logic to make e2e tests mandatory for new notebooks

### DIFF
--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  ci-python:
+  ci-raiwidgets-python-typescript:
     env:
       node-version: 16.8
     strategy:
@@ -25,9 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.pythonVersion }}
-        uses: actions/setup-python@v2
+      - uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
           python-version: ${{ matrix.pythonVersion }}
 
       - name: Use Node.js ${{ env.node-version }}
@@ -48,39 +48,52 @@ jobs:
         name: Use Homebrew to install libomp on MacOS for lightgbm
         run: brew install https://publictestdatasets.blob.core.windows.net/data/libomp-11.1.0.catalina.bottle.tar.gz
 
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+        name: Install pytorch on non-MacOS
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+
+      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
+        name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet pytorch torchvision captum -c pytorch
+
       - name: Setup tools
+        shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip~=21.3
           pip install --upgrade setuptools
           pip install --upgrade pip-tools
 
-      - name: Pip compile
+      - name: Install dependencies
+        shell: bash -l {0}
         run: |
-          pip-compile requirements-dev.txt
-          cat requirements-dev.txt
+          pip install -r requirements-dev.txt
+          pip install .
+        working-directory: ${{ matrix.packageDirectory }}
+
+      - name: Pip freeze
+        shell: bash -l {0}
+        run: |
+          pip freeze > installed-requirements-dev.txt
+          cat installed-requirements-dev.txt
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload requirements
         uses: actions/upload-artifact@v2
         with:
           name: requirements-dev.txt
-          path: ${{ matrix.packageDirectory }}/requirements-dev.txt
-
-      - name: Install dependencies
-        run: |
-          pip-sync requirements-dev.txt
-        working-directory: ${{ matrix.packageDirectory }}
-
-      - name: Install package
-        run: |
-          pip install -v .
-        working-directory: ${{ matrix.packageDirectory }}
+          path: ${{ matrix.packageDirectory }}/installed-requirements-dev.txt
 
       - name: Run widget tests
+        shell: bash -l {0}
         if: ${{ matrix.operatingSystem != 'macos-latest' }}
         run: yarn e2e-widget
 
       - name: Run tests
+        shell: bash -l {0}
         run: |
           pytest --durations=10 --junitxml=junit/test-results.xml --cov=${{ matrix.packageDirectory }} --cov-report=xml --cov-report=html
         working-directory: ${{ matrix.packageDirectory }}

--- a/apps/widget-e2e/src/describer/modelAssessment/IModelAssessmentData.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/IModelAssessmentData.ts
@@ -129,5 +129,7 @@ export enum RAINotebookNames {
   "ClassificationModelDebugging" = "responsibleaidashboard-census-classification-model-debugging.py",
   "DiabetesRegressionModelDebugging" = "responsibleaidashboard-diabetes-regression-model-debugging.py",
   "HousingClassificationModelDebugging" = "responsibleaidashboard-housing-classification-model-debugging.py",
-  "DiabetesDecisionMaking" = "responsibleaidashboard-diabetes-decision-making.py"
+  "DiabetesDecisionMaking" = "responsibleaidashboard-diabetes-decision-making.py",
+  "HousingDecisionMaking" = "responsibleaidashboard-housing-decision-making.py",
+  "MulticlassDnnModelDebugging" = "responsibleaidashboard-multiclass-dnn-model-debugging.py"
 }

--- a/apps/widget-e2e/src/describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeCohortFunctionality.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeCohortFunctionality.ts
@@ -14,7 +14,7 @@ export function describeCohortFunctionality(): void {
     it("Should have cohort selection in 'Sort by' dropdown", () => {
       createCohort();
 
-      cy.get(Locators.SortByDropdown).click();
+      cy.get(Locators.SortByDropdown).eq(0).click(); // Dropdown to select cohort
       cy.get(Locators.SortByDropdownOptions).should("exist");
     });
 

--- a/apps/widget-e2e/src/describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeGlobalExplanationChart.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeGlobalExplanationChart.ts
@@ -35,7 +35,13 @@ export function describeGlobalExplanationChart<
             .eq(i)
             .invoke("text")
             .then((text) => {
-              expect(columns).contain(text);
+              const trimmedString = text.includes("...")
+                ? text.slice(0, Math.max(0, text.indexOf("...")))
+                : text;
+              const stringInArray = columns.find((column) =>
+                column.includes(trimmedString)
+              );
+              expect(stringInArray).not.equal(undefined);
             });
         }
       }

--- a/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
@@ -322,6 +322,57 @@ const modelAssessmentDatasets = {
       yAxisNewValue: "1stFlrSF",
       yAxisValue: "LotFrontage"
     }
+  },
+  HousingDecisionMaking: {
+    cohortDefaultName: "All data",
+    featureImportanceData: {
+      datapoint: 89,
+      hasFeatureImportanceComponent: false
+    },
+    featureNames: [
+      "s5",
+      "bmi",
+      "bp",
+      "s3",
+      "sex",
+      "s1",
+      "s4",
+      "s2",
+      "age",
+      "s6"
+    ]
+  },
+  MulticlassDnnModelDebugging: {
+    cohortDefaultName: "All data",
+    featureImportanceData: {
+      correctPredictionDatapoint: "398",
+      datapoint: 500,
+      dropdownRowName: "Row 4",
+      hasCorrectIncorrectDatapoints: true,
+      hasFeatureImportanceComponent: true,
+      incorrectPredictionDatapoint: "102",
+      newFeatureDropdownValue: "workclass",
+      noDataset: false,
+      noFeatureImportance: false,
+      noLocalImportance: false,
+      topFeaturesCurrentValue: "4",
+      topFeaturesText: "Top 4 features by their importance"
+    },
+    featureNames: [
+      "total_phenols",
+      "proline",
+      "hue",
+      "alcohol",
+      "proanthocyanins",
+      "od280/od315_of_diluted_wines",
+      "malic_acid",
+      "ash",
+      "alcalinity_of_ash",
+      "magnesium",
+      "flavanoids",
+      "nonflavanoid_phenols",
+      "color_intensity"
+    ]
   }
 };
 

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingDecisionMaking/aggregateFeatureImportance.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingDecisionMaking/aggregateFeatureImportance.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeAggregateFeatureImportance } from "../../../describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeAggregateFeatureImportance";
+
+describeAggregateFeatureImportance("DiabetesDecisionMaking");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxMulticlassDnnModelDebugging/aggregateFeatureImportance.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxMulticlassDnnModelDebugging/aggregateFeatureImportance.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeAggregateFeatureImportance } from "../../../describer/modelAssessment/featureImportances/aggregateFeatureImportance/describeAggregateFeatureImportance";
+
+describeAggregateFeatureImportance("MulticlassDnnModelDebugging");

--- a/scripts/e2e-widget.js
+++ b/scripts/e2e-widget.js
@@ -6,11 +6,14 @@ const commander = require("commander");
 
 const baseDir = path.join(__dirname, "../notebooks/responsibleaidashboard");
 const filePrefix = "responsibleaidashboard-";
+// Please add notebook name into 'fileNames' array only when you are adding e2e tests to that notebook.
 const fileNames = [
   "responsibleaidashboard-census-classification-model-debugging",
   "responsibleaidashboard-diabetes-regression-model-debugging",
   "responsibleaidashboard-housing-classification-model-debugging",
-  "responsibleaidashboard-diabetes-decision-making"
+  "responsibleaidashboard-diabetes-decision-making",
+  "responsibleaidashboard-housing-decision-making",
+  "responsibleaidashboard-multiclass-dnn-model-debugging"
 ];
 const hostReg = /^ResponsibleAI started at (http:\/\/localhost:\d+)$/m;
 const timeout = 3600;
@@ -46,6 +49,21 @@ async function runNotebook(name) {
       throw error;
     });
   });
+}
+
+function checkIfAllNotebooksHaveTests() {
+  console.log(`Checking if all notebooks under ${baseDir} has tests`);
+  const files = fs
+    .readdirSync(baseDir)
+    .filter((f) => f.startsWith(filePrefix) && f.endsWith(".ipynb"))
+    .map((f) => f.replace(".ipynb", ""));
+  const allNotebooksHaveTests = _.isEqual(_.sortBy(files), _.sortBy(fileNames));
+  if (!allNotebooksHaveTests) {
+    throw new Error(
+      `Some of the notebooks doesn't have tests. If a new notebook is added, Please add tests.`
+    );
+  }
+  console.log(`All notebooks have tests.`);
 }
 
 function convertNotebook() {
@@ -119,6 +137,7 @@ async function main() {
     .option("-w, --watch", "Watch mode")
     .parse(process.argv)
     .outputHelp();
+  checkIfAllNotebooksHaveTests();
   convertNotebook();
   const hosts = await runNotebooks();
   writeCypressSettings(hosts);


### PR DESCRIPTION
Add aggregate feature importance tests to multiclass wine data and housing decision making notebook

## Description

Add aggregate feature importance tests to [multiclass wine data](https://github.com/microsoft/responsible-ai-toolbox/blob/main/notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb) and [housing decision making notebook](https://github.com/microsoft/responsible-ai-toolbox/blob/main/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb).

Also add logic in script to make e2e tests mandatory for newly added notebooks.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
