### PR TITLE
erroranalysis version bump in raiwidgets to 0.1.31

### DIFF
--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,5 +6,5 @@ itsdangerous==2.0.1
 jinja2==2.11.3
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.1.30
+erroranalysis>=0.1.31
 fairlearn>=0.7.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,7 +1,7 @@
 dice-ml>=0.7.2,<0.8
 econml~=0.12.0
 jsonschema
-erroranalysis>=0.1.30
+erroranalysis>=0.1.31
 interpret-community>=0.24.2
 lightgbm>=2.0.11
 numpy>=1.17.2


### PR DESCRIPTION
## Description

erroranalysis version bump in raiwidgets to 0.1.31.
erroranalysis 0.1.31 package was released to pypi test and prod today.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
