### PR TITLE
fix total metric changing with different num bins when using quantile binning on diabetes dataset

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -274,7 +274,8 @@ def bin_data(df, feat, bins, quantile_binning=False):
     if quantile_binning and not feat_col.empty:
         bindf = pd.qcut(feat_col, bins, precision=PRECISION, duplicates=DROP)
         zero_interval = bindf.cat.categories[0]
-        left = zero_interval.left - ZERO_BIN_TOL * zero_interval.left
+        left_abs = abs(zero_interval.left)
+        left = zero_interval.left - ZERO_BIN_TOL * left_abs
         zero_interval = pd.Interval(left=left, right=zero_interval.right,
                                     closed=zero_interval.closed)
         indexes = [zero_interval]
@@ -284,6 +285,15 @@ def bin_data(df, feat, bins, quantile_binning=False):
                                 dtype=bindf.cat.categories.dtype,
                                 name=bindf.cat.categories.name)
         bindf.cat.categories = cats
+        # re-bin data according to new categories, otherwise can have
+        # issues with precision when using pd.qcut.
+        # Specifically, it can bin some points incorrectly for low precision,
+        # for example a point with value -0.0127796318808497
+        # will be binned incorrectly in interval
+        # (-0.0309423241359475, -0.012779631880849702]
+        # even though it should be binned in the interval above since
+        # -0.0127796318808497 > -0.012779631880849702
+        bindf = bin_data(df, feat, bindf.cat.categories, quantile_binning)
         return bindf
     else:
         return pd.cut(feat_col, bins, precision=PRECISION)

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '30'
+_patch = '31'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -10,7 +10,8 @@ from pandas import read_csv
 from sklearn import svm
 from sklearn.compose import ColumnTransformer
 from sklearn.datasets import (fetch_california_housing, load_breast_cancer,
-                              load_iris, load_wine, make_classification)
+                              load_diabetes, load_iris, load_wine,
+                              make_classification)
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
@@ -131,6 +132,17 @@ def create_cancer_data():
     feature_names = breast_cancer_data.feature_names
     classes = breast_cancer_data.target_names.tolist()
     return X_train, X_test, y_train, y_test, feature_names, classes
+
+
+def create_diabetes_data():
+    diabetes_data = load_diabetes()
+    X = diabetes_data.data
+    y = diabetes_data.target
+    feature_names = diabetes_data.feature_names
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=0)
+    return X_train, X_test, y_train, y_test, feature_names
 
 
 def create_binary_classification_dataset(n_samples=100):

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -6,8 +6,9 @@ import pandas as pd
 import pytest
 from common_utils import (create_adult_census_data,
                           create_binary_classification_dataset,
-                          create_cancer_data, create_housing_data,
-                          create_iris_data, create_kneighbors_classifier,
+                          create_cancer_data, create_diabetes_data,
+                          create_housing_data, create_iris_data,
+                          create_kneighbors_classifier,
                           create_models_classification,
                           create_models_regression, create_simple_titanic_data,
                           create_titanic_pipeline, create_wine_data)
@@ -83,6 +84,24 @@ class TestMatrixFilter(object):
                                      model_task,
                                      quantile_binning=True)
 
+    @pytest.mark.parametrize('metric', [Metrics.MEAN_SQUARED_ERROR,
+                                        Metrics.MEAN_ABSOLUTE_ERROR])
+    @pytest.mark.parametrize('num_bins', [4, 8, 10, 20])
+    def test_matrix_filter_diabetes_quantile_binning(self, num_bins, metric):
+        # this dataset seemed to have unique errors for quantile binning
+        (X_train, X_test, y_train, y_test,
+            feature_names) = create_diabetes_data()
+
+        model_task = ModelTask.REGRESSION
+        matrix_features = ['age']
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names,
+                                     model_task,
+                                     matrix_features=matrix_features,
+                                     quantile_binning=True,
+                                     num_bins=num_bins,
+                                     metric=metric)
+
     @pytest.mark.parametrize('string_labels', [True, False])
     @pytest.mark.parametrize('metric', [Metrics.ERROR_RATE,
                                         Metrics.PRECISION_SCORE,
@@ -92,8 +111,8 @@ class TestMatrixFilter(object):
     def test_matrix_filter_adult_census_quantile_binning(self,
                                                          string_labels,
                                                          metric):
-        X_train, X_test, y_train, y_test, categorical_features = \
-            create_adult_census_data(string_labels)
+        (X_train, X_test, y_train, y_test,
+            categorical_features) = create_adult_census_data(string_labels)
 
         model_task = ModelTask.CLASSIFICATION
         feature_names = X_test.columns.tolist()
@@ -186,8 +205,8 @@ class TestMatrixFilter(object):
                                      metric=metric)
 
     def test_matrix_filter_cancer(self):
-        X_train, X_test, y_train, y_test, feature_names, _ = \
-            create_cancer_data()
+        (X_train, X_test, y_train, y_test,
+            feature_names, _) = create_cancer_data()
 
         model_task = ModelTask.CLASSIFICATION
         run_error_analyzer_on_models(X_train, y_train, X_test,
@@ -197,8 +216,8 @@ class TestMatrixFilter(object):
     def test_matrix_filter_cancer_filters(self):
         # Validate the shift cohort functionality where base
         # cohort was chosen in matrix view
-        X_train, X_test, y_train, y_test, feature_names, _ = \
-            create_cancer_data()
+        (X_train, X_test, y_train, y_test,
+            feature_names, _) = create_cancer_data()
 
         composite_filters = [{'compositeFilters':
                              [{'compositeFilters':
@@ -229,16 +248,16 @@ class TestMatrixFilter(object):
                                      composite_filters=composite_filters)
 
     def test_matrix_filter_binary_classification(self):
-        X_train, y_train, X_test, y_test, _ = \
-            create_binary_classification_dataset()
+        (X_train, y_train, X_test,
+            y_test, _) = create_binary_classification_dataset()
         feature_names = list(X_train.columns)
         model_task = ModelTask.CLASSIFICATION
         run_error_analyzer_on_models(X_train, y_train, X_test,
                                      y_test, feature_names, model_task)
 
     def test_matrix_filter_titanic(self):
-        X_train, X_test, y_train, y_test, numeric, categorical = \
-            create_simple_titanic_data()
+        (X_train, X_test, y_train, y_test, numeric,
+            categorical) = create_simple_titanic_data()
         feature_names = categorical + numeric
         clf = create_titanic_pipeline(X_train, y_train)
         categorical_features = categorical
@@ -288,8 +307,8 @@ class TestMatrixFilter(object):
     def test_matrix_filter_housing_quantile_binning(self):
         # Test quantile binning on CRIM feature in california housing dataset,
         # which errored out due to first category not fitting into bins
-        X_train, X_test, y_train, y_test, feature_names = \
-            create_housing_data(test_size=0.5)
+        (X_train, X_test, y_train, y_test,
+            feature_names) = create_housing_data(test_size=0.5)
 
         model_task = ModelTask.REGRESSION
         matrix_features = ['Population']


### PR DESCRIPTION
## Description

Fix total metric changing with different num bins when using quantile binning on diabetes dataset.
Fixes issue:
https://github.com/microsoft/responsible-ai-toolbox/issues/1217

This was fixed by re-binning the quantile binned dataset, as for low precision values pd.qcut miscategorizes data.  This is partly fixed by setting the PRECISION parameter to pd.qcut, but it seems for some datasets even lowest precision still has miscategorizations.
Specifically, it can bin some points incorrectly for low precision, for example a point with value
```-0.0127796318808497```
will be binned incorrectly in interval
```(-0.0309423241359475, -0.012779631880849702]```
even though it should be binned in the interval above since
```-0.0127796318808497 > -0.012779631880849702```

Also, during testing I discovered another error, which is also fixed in this PR.  This other error is caused by the first quantile bin being incorrectly resized for negative values.  For more detailed information please see PR:
https://github.com/microsoft/responsible-ai-toolbox/pull/898
Which has a description of some of the limitations of pd.qcut due to the interval brackets.  Calculating abs fixes this issue.  For the error message please see below:

```
Traceback (most recent call last):
  File "c:\responsible-ai-toolbox\raiwidgets\raiwidgets\responsibleai_dashboard_input.py", line 102, in matrix
    quantile_binning, num_bins)
  File "c:\responsible-ai-toolbox\erroranalysis\erroranalysis\analyzer\error_analyzer.py", line 257, in compute_matrix
    num_bins=num_bins)
  File "c:\responsible-ai-toolbox\erroranalysis\erroranalysis\_internal\matrix_filter.py", line 221, in compute_matrix
    val_err = cut_err.cat.categories[val_err]
  File "C:\Users\ilmat\Miniconda3\envs\sh\lib\site-packages\pandas\core\indexes\extension.py", line 279, in __getitem__
    result = self._data[key]
  File "C:\Users\ilmat\Miniconda3\envs\sh\lib\site-packages\pandas\core\arrays\interval.py", line 633, in __getitem__
    key = check_array_indexer(self, key)
  File "C:\Users\ilmat\Miniconda3\envs\sh\lib\site-packages\pandas\core\indexers.py", line 573, in check_array_indexer
    raise IndexError("arrays used as indices must be of integer or boolean type")
IndexError: arrays used as indices must be of integer or boolean type
```

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [x] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
