### PR TITLE
fix tree api being called twice on initial load due to uninitialized context being used

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -12,7 +12,8 @@ import {
   MetricCohortStats,
   ModelAssessmentContext,
   defaultModelAssessmentContext,
-  IErrorAnalysisTreeNode
+  IErrorAnalysisTreeNode,
+  IModelAssessmentContext
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { Property } from "csstype";
@@ -80,7 +81,10 @@ export class TreeViewRenderer extends React.PureComponent<
   private static saveStateOnUnmount = true;
   public context: React.ContextType<typeof ModelAssessmentContext> =
     defaultModelAssessmentContext;
-  public constructor(props: ITreeViewRendererProps) {
+  public constructor(
+    props: ITreeViewRendererProps,
+    context: IModelAssessmentContext
+  ) {
     super(props);
     if (
       this.props.selectedCohort !== this.props.baseCohort &&
@@ -88,7 +92,7 @@ export class TreeViewRenderer extends React.PureComponent<
     ) {
       this.state = TreeViewRenderer.savedState;
     } else {
-      this.state = createInitialTreeViewState(this.context.errorAnalysisData);
+      this.state = createInitialTreeViewState(context.errorAnalysisData);
     }
     TreeViewRenderer.saveStateOnUnmount = true;
   }


### PR DESCRIPTION
## Description

During profiling, I found that /tree was still being called twice on initial load of error analysis component, hurting performance - specifically for large data.  This was due to context being used incorrectly in the constructor.  For more information, please see:
https://github.com/facebook/react/issues/6598
This is the correct way to use context in constructor.  Due to uninitialized context being used in constructor, we were calling the tree API again in componentDidUpdate because the code thought there was a state change.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
