### PR TITLE
Make cohortData empty list in case no pre-defined cohorts are injected

### DIFF
--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -41,8 +41,11 @@ class ResponsibleAIDashboardInput:
         self.dashboard_input = analysis.get_data()
 
         self._validate_cohort_list(cohort_list)
-        # Add cohort_list to dashboard_input
-        self.dashboard_input.cohortData = cohort_list
+        if cohort_list is not None:
+            # Add cohort_list to dashboard_input
+            self.dashboard_input.cohortData = cohort_list
+        else:
+            self.dashboard_input.cohortData = []
 
         self._feature_length = len(self.dashboard_input.dataset.feature_names)
         self._row_length = len(self.dashboard_input.dataset.features)

--- a/raiwidgets/tests/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard.py
@@ -32,7 +32,7 @@ class TestResponsibleAIDashboard:
             rai_widget.input.dashboard_input.counterfactualData[0],
             CounterfactualData)
 
-        if rai_widget.input.dashboard_input.cohortData is not None:
+        if len(rai_widget.input.dashboard_input.cohortData) != 0:
             assert isinstance(rai_widget.input.dashboard_input.cohortData[0],
                               Cohort)
 


### PR DESCRIPTION
## Description

The widget requires the dashboard data fields like counterfactualData, causalData to be empty lists in case these are not computed. Hence, making the cohortData an empty list if no pre-defined cohorts are injected in ResponsibleAIDashboard.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
