### PR TITLE
Add regression test for pre-defined cohorts in raiwidgets

### DIFF
--- a/raiwidgets/tests/conftest.py
+++ b/raiwidgets/tests/conftest.py
@@ -1,16 +1,19 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pandas as pd
 import pytest
 import shap
 import sklearn
+from sklearn.datasets import fetch_california_housing
+from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
 from responsibleai import RAIInsights
 
 
 @pytest.fixture(scope='session')
-def create_rai_insights_object():
+def create_rai_insights_object_classification():
     X, y = shap.datasets.adult()
     y = [1 if r else 0 for r in y]
 
@@ -36,6 +39,35 @@ def create_rai_insights_object():
     ri.counterfactual.add(10, desired_class='opposite')
     ri.error_analysis.add()
     ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
+                  heterogeneity_features=None,
+                  upper_bound_on_cat_expansion=42,
+                  skip_cat_limit_checks=True)
+    ri.compute()
+    return ri
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_regression():
+    housing = fetch_california_housing()
+    X_train, X_test, y_train, y_test = train_test_split(housing.data,
+                                                        housing.target,
+                                                        test_size=0.005,
+                                                        random_state=7)
+    X_train = pd.DataFrame(X_train, columns=housing.feature_names)
+    X_test = pd.DataFrame(X_test, columns=housing.feature_names)
+
+    rfc = RandomForestRegressor(n_estimators=10, max_depth=4,
+                                random_state=777)
+    model = rfc.fit(X_train, y_train)
+
+    X_train['target'] = y_train
+    X_test['target'] = y_test
+
+    ri = RAIInsights(model, X_train, X_test, 'target', 'regression')
+    ri.explainer.add()
+    ri.counterfactual.add(10, desired_range=[5, 10])
+    ri.error_analysis.add()
+    ri.causal.add(treatment_features=['AveRooms'],
                   heterogeneity_features=None,
                   upper_bound_on_cat_expansion=42,
                   skip_cat_limit_checks=True)

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -27,8 +27,9 @@ class TestModelAnalysisDashboard:
             rai_widget.input.dashboard_input.counterfactualData[0],
             CounterfactualData)
 
-    def test_model_analysis_adult(self, tmpdir, create_rai_insights_object):
-        ri = create_rai_insights_object
+    def test_model_analysis_adult(self, tmpdir,
+                                  create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
         with pytest.warns(
             DeprecationWarning,
             match="MODULE-DEPRECATION-WARNING: "

--- a/raiwidgets/tests/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard.py
@@ -40,8 +40,9 @@ class TestResponsibleAIDashboard:
         json.dumps(rai_widget.input.dashboard_input,
                    default=serialize_json_safe)
 
-    def test_responsibleai_adult(self, tmpdir, create_rai_insights_object):
-        ri = create_rai_insights_object
+    def test_responsibleai_adult_save_and_load(
+            self, tmpdir, create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
 
         widget = ResponsibleAIDashboard(ri)
         self.validate_rai_dashboard_data(widget)
@@ -53,9 +54,73 @@ class TestResponsibleAIDashboard:
         widget_copy = ResponsibleAIDashboard(ri_copy)
         self.validate_rai_dashboard_data(widget_copy)
 
+    def test_responsibleai_housing_save_and_load(
+            self, tmpdir, create_rai_insights_object_regression):
+        ri = create_rai_insights_object_regression
+
+        widget = ResponsibleAIDashboard(ri)
+        self.validate_rai_dashboard_data(widget)
+
+        save_dir = tmpdir.mkdir('save-dir')
+        ri.save(save_dir)
+        ri_copy = ri.load(save_dir)
+
+        widget_copy = ResponsibleAIDashboard(ri_copy)
+        self.validate_rai_dashboard_data(widget_copy)
+
+    def test_responsibleai_housing_with_pre_defined_cohorts(
+            self, create_rai_insights_object_regression):
+        ri = create_rai_insights_object_regression
+
+        cohort_filter_continuous_1 = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[30.5],
+            column='HouseAge')
+        cohort_filter_continuous_2 = CohortFilter(
+            method=CohortFilterMethods.METHOD_GREATER,
+            arg=[3.0],
+            column='AveRooms')
+
+        user_cohort_continuous = Cohort(name='Cohort Continuous')
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_1)
+        user_cohort_continuous.add_cohort_filter(cohort_filter_continuous_2)
+
+        cohort_filter_index = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[20],
+            column='Index')
+
+        user_cohort_index = Cohort(name='Cohort Index')
+        user_cohort_index.add_cohort_filter(cohort_filter_index)
+
+        cohort_filter_predicted_y = CohortFilter(
+            method=CohortFilterMethods.METHOD_LESS,
+            arg=[5.0],
+            column='Predicted Y')
+
+        user_cohort_predicted_y = Cohort(name='Cohort Predicted Y')
+        user_cohort_predicted_y.add_cohort_filter(cohort_filter_predicted_y)
+
+        cohort_filter_true_y = CohortFilter(
+            method=CohortFilterMethods.METHOD_GREATER,
+            arg=[1.0],
+            column='True Y')
+
+        user_cohort_true_y = Cohort(name='Cohort True Y')
+        user_cohort_true_y.add_cohort_filter(cohort_filter_true_y)
+
+        widget = ResponsibleAIDashboard(
+            ri,
+            cohort_list=[user_cohort_continuous,
+                         user_cohort_index,
+                         user_cohort_predicted_y,
+                         user_cohort_true_y])
+
+        self.validate_rai_dashboard_data(widget)
+
     def test_responsibleai_adult_with_pre_defined_cohorts(
-            self, create_rai_insights_object):
-        ri = create_rai_insights_object
+            self, create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
 
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
@@ -95,8 +160,8 @@ class TestResponsibleAIDashboard:
         self.validate_rai_dashboard_data(widget)
 
     def test_responsibleai_adult_with_ill_defined_cohorts(
-            self, create_rai_insights_object):
-        ri = create_rai_insights_object
+            self, create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
 
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
@@ -123,8 +188,8 @@ class TestResponsibleAIDashboard:
                 ri, cohort_list=[user_cohort_continuous, {}])
 
     def test_responsibleai_adult_duplicate_cohort_names(
-            self, create_rai_insights_object):
-        ri = create_rai_insights_object
+            self, create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
 
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,

--- a/raiwidgets/tests/test_responsibleai_dashboard_input.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard_input.py
@@ -8,8 +8,9 @@ from raiwidgets.responsibleai_dashboard_input import \
 
 
 class TestResponsibleAIDashboardInput:
-    def test_model_analysis_adult(self, create_rai_insights_object):
-        ri = create_rai_insights_object
+    def test_model_analysis_adult(
+            self, create_rai_insights_object_classification):
+        ri = create_rai_insights_object_classification
         knn = ri.model
         test_data = ri.test
 


### PR DESCRIPTION
## Description

Add regression test for pre-defined cohorts in raiwidgets using housing dataset.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
