### PR TITLE
update raiwidgets to rai-core-flask 0.2.5 release

### DIFF
--- a/_NOTICE.md
+++ b/_NOTICE.md
@@ -16174,7 +16174,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-rai-core-flask 0.2.4 - MIT
+rai-core-flask 0.2.5 - MIT
 
 
 

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.2
 pandas>=0.25.1
 scipy>=1.4.1
-rai-core-flask==0.2.4
+rai-core-flask==0.2.5
 jinja2==2.11.3
 scikit-learn>=0.22.1
 lightgbm>=2.0.11


### PR DESCRIPTION
## Description

Update raiwidgets to rai-core-flask 0.2.5 release.
This is required before releasing raiwidgets and responsibleai packages.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
