### PR TITLE
add missing release steps causing rai-core-flask release errors

### DIFF
--- a/.github/workflows/release-erroranalysis.yml
+++ b/.github/workflows/release-erroranalysis.yml
@@ -21,17 +21,26 @@ jobs:
 
       # build wheel
       - uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
+      - name: update and upgrade pip, setuptools, wheel, and twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine
+
       - name: install requirements.txt for erroranalysis
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
         working-directory: erroranalysis
+
       - name: pip freeze
         run: pip freeze
+
       - name: build wheel for erroranalysis
         run: python setup.py sdist bdist_wheel
         working-directory: erroranalysis

--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -21,17 +21,26 @@ jobs:
 
       # build wheel
       - uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
+      - name: update and upgrade pip, setuptools, wheel, and twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel twine
+
       - name: install requirements.txt for rai_core_flask
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
         working-directory: rai_core_flask
+
       - name: pip freeze
         run: pip freeze
+
       - name: build wheel for wrapped flask
         run: python setup.py sdist bdist_wheel
         working-directory: rai_core_flask


### PR DESCRIPTION
## Description

Add missing release steps causing rai-core-flask release errors.
When I tried to release rai-core-flask package to pypi, I got the error:

```
error: invalid command 'bdist_wheel'
Error: Process completed with exit code 1.
```
See build:
https://github.com/microsoft/responsible-ai-toolbox/runs/5145702921?check_suite_focus=true

We are clearly missing the step to install wheel package.  I also noticed this is missing from error analysis release pipeline as well, which was added based on rai-core-flask pipeline.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
