### PR TITLE
Make search case insensitive in feature list

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -379,7 +379,7 @@ export class FeatureList extends React.Component<
     this.setState(
       {
         searchedFeatures: this.props.features.filter((feature) =>
-          feature.includes(searchValue)
+          feature.toLocaleLowerCase().includes(searchValue.toLocaleLowerCase())
         )
       },
       () => {


### PR DESCRIPTION
This PR makes search case insensitive in feature list.

## Description
This PR makes search case insensitive in feature list. Here for example, when user wants to search for feature `Education`, they can search with `edu` without capitalizing `E`.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
