### PR TITLE
Add user defined cohort injection logic into raiwidgets

### DIFF
--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -24,10 +24,15 @@ class ResponsibleAIDashboard(Dashboard):
     :param locale: The language in which user wants to load and access the
         ResponsibleAI Dashboard. The default language is english ("en").
     :type locale: str
+    :param cohort_list:
+        List of cohorts defined by the user for the dashboard.
+    :type cohort_list: List[Cohort]
     """
     def __init__(self, analysis: RAIInsights,
-                 public_ip=None, port=None, locale=None):
-        self.input = ResponsibleAIDashboardInput(analysis)
+                 public_ip=None, port=None, locale=None,
+                 cohort_list=None):
+        self.input = ResponsibleAIDashboardInput(
+            analysis, cohort_list=cohort_list)
 
         super(ResponsibleAIDashboard, self).__init__(
             dashboard_type="ResponsibleAI",

--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -2,13 +2,17 @@
 # Licensed under the MIT License.
 
 import traceback
+from typing import List, Optional
 
+import numpy as np
 import pandas as pd
 
-from erroranalysis._internal.constants import display_name_to_metric
+from erroranalysis._internal.constants import ModelTask, display_name_to_metric
 from responsibleai import RAIInsights
 from responsibleai._input_processing import _convert_to_list
+from responsibleai.exceptions import UserConfigValidationException
 
+from ._cohort import Cohort
 from .constants import ErrorMessages
 from .error_handling import _format_exception
 from .interfaces import WidgetRequestResponseConstants
@@ -20,20 +24,73 @@ EXP_VIZ_ERR_MSG = ErrorMessages.EXP_VIZ_ERR_MSG
 class ResponsibleAIDashboardInput:
     def __init__(
             self,
-            analysis: RAIInsights):
+            analysis: RAIInsights,
+            cohort_list: Optional[List[Cohort]] = None):
         """Initialize the Explanation Dashboard Input.
 
         :param analysis:
             A RAIInsights object that represents an explanation.
         :type analysis: RAIInsights
+        :param cohort_list:
+            List of cohorts defined by the user for the dashboard.
+        :type cohort_list: List[Cohort]
         """
         self._analysis = analysis
         model = analysis.model
         self._is_classifier = _is_classifier(model)
         self.dashboard_input = analysis.get_data()
+
+        self._validate_cohort_list(cohort_list)
+        # Add cohort_list to dashboard_input
+        self.dashboard_input.cohortData = cohort_list
+
         self._feature_length = len(self.dashboard_input.dataset.feature_names)
         self._row_length = len(self.dashboard_input.dataset.features)
         self._error_analyzer = analysis.error_analysis._analyzer
+
+    def _validate_cohort_list(self, cohort_list=None):
+        if cohort_list is None:
+            return
+
+        if not isinstance(cohort_list, list):
+            raise UserConfigValidationException(
+                "cohort_list parameter should be a list.")
+
+        if not all(isinstance(entry, Cohort) for entry in cohort_list):
+            raise UserConfigValidationException(
+                "All entries in cohort_list should be of type Cohort.")
+
+        all_cohort_names = [cohort.name for cohort in cohort_list]
+        unique_cohort_names = np.unique(all_cohort_names).tolist()
+
+        if len(unique_cohort_names) != len(all_cohort_names):
+            raise UserConfigValidationException(
+                "Found cohorts with duplicate names. "
+                "All pre-defined cohorts need to have distinct names.")
+
+        test_data = pd.DataFrame(
+            data=self.dashboard_input.dataset.features,
+            columns=self.dashboard_input.dataset.feature_names)
+        if self.dashboard_input.dataset.task_type == \
+                ModelTask.CLASSIFICATION:
+            class_names_list = self.dashboard_input.dataset.class_names
+            true_y_array = self.dashboard_input.dataset.true_y
+            true_class_array = np.array(
+                [class_names_list[index] for index in true_y_array])
+            test_data[self.dashboard_input.dataset.target_column] = \
+                true_class_array
+        else:
+            test_data[self.dashboard_input.dataset.target_column] = \
+                self.dashboard_input.dataset.true_y
+
+        categorical_features = \
+            self.dashboard_input.dataset.categorical_features
+        for cohort in cohort_list:
+            cohort._validate_with_test_data(
+                test_data=test_data,
+                target_column=self.dashboard_input.dataset.target_column,
+                categorical_features=categorical_features,
+                is_classification=self._is_classifier)
 
     def on_predict(self, data):
         try:

--- a/raiwidgets/tests/conftest.py
+++ b/raiwidgets/tests/conftest.py
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pytest
+import shap
+import sklearn
+from sklearn.model_selection import train_test_split
+
+from responsibleai import RAIInsights
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object():
+    X, y = shap.datasets.adult()
+    y = [1 if r else 0 for r in y]
+
+    X, y = sklearn.utils.resample(
+        X, y, n_samples=1000, random_state=7, stratify=y)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.01, random_state=7, stratify=y)
+
+    knn = sklearn.neighbors.KNeighborsClassifier()
+    knn.fit(X_train, y_train)
+
+    X['Income'] = y
+    X_test['Income'] = y_test
+
+    ri = RAIInsights(knn, X, X_test, 'Income', 'classification',
+                     categorical_features=['Workclass', 'Education-Num',
+                                           'Marital Status',
+                                           'Occupation', 'Relationship',
+                                           'Race',
+                                           'Sex', 'Country'])
+    ri.explainer.add()
+    ri.counterfactual.add(10, desired_class='opposite')
+    ri.error_analysis.add()
+    ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
+                  heterogeneity_features=None,
+                  upper_bound_on_cat_expansion=42,
+                  skip_cat_limit_checks=True)
+    ri.compute()
+    return ri

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -31,37 +31,8 @@ class TestModelAnalysisDashboard:
             rai_widget.input.dashboard_input.counterfactualData[0],
             CounterfactualData)
 
-    def test_model_analysis_adult(self, tmpdir):
-        X, y = shap.datasets.adult()
-        y = [1 if r else 0 for r in y]
-
-        X, y = sklearn.utils.resample(
-            X, y, n_samples=1000, random_state=7, stratify=y)
-
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, test_size=0.02, random_state=7, stratify=y)
-
-        knn = sklearn.neighbors.KNeighborsClassifier()
-        knn.fit(X_train, y_train)
-
-        X['Income'] = y
-        X_test['Income'] = y_test
-
-        ri = RAIInsights(knn, X, X_test, 'Income', 'classification',
-                         categorical_features=['Workclass', 'Education-Num',
-                                               'Marital Status',
-                                               'Occupation', 'Relationship',
-                                               'Race',
-                                               'Sex', 'Country'])
-        ri.explainer.add()
-        ri.counterfactual.add(10, desired_class='opposite')
-        ri.error_analysis.add()
-        ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
-                      heterogeneity_features=None,
-                      upper_bound_on_cat_expansion=42,
-                      skip_cat_limit_checks=True)
-        ri.compute()
-
+    def test_model_analysis_adult(self, tmpdir, create_rai_insights_object):
+        ri = create_rai_insights_object
         with pytest.warns(
             DeprecationWarning,
             match="MODULE-DEPRECATION-WARNING: "

--- a/raiwidgets/tests/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard.py
@@ -1,14 +1,16 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-import shap
-import sklearn
-from sklearn.model_selection import train_test_split
+import json
+
+import pytest
 
 from raiwidgets import ResponsibleAIDashboard
-from responsibleai import RAIInsights
+from raiwidgets._cohort import Cohort, CohortFilter, CohortFilterMethods
 from responsibleai._interfaces import (CausalData, CounterfactualData, Dataset,
                                        ErrorAnalysisData, ModelExplanationData)
+from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.serialization_utilities import serialize_json_safe
 
 
 class TestResponsibleAIDashboard:
@@ -30,36 +32,16 @@ class TestResponsibleAIDashboard:
             rai_widget.input.dashboard_input.counterfactualData[0],
             CounterfactualData)
 
-    def test_responsibleai_adult(self, tmpdir):
-        X, y = shap.datasets.adult()
-        y = [1 if r else 0 for r in y]
+        if rai_widget.input.dashboard_input.cohortData is not None:
+            assert isinstance(rai_widget.input.dashboard_input.cohortData[0],
+                              Cohort)
 
-        X, y = sklearn.utils.resample(
-            X, y, n_samples=1000, random_state=7, stratify=y)
+        # Make sure the dashboard input can be serialized
+        json.dumps(rai_widget.input.dashboard_input,
+                   default=serialize_json_safe)
 
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, test_size=0.02, random_state=7, stratify=y)
-
-        knn = sklearn.neighbors.KNeighborsClassifier()
-        knn.fit(X_train, y_train)
-
-        X['Income'] = y
-        X_test['Income'] = y_test
-
-        ri = RAIInsights(knn, X, X_test, 'Income', 'classification',
-                         categorical_features=['Workclass', 'Education-Num',
-                                               'Marital Status',
-                                               'Occupation', 'Relationship',
-                                               'Race',
-                                               'Sex', 'Country'])
-        ri.explainer.add()
-        ri.counterfactual.add(10, desired_class='opposite')
-        ri.error_analysis.add()
-        ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
-                      heterogeneity_features=None,
-                      upper_bound_on_cat_expansion=42,
-                      skip_cat_limit_checks=True)
-        ri.compute()
+    def test_responsibleai_adult(self, tmpdir, create_rai_insights_object):
+        ri = create_rai_insights_object
 
         widget = ResponsibleAIDashboard(ri)
         self.validate_rai_dashboard_data(widget)
@@ -70,3 +52,96 @@ class TestResponsibleAIDashboard:
 
         widget_copy = ResponsibleAIDashboard(ri_copy)
         self.validate_rai_dashboard_data(widget_copy)
+
+    def test_responsibleai_adult_with_pre_defined_cohorts(
+            self, create_rai_insights_object):
+        ri = create_rai_insights_object
+
+        cohort_filter_continuous_1 = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[65],
+            column='Age')
+        cohort_filter_continuous_2 = CohortFilter(
+            method=CohortFilterMethods.METHOD_GREATER,
+            arg=[40],
+            column='Hours per week')
+
+        user_cohort_continuous = Cohort(name='Cohort Continuous')
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_1)
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_2)
+
+        cohort_filter_categorical = CohortFilter(
+            method=CohortFilterMethods.METHOD_INCLUDES,
+            arg=[2, 6, 4],
+            column='Marital Status')
+
+        user_cohort_categorical = Cohort(name='Cohort Categorical')
+        user_cohort_categorical.add_cohort_filter(cohort_filter_categorical)
+
+        cohort_filter_index = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[20],
+            column='Index')
+
+        user_cohort_index = Cohort(name='Cohort Index')
+        user_cohort_index.add_cohort_filter(cohort_filter_index)
+
+        widget = ResponsibleAIDashboard(
+            ri,
+            cohort_list=[user_cohort_continuous,
+                         user_cohort_categorical,
+                         user_cohort_index])
+
+        self.validate_rai_dashboard_data(widget)
+
+    def test_responsibleai_adult_with_ill_defined_cohorts(
+            self, create_rai_insights_object):
+        ri = create_rai_insights_object
+
+        cohort_filter_continuous_1 = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[65],
+            column='Age')
+        cohort_filter_continuous_2 = CohortFilter(
+            method=CohortFilterMethods.METHOD_GREATER,
+            arg=[40],
+            column='Hours per week')
+
+        user_cohort_continuous = Cohort(name='Cohort Continuous')
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_1)
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_2)
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match="cohort_list parameter should be a list."):
+            ResponsibleAIDashboard(ri, cohort_list={})
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match="All entries in cohort_list should be of type Cohort."):
+            ResponsibleAIDashboard(
+                ri, cohort_list=[user_cohort_continuous, {}])
+
+    def test_responsibleai_adult_duplicate_cohort_names(
+            self, create_rai_insights_object):
+        ri = create_rai_insights_object
+
+        cohort_filter_continuous_1 = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[65],
+            column='Age')
+        cohort_filter_continuous_2 = CohortFilter(
+            method=CohortFilterMethods.METHOD_GREATER,
+            arg=[40],
+            column='Hours per week')
+
+        user_cohort_continuous = Cohort(name='Cohort Continuous')
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_1)
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_2)
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match="Found cohorts with duplicate names. "
+                      "All pre-defined cohorts need to have distinct names."):
+            ResponsibleAIDashboard(ri, cohort_list=[
+                user_cohort_continuous, user_cohort_continuous])


### PR DESCRIPTION
## Description

This change proposes the injection of user defined cohorts defined in SDK into the `ResponsibleAIDashboard`. The user defined cohorts are added into the `dashboard_input` as `cohortData` (which in python world is a list of `Cohort` class objects.). The injection logic is tested in the `test_responsibleai_dashboard.py`.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
