### PR TITLE
Set bar color to align with plot style

### DIFF
--- a/libs/core-ui/src/lib/util/getErrorBarChartOptions.ts
+++ b/libs/core-ui/src/lib/util/getErrorBarChartOptions.ts
@@ -7,6 +7,7 @@ import { localization } from "@responsible-ai/localization";
 import { IHighchartsConfig } from "../Highchart/HighchartTypes";
 import { ICausalAnalysisSingleData } from "../Interfaces/ICausalAnalysisData";
 
+import { FabricStyles } from "./FabricStyles";
 import { getCausalDisplayFeatureName } from "./getCausalDisplayFeatureName";
 
 export function getErrorBarChartOptions(
@@ -26,7 +27,7 @@ export function getErrorBarChartOptions(
     },
     series: [
       {
-        color: colorTheme.fontColor,
+        color: FabricStyles.fabricColorPalette[0],
         data: data.map((d) => d.point),
         showInLegend: false,
         tooltip: {
@@ -35,7 +36,7 @@ export function getErrorBarChartOptions(
         type: "spline"
       },
       {
-        color: colorTheme.fontColor,
+        color: FabricStyles.fabricColorPalette[0],
         data: data.map((d) => [d.ci_lower, d.ci_upper]),
         tooltip: {
           pointFormat:

--- a/libs/core-ui/src/lib/util/getTreatmentBarChartOptions.ts
+++ b/libs/core-ui/src/lib/util/getTreatmentBarChartOptions.ts
@@ -7,6 +7,8 @@ import { localization } from "@responsible-ai/localization";
 import { IHighchartsConfig } from "../Highchart/HighchartTypes";
 import { ICausalPolicyGains } from "../Interfaces/ICausalAnalysisData";
 
+import { FabricStyles } from "./FabricStyles";
+
 export function getTreatmentBarChartOptions(
   data: ICausalPolicyGains,
   title: string,
@@ -38,7 +40,7 @@ export function getTreatmentBarChartOptions(
     },
     series: [
       {
-        color: colorTheme.axisColor,
+        color: FabricStyles.fabricColorPalette[0],
         data: xData,
         dataLabels: {
           color: colorTheme.fontColor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set bar color to align with plot style

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):
![1](https://user-images.githubusercontent.com/71688188/155774447-c1e88f72-d659-42e5-9720-4e522eeb3001.JPG)
![2](https://user-images.githubusercontent.com/71688188/155774479-8ed14e09-55ad-4231-b576-7bcfebbd8d75.JPG)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
