### PR TITLE
fix release error on unknown shell command when uploading to pypi

### DIFF
--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -180,7 +180,6 @@ jobs:
           path: ${{ matrix.package }}
 
       - name: Publish responsibleai package to Test PyPI
-        shell: bash -l {0}
         if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'responsibleai' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
@@ -190,7 +189,6 @@ jobs:
           packages_dir: ${{steps.download.outputs.download-path}}
 
       - name: Publish responsibleai package to Prod PyPI
-        shell: bash -l {0}
         if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'responsibleai' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
@@ -199,7 +197,6 @@ jobs:
           packages_dir: ${{steps.download.outputs.download-path}}
 
       - name: Publish raiwidgets package to Test PyPI
-        shell: bash -l {0}
         if: ${{ github.event.inputs.releaseType == 'Test' && matrix.package == 'raiwidgets' }}
         uses: pypa/gh-action-pypi-publish@master
         with:
@@ -209,7 +206,6 @@ jobs:
           packages_dir: ${{steps.download.outputs.download-path}}
 
       - name: Publish raiwidgets package to Prod PyPI
-        shell: bash -l {0}
         if: ${{ github.event.inputs.releaseType == 'Prod' && matrix.package == 'raiwidgets' }}
         uses: pypa/gh-action-pypi-publish@master
         with:


### PR DESCRIPTION
## Description

Fix release error on unknown shell command when uploading to pypi.
It seems the "pypa/gh-action-pypi-publish@master" isn't able to take "shell: bash -l {0}" to use miniconda.
I'm hoping this will fix it, but I'm not quite sure, as then we won't be activating the correct env.
## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
