### PR TITLE
Add docstrings for locale

### DIFF
--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -94,6 +94,9 @@ class ErrorAnalysisDashboard(Dashboard):
         explanation is not specified for the dataset explorer.
         Specify less than 10k points for optimal performance.
     :type sample_dataset: pd.DataFrame or numpy.ndarray or list[][]
+    :param locale: The language in which user wants to load and access the
+        ErrorAnalysis Dashboard. The default language is english ("en").
+    :type locale: str
 
     :Example:
 

--- a/raiwidgets/raiwidgets/explanation_dashboard.py
+++ b/raiwidgets/raiwidgets/explanation_dashboard.py
@@ -39,9 +39,10 @@ class ExplanationDashboard(Dashboard):
     :type public_ip: str
     :param port: The port to use on locally hosted service.
     :type port: int
-
+    :param locale: The language in which user wants to load and access the
+        Explanation Dashboard. The default language is english ("en").
+    :type locale: str
     """
-
     def __init__(self, explanation, model=None, dataset=None,
                  true_y=None, classes=None, features=None,
                  public_ip=None, port=None, locale=None):

--- a/raiwidgets/raiwidgets/fairness_dashboard.py
+++ b/raiwidgets/raiwidgets/fairness_dashboard.py
@@ -29,8 +29,15 @@ class FairnessDashboard(Dashboard):
         names of "Model <n>" are generated
     :type y_pred: pandas.Series, pandas.DataFrame, list, Dict[str,1d array]
         or something convertible to numpy.ndarray
+    :param locale: The language in which user wants to load and access the
+        Fairness Dashboard. The default language is english ("en").
+    :type locale: str
+    :param public_ip: Optional. If running on a remote vm,
+        the external public ip address of the VM.
+    :type public_ip: str
+    :param port: The port to use on locally hosted service.
+    :type port: int
     """
-
     def __init__(
             self, *,
             sensitive_features,

--- a/raiwidgets/raiwidgets/model_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard.py
@@ -23,9 +23,10 @@ class ModelAnalysisDashboard(object):
     :type public_ip: str
     :param port: The port to use on locally hosted service.
     :type port: int
-
+    :param locale: The language in which user wants to load and access the
+        ModelAnalysis Dashboard. The default language is english ("en").
+    :type locale: str
     """
-
     def __init__(self, analysis: RAIInsights,
                  public_ip=None, port=None, locale=None):
         warnings.warn("MODULE-DEPRECATION-WARNING: "

--- a/raiwidgets/raiwidgets/model_performance_dashboard.py
+++ b/raiwidgets/raiwidgets/model_performance_dashboard.py
@@ -37,9 +37,10 @@ class ModelPerformanceDashboard(Dashboard):
     :type public_ip: str
     :param port: The port to use on locally hosted service.
     :type port: int
-
+    :param locale: The language in which user wants to load and access the
+        ModelPerformance Dashboard. The default language is english ("en").
+    :type locale: str
     """
-
     def __init__(self, model=None, dataset=None,
                  true_y=None, classes=None, features=None,
                  public_ip=None, port=None, locale=None):

--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -21,9 +21,10 @@ class ResponsibleAIDashboard(Dashboard):
     :type public_ip: str
     :param port: The port to use on locally hosted service.
     :type port: int
-
+    :param locale: The language in which user wants to load and access the
+        ResponsibleAI Dashboard. The default language is english ("en").
+    :type locale: str
     """
-
     def __init__(self, analysis: RAIInsights,
                  public_ip=None, port=None, locale=None):
         self.input = ResponsibleAIDashboardInput(analysis)


### PR DESCRIPTION
## Description

The 'locale' was added in various dashboards in RAI but no docstrings were added. Adding the missing docstrings .

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
