### PR TITLE
refactor tabs out of RAI dashboard into a separate component

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -328,8 +328,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       showMessageBar: false,
       viewType: ViewTypeKeys.ErrorAnalysisView,
       weightVectorLabels,
-      weightVectorOptions,
-      whatIfChartConfig: undefined
+      weightVectorOptions
     };
   }
 

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
@@ -25,7 +25,6 @@ export interface IErrorAnalysisDashboardState
   modelMetadata: IExplanationModelMetadata;
   modelChartConfig?: IGenericChartProps;
   dataChartConfig?: IGenericChartProps;
-  whatIfChartConfig?: IGenericChartProps;
   dependenceProps?: IGenericChartProps;
   globalImportanceIntercept: number[];
   globalImportance: number[][];

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -6,8 +6,6 @@ import {
   ISingleClassLocalFeatureImportance,
   JointDataset,
   Cohort,
-  WeightVectors,
-  ModelTypes,
   IExplanationModelMetadata,
   isThreeDimArray,
   ErrorCohort,
@@ -71,21 +69,6 @@ export function buildInitialModelAssessmentContext(
   errorCohortList = errorCohortList.concat(preBuiltErrorCohortList);
   const cohorts = errorCohortList;
 
-  const weightVectorLabels = {
-    [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
-  };
-  const weightVectorOptions = [];
-  if (modelMetadata.modelType === ModelTypes.Multiclass) {
-    weightVectorOptions.push(WeightVectors.AbsAvg);
-  }
-  modelMetadata.classNames.forEach((name, index) => {
-    weightVectorLabels[index] = localization.formatString(
-      localization.Interpret.WhatIfTab.classLabel,
-      name
-    );
-    weightVectorOptions.push(index);
-  });
-
   // only include tabs for which we have the required data
   const activeGlobalTabs: IModelAssessmentDashboardTab[] = getAvailableTabs(
     props,
@@ -97,7 +80,6 @@ export function buildInitialModelAssessmentContext(
       name: item.text as string
     };
   });
-  const importances = props.errorAnalysisData?.[0]?.importances ?? [];
   return {
     activeGlobalTabs,
     baseCohort: cohorts[0],
@@ -108,26 +90,15 @@ export function buildInitialModelAssessmentContext(
     errorAnalysisOption: ErrorAnalysisOptions.TreeMap,
     globalImportance: globalProps.globalImportance,
     globalImportanceIntercept: globalProps.globalImportanceIntercept,
-    importances,
     isGlobalImportanceDerivedFromLocal:
       globalProps.isGlobalImportanceDerivedFromLocal,
     jointDataset,
-    mapShiftErrorAnalysisOption: ErrorAnalysisOptions.TreeMap,
-    mapShiftVisible: false,
     modelChartConfig: undefined,
     modelMetadata,
     saveCohortVisible: false,
     selectedCohort: cohorts[0],
-    selectedFeatures: props.dataset.feature_names,
-    selectedWeightVector:
-      modelMetadata.modelType === ModelTypes.Multiclass
-        ? WeightVectors.AbsAvg
-        : 0,
     selectedWhatIfIndex: undefined,
-    sortVector: undefined,
-    weightVectorLabels,
-    weightVectorOptions,
-    whatIfChartConfig: undefined
+    sortVector: undefined
   };
 }
 

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.styles.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme
+} from "office-ui-fabric-react";
+
+export interface ITabsViewStyles {
+  section: IStyle;
+  sectionHeader: IStyle;
+  buttonSection: IStyle;
+}
+
+export const tabsViewStyles: () => IProcessedStyleSet<ITabsViewStyles> = () => {
+  const theme = getTheme();
+  return mergeStyleSets<ITabsViewStyles>({
+    buttonSection: {
+      textAlign: "center"
+    },
+    section: {
+      textAlign: "left"
+    },
+    sectionHeader: {
+      color: theme.semanticColors.bodyText,
+      padding: "16px 24px 16px 40px"
+    }
+  });
+};

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CausalInsightsTab } from "@responsible-ai/causality";
+import {
+  WeightVectorOption,
+  ModelTypes,
+  WeightVectors
+} from "@responsible-ai/core-ui";
+import { CounterfactualsTab } from "@responsible-ai/counterfactuals";
+import { DatasetExplorerTab } from "@responsible-ai/dataset-explorer";
+import {
+  ErrorAnalysisOptions,
+  ErrorAnalysisViewTab,
+  MapShift,
+  MatrixArea,
+  MatrixFilter,
+  TreeViewRenderer
+} from "@responsible-ai/error-analysis";
+import { localization } from "@responsible-ai/localization";
+import _, { Dictionary } from "lodash";
+import { DefaultEffects, PivotItem, Stack, Text } from "office-ui-fabric-react";
+import * as React from "react";
+
+import { AddTabButton } from "../../AddTabButton";
+import { GlobalTabKeys } from "../../ModelAssessmentEnums";
+import { FeatureImportancesTab } from "../FeatureImportances";
+import { ModelOverview } from "../ModelOverview";
+
+import { tabsViewStyles } from "./TabsView.styles";
+import { ITabsViewProps } from "./TabsViewProps";
+
+export interface ITabsViewState {
+  errorAnalysisOption: ErrorAnalysisOptions;
+  importances: number[];
+  mapShiftErrorAnalysisOption: ErrorAnalysisOptions;
+  mapShiftVisible: boolean;
+  selectedFeatures: string[];
+  selectedWeightVector: WeightVectorOption;
+  weightVectorLabels: Dictionary<string>;
+  weightVectorOptions: WeightVectorOption[];
+}
+
+export class TabsView extends React.PureComponent<
+  ITabsViewProps,
+  ITabsViewState
+> {
+  public constructor(props: ITabsViewProps) {
+    super(props);
+    const weightVectorLabels = {
+      [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
+    };
+    const weightVectorOptions = [];
+    if (props.modelMetadata.modelType === ModelTypes.Multiclass) {
+      weightVectorOptions.push(WeightVectors.AbsAvg);
+    }
+    props.modelMetadata.classNames.forEach((name, index) => {
+      weightVectorLabels[index] = localization.formatString(
+        localization.Interpret.WhatIfTab.classLabel,
+        name
+      );
+      weightVectorOptions.push(index);
+    });
+    const importances = props.errorAnalysisData?.[0]?.importances ?? [];
+    this.state = {
+      errorAnalysisOption: ErrorAnalysisOptions.TreeMap,
+      importances,
+      mapShiftErrorAnalysisOption: ErrorAnalysisOptions.TreeMap,
+      mapShiftVisible: false,
+      selectedFeatures: props.dataset.feature_names,
+      selectedWeightVector:
+        props.modelMetadata.modelType === ModelTypes.Multiclass
+          ? WeightVectors.AbsAvg
+          : 0,
+      weightVectorLabels,
+      weightVectorOptions
+    };
+    if (this.props.requestImportances) {
+      this.props
+        .requestImportances([], new AbortController().signal)
+        .then((result) => {
+          this.setState({ importances: result });
+        });
+    }
+  }
+
+  public render(): React.ReactNode {
+    const disabledView =
+      this.props.requestDebugML === undefined &&
+      this.props.requestMatrix === undefined &&
+      this.props.baseCohort.cohort.name !==
+        localization.ErrorAnalysis.Cohort.defaultLabel;
+    const classNames = tabsViewStyles();
+    return (
+      <Stack tokens={{ childrenGap: "10px", padding: "50px 0 0 0" }}>
+        {this.props.activeGlobalTabs[0]?.key !==
+          GlobalTabKeys.ErrorAnalysisTab && (
+          <Stack.Item className={classNames.buttonSection}>
+            <AddTabButton
+              tabIndex={0}
+              onAdd={this.props.addTab}
+              availableTabs={this.props.addTabDropdownOptions}
+            />
+          </Stack.Item>
+        )}
+        {this.props.activeGlobalTabs.map((t, i) => (
+          <>
+            <Stack.Item
+              key={i}
+              className={classNames.section}
+              styles={{ root: { boxShadow: DefaultEffects.elevation4 } }}
+            >
+              {t.key === GlobalTabKeys.ErrorAnalysisTab &&
+                this.props.errorAnalysisData?.[0] && (
+                  <ErrorAnalysisViewTab
+                    disabledView={disabledView}
+                    tree={this.props.errorAnalysisData[0].tree}
+                    matrix={this.props.errorAnalysisData[0].matrix}
+                    matrixFeatures={
+                      this.props.errorAnalysisData[0].matrix_features
+                    }
+                    messages={this.props.stringParams?.contextualHelp}
+                    getTreeNodes={this.props.requestDebugML}
+                    getMatrix={this.props.requestMatrix}
+                    updateSelectedCohort={this.props.updateSelectedCohort}
+                    features={
+                      this.props.errorAnalysisData[0].tree_features ||
+                      this.props.dataset.feature_names
+                    }
+                    selectedFeatures={this.state.selectedFeatures}
+                    errorAnalysisOption={this.state.errorAnalysisOption}
+                    selectedCohort={this.props.selectedCohort}
+                    baseCohort={this.props.baseCohort}
+                    selectFeatures={(features: string[]): void =>
+                      this.setState({ selectedFeatures: features })
+                    }
+                    importances={this.state.importances}
+                    onSaveCohortClick={(): void => {
+                      this.props.setSaveCohortVisible();
+                    }}
+                    showCohortName={false}
+                    handleErrorDetectorChanged={this.handleErrorDetectorChanged}
+                    selectedKey={this.state.errorAnalysisOption}
+                  />
+                )}
+              {t.key === GlobalTabKeys.ModelOverviewTab && (
+                <>
+                  <div className={classNames.sectionHeader}>
+                    <Text variant={"xxLarge"} id="modelStatisticsHeader">
+                      {
+                        localization.ModelAssessment.ComponentNames
+                          .ModelOverview
+                      }
+                    </Text>
+                  </div>
+                  <ModelOverview />
+                </>
+              )}
+              {t.key === GlobalTabKeys.DataExplorerTab && (
+                <>
+                  <div className={classNames.sectionHeader}>
+                    <Text variant={"xxLarge"} id="dataExplorerHeader">
+                      {localization.ModelAssessment.ComponentNames.DataExplorer}
+                    </Text>
+                  </div>
+                  <DatasetExplorerTab />
+                </>
+              )}
+              {t.key === GlobalTabKeys.FeatureImportancesTab &&
+                this.props.modelExplanationData?.[0] && (
+                  <FeatureImportancesTab
+                    modelMetadata={this.props.modelMetadata}
+                    modelExplanationData={this.props.modelExplanationData}
+                    selectedWeightVector={this.state.selectedWeightVector}
+                    weightVectorOptions={this.state.weightVectorOptions}
+                    weightVectorLabels={this.state.weightVectorLabels}
+                    requestPredictions={this.props.requestPredictions}
+                    onWeightVectorChange={this.onWeightVectorChange}
+                  />
+                )}
+              {t.key === GlobalTabKeys.CausalAnalysisTab &&
+                this.props.causalAnalysisData?.[0] && (
+                  <CausalInsightsTab
+                    data={this.props.causalAnalysisData?.[0]}
+                  />
+                )}
+
+              {t.key === GlobalTabKeys.CounterfactualsTab &&
+                this.props.counterfactualData?.[0] && (
+                  <CounterfactualsTab
+                    data={this.props.counterfactualData?.[0]}
+                  />
+                )}
+            </Stack.Item>
+            <Stack.Item className={classNames.buttonSection}>
+              <AddTabButton
+                tabIndex={i + 1}
+                onAdd={this.props.addTab}
+                availableTabs={this.props.addTabDropdownOptions}
+              />
+            </Stack.Item>
+          </>
+        ))}
+        {this.state.mapShiftVisible && (
+          <MapShift
+            currentOption={this.state.mapShiftErrorAnalysisOption}
+            isOpen={this.state.mapShiftVisible}
+            onDismiss={(): void =>
+              this.setState({
+                errorAnalysisOption: this.state.errorAnalysisOption,
+                mapShiftVisible: false
+              })
+            }
+            onSave={(): void => {
+              this.setState({
+                mapShiftVisible: false
+              });
+              this.props.setSaveCohortVisible();
+            }}
+            onShift={(): void => {
+              // reset all states on shift
+              MatrixFilter.resetState();
+              MatrixArea.resetState();
+              TreeViewRenderer.resetState();
+              this.setState({
+                errorAnalysisOption: this.state.mapShiftErrorAnalysisOption,
+                mapShiftVisible: false
+              });
+              this.props.setSelectedCohort(this.props.baseCohort);
+            }}
+          />
+        )}
+      </Stack>
+    );
+  }
+
+  private onWeightVectorChange = (weightOption: WeightVectorOption): void => {
+    this.props.jointDataset.buildLocalFlattenMatrix(weightOption);
+    this.props.cohorts.forEach((errorCohort) =>
+      errorCohort.cohort.clearCachedImportances()
+    );
+    this.setState({ selectedWeightVector: weightOption });
+  };
+
+  private handleErrorDetectorChanged = (item?: PivotItem): void => {
+    if (item && item.props.itemKey) {
+      // Note comparison below is actually string comparison (key is string), we have to set the enum
+      if (item.props.itemKey === ErrorAnalysisOptions.HeatMap) {
+        const selectedOptionHeatMap = ErrorAnalysisOptions.HeatMap;
+        this.setErrorDetector(selectedOptionHeatMap);
+      } else {
+        const selectedOptionTreeMap = ErrorAnalysisOptions.TreeMap;
+        this.setErrorDetector(selectedOptionTreeMap);
+      }
+    }
+  };
+
+  private setErrorDetector = (key: ErrorAnalysisOptions): void => {
+    if (this.props.selectedCohort.isTemporary) {
+      this.setState({
+        mapShiftErrorAnalysisOption: key,
+        mapShiftVisible: true
+      });
+    } else {
+      this.setState({
+        errorAnalysisOption: key
+      });
+    }
+  };
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsViewProps.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsViewProps.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  ErrorCohort,
+  CohortSource,
+  IModelExplanationData,
+  IDataset,
+  IErrorAnalysisData,
+  ICausalAnalysisData,
+  ICounterfactualData,
+  IErrorAnalysisTreeNode,
+  IErrorAnalysisMatrix,
+  IPreBuiltCohort,
+  JointDataset,
+  IFilter,
+  ICompositeFilter,
+  MetricCohortStats,
+  IExplanationModelMetadata
+} from "@responsible-ai/core-ui";
+import { IStringsParam } from "@responsible-ai/error-analysis";
+import { IDropdownOption } from "office-ui-fabric-react";
+
+import { IModelAssessmentDashboardTab } from "../../ModelAssessmentDashboardState";
+import { GlobalTabKeys } from "../../ModelAssessmentEnums";
+
+export interface ITabsViewProps {
+  modelExplanationData?: Array<
+    Omit<IModelExplanationData, "method" | "predictedY" | "probabilityY">
+  >;
+  causalAnalysisData?: ICausalAnalysisData[];
+  counterfactualData?: ICounterfactualData[];
+  errorAnalysisData?: IErrorAnalysisData[];
+  cohortData?: IPreBuiltCohort[];
+  cohorts: ErrorCohort[];
+  jointDataset: JointDataset;
+  activeGlobalTabs: IModelAssessmentDashboardTab[];
+  baseCohort: ErrorCohort;
+  selectedCohort: ErrorCohort;
+  dataset: IDataset;
+  requestPredictions?: (
+    request: any[],
+    abortSignal: AbortSignal
+  ) => Promise<any[]>;
+  requestDebugML?: (
+    request: any[],
+    abortSignal: AbortSignal
+  ) => Promise<IErrorAnalysisTreeNode[]>;
+  requestImportances?: (
+    request: any[],
+    abortSignal: AbortSignal
+  ) => Promise<any[]>;
+  requestMatrix?: (
+    request: any[],
+    abortSignal: AbortSignal
+  ) => Promise<IErrorAnalysisMatrix>;
+  stringParams?: IStringsParam;
+  updateSelectedCohort: (
+    filters: IFilter[],
+    compositeFilters: ICompositeFilter[],
+    source: CohortSource,
+    cells: number,
+    cohortStats: MetricCohortStats | undefined
+  ) => void;
+  setSaveCohortVisible: () => void;
+  setSelectedCohort: (cohort: ErrorCohort) => void;
+  modelMetadata: IExplanationModelMetadata;
+  addTabDropdownOptions: IDropdownOption[];
+  addTab: (index: number, tab: GlobalTabKeys) => void;
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -1,46 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { CausalInsightsTab } from "@responsible-ai/causality";
 import {
   CohortBasedComponent,
   ModelAssessmentContext,
   ErrorCohort,
-  WeightVectorOption,
   CohortSource,
   Cohort,
   SaveCohort,
   defaultTheme
 } from "@responsible-ai/core-ui";
-import { CounterfactualsTab } from "@responsible-ai/counterfactuals";
-import { DatasetExplorerTab } from "@responsible-ai/dataset-explorer";
-import {
-  ErrorAnalysisOptions,
-  ErrorAnalysisViewTab,
-  MapShift,
-  MatrixArea,
-  MatrixFilter,
-  TreeViewRenderer
-} from "@responsible-ai/error-analysis";
 import { localization } from "@responsible-ai/localization";
 import _ from "lodash";
 import {
-  DefaultEffects,
   getTheme,
   IDropdownOption,
   loadTheme,
-  PivotItem,
-  Stack,
-  Text
+  Stack
 } from "office-ui-fabric-react";
 import * as React from "react";
 
-import { AddTabButton } from "./AddTabButton";
 import { getAvailableTabs } from "./AvailableTabs";
 import { buildInitialModelAssessmentContext } from "./Context/buildModelAssessmentContext";
-import { FeatureImportancesTab } from "./Controls/FeatureImportances";
 import { MainMenu } from "./Controls/MainMenu";
-import { ModelOverview } from "./Controls/ModelOverview";
+import { TabsView } from "./Controls/TabsView/TabsView";
 import { modelAssessmentDashboardStyles } from "./ModelAssessmentDashboard.styles";
 import { IModelAssessmentDashboardProps } from "./ModelAssessmentDashboardProps";
 import { IModelAssessmentDashboardState } from "./ModelAssessmentDashboardState";
@@ -60,14 +43,6 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
     this.state = buildInitialModelAssessmentContext(_.cloneDeep(props));
     loadTheme(props.theme || defaultTheme);
     this.addTabDropdownOptions = getAvailableTabs(this.props, true);
-
-    if (this.props.requestImportances) {
-      this.props
-        .requestImportances([], new AbortController().signal)
-        .then((result) => {
-          this.setState({ importances: result });
-        });
-    }
   }
   public componentDidUpdate(prev: IModelAssessmentDashboardProps): void {
     if (prev.theme !== this.props.theme) {
@@ -79,11 +54,6 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
   }
 
   public render(): React.ReactNode {
-    const disabledView =
-      this.props.requestDebugML === undefined &&
-      this.props.requestMatrix === undefined &&
-      this.state.baseCohort.cohort.name !==
-        localization.ErrorAnalysis.Cohort.defaultLabel;
     const classNames = modelAssessmentDashboardStyles();
     return (
       <ModelAssessmentContext.Provider
@@ -126,121 +96,30 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
             removeTab={this.removeTab}
           />
           <Stack.Item className={classNames.mainContent}>
-            <Stack tokens={{ childrenGap: "10px", padding: "50px 0 0 0" }}>
-              {this.state.activeGlobalTabs[0]?.key !==
-                GlobalTabKeys.ErrorAnalysisTab && (
-                <Stack.Item className={classNames.buttonSection}>
-                  <AddTabButton
-                    tabIndex={0}
-                    onAdd={this.addTab}
-                    availableTabs={this.addTabDropdownOptions}
-                  />
-                </Stack.Item>
-              )}
-              {this.state.activeGlobalTabs.map((t, i) => (
-                <>
-                  <Stack.Item
-                    key={i}
-                    className={classNames.section}
-                    styles={{ root: { boxShadow: DefaultEffects.elevation4 } }}
-                  >
-                    {t.key === GlobalTabKeys.ErrorAnalysisTab &&
-                      this.props.errorAnalysisData?.[0] && (
-                        <ErrorAnalysisViewTab
-                          disabledView={disabledView}
-                          tree={this.props.errorAnalysisData[0].tree}
-                          matrix={this.props.errorAnalysisData[0].matrix}
-                          matrixFeatures={
-                            this.props.errorAnalysisData[0].matrix_features
-                          }
-                          messages={this.props.stringParams?.contextualHelp}
-                          getTreeNodes={this.props.requestDebugML}
-                          getMatrix={this.props.requestMatrix}
-                          updateSelectedCohort={this.updateSelectedCohort}
-                          features={
-                            this.props.errorAnalysisData[0].tree_features ||
-                            this.props.dataset.feature_names
-                          }
-                          selectedFeatures={this.state.selectedFeatures}
-                          errorAnalysisOption={this.state.errorAnalysisOption}
-                          selectedCohort={this.state.selectedCohort}
-                          baseCohort={this.state.baseCohort}
-                          selectFeatures={(features: string[]): void =>
-                            this.setState({ selectedFeatures: features })
-                          }
-                          importances={this.state.importances}
-                          onSaveCohortClick={(): void => {
-                            this.setState({ saveCohortVisible: true });
-                          }}
-                          showCohortName={false}
-                          handleErrorDetectorChanged={
-                            this.handleErrorDetectorChanged
-                          }
-                          selectedKey={this.state.errorAnalysisOption}
-                        />
-                      )}
-                    {t.key === GlobalTabKeys.ModelOverviewTab && (
-                      <>
-                        <div className={classNames.sectionHeader}>
-                          <Text variant={"xxLarge"} id="modelStatisticsHeader">
-                            {
-                              localization.ModelAssessment.ComponentNames
-                                .ModelOverview
-                            }
-                          </Text>
-                        </div>
-                        <ModelOverview />
-                      </>
-                    )}
-                    {t.key === GlobalTabKeys.DataExplorerTab && (
-                      <>
-                        <div className={classNames.sectionHeader}>
-                          <Text variant={"xxLarge"} id="dataExplorerHeader">
-                            {
-                              localization.ModelAssessment.ComponentNames
-                                .DataExplorer
-                            }
-                          </Text>
-                        </div>
-                        <DatasetExplorerTab />
-                      </>
-                    )}
-                    {t.key === GlobalTabKeys.FeatureImportancesTab &&
-                      this.props.modelExplanationData?.[0] && (
-                        <FeatureImportancesTab
-                          modelMetadata={this.state.modelMetadata}
-                          modelExplanationData={this.props.modelExplanationData}
-                          selectedWeightVector={this.state.selectedWeightVector}
-                          weightVectorOptions={this.state.weightVectorOptions}
-                          weightVectorLabels={this.state.weightVectorLabels}
-                          requestPredictions={this.props.requestPredictions}
-                          onWeightVectorChange={this.onWeightVectorChange}
-                        />
-                      )}
-                    {t.key === GlobalTabKeys.CausalAnalysisTab &&
-                      this.props.causalAnalysisData?.[0] && (
-                        <CausalInsightsTab
-                          data={this.props.causalAnalysisData?.[0]}
-                        />
-                      )}
-
-                    {t.key === GlobalTabKeys.CounterfactualsTab &&
-                      this.props.counterfactualData?.[0] && (
-                        <CounterfactualsTab
-                          data={this.props.counterfactualData?.[0]}
-                        />
-                      )}
-                  </Stack.Item>
-                  <Stack.Item className={classNames.buttonSection}>
-                    <AddTabButton
-                      tabIndex={i + 1}
-                      onAdd={this.addTab}
-                      availableTabs={this.addTabDropdownOptions}
-                    />
-                  </Stack.Item>
-                </>
-              ))}
-            </Stack>
+            <TabsView
+              modelExplanationData={this.props.modelExplanationData}
+              causalAnalysisData={this.props.causalAnalysisData}
+              counterfactualData={this.props.counterfactualData}
+              errorAnalysisData={this.props.errorAnalysisData}
+              cohortData={this.props.cohortData}
+              cohorts={this.state.cohorts}
+              jointDataset={this.state.jointDataset}
+              activeGlobalTabs={this.state.activeGlobalTabs}
+              baseCohort={this.state.baseCohort}
+              selectedCohort={this.state.selectedCohort}
+              dataset={this.props.dataset}
+              requestPredictions={this.props.requestPredictions}
+              requestDebugML={this.props.requestDebugML}
+              requestImportances={this.props.requestImportances}
+              requestMatrix={this.props.requestMatrix}
+              stringParams={this.props.stringParams}
+              updateSelectedCohort={this.updateSelectedCohort}
+              setSaveCohortVisible={this.setSaveCohortVisible}
+              setSelectedCohort={this.setSelectedCohort}
+              modelMetadata={this.state.modelMetadata}
+              addTabDropdownOptions={this.addTabDropdownOptions}
+              addTab={this.addTab}
+            />
           </Stack.Item>
           {this.state.saveCohortVisible && (
             <SaveCohort
@@ -253,39 +132,14 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
               baseCohort={this.state.baseCohort}
             />
           )}
-          {this.state.mapShiftVisible && (
-            <MapShift
-              currentOption={this.state.mapShiftErrorAnalysisOption}
-              isOpen={this.state.mapShiftVisible}
-              onDismiss={(): void =>
-                this.setState({
-                  errorAnalysisOption: this.state.errorAnalysisOption,
-                  mapShiftVisible: false
-                })
-              }
-              onSave={(): void => {
-                this.setState({
-                  mapShiftVisible: false,
-                  saveCohortVisible: true
-                });
-              }}
-              onShift={(): void => {
-                // reset all states on shift
-                MatrixFilter.resetState();
-                MatrixArea.resetState();
-                TreeViewRenderer.resetState();
-                this.setState({
-                  errorAnalysisOption: this.state.mapShiftErrorAnalysisOption,
-                  mapShiftVisible: false,
-                  selectedCohort: this.state.baseCohort
-                });
-              }}
-            />
-          )}
         </Stack>
       </ModelAssessmentContext.Provider>
     );
   }
+
+  private setSaveCohortVisible = (): void => {
+    this.setState({ saveCohortVisible: true });
+  };
 
   private addTab = (index: number, tab: GlobalTabKeys): void => {
     const tabs = [...this.state.activeGlobalTabs];
@@ -310,43 +164,15 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
     this.setState({ activeGlobalTabs: tabs });
   };
 
-  private onWeightVectorChange = (weightOption: WeightVectorOption): void => {
-    this.state.jointDataset.buildLocalFlattenMatrix(weightOption);
-    this.state.cohorts.forEach((errorCohort) =>
-      errorCohort.cohort.clearCachedImportances()
-    );
-    this.setState({ selectedWeightVector: weightOption });
-  };
-
-  private handleErrorDetectorChanged = (item?: PivotItem): void => {
-    if (item && item.props.itemKey) {
-      // Note comparison below is actually string comparison (key is string), we have to set the enum
-      if (item.props.itemKey === ErrorAnalysisOptions.HeatMap) {
-        const selectedOptionHeatMap = ErrorAnalysisOptions.HeatMap;
-        this.setErrorDetector(selectedOptionHeatMap);
-      } else {
-        const selectedOptionTreeMap = ErrorAnalysisOptions.TreeMap;
-        this.setErrorDetector(selectedOptionTreeMap);
-      }
-    }
-  };
-
-  private setErrorDetector = (key: ErrorAnalysisOptions): void => {
-    if (this.state.selectedCohort.isTemporary) {
-      this.setState({
-        mapShiftErrorAnalysisOption: key,
-        mapShiftVisible: true
-      });
-    } else {
-      this.setState({
-        errorAnalysisOption: key
-      });
-    }
-  };
-
   private shiftErrorCohort = (cohort: ErrorCohort) => {
     this.setState({
       baseCohort: cohort,
+      selectedCohort: cohort
+    });
+  };
+
+  private setSelectedCohort = (cohort: ErrorCohort): void => {
+    this.setState({
       selectedCohort: cohort
     });
   };

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboardState.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboardState.ts
@@ -4,11 +4,9 @@
 import {
   IExplanationModelMetadata,
   IGenericChartProps,
-  WeightVectorOption,
   ICohortBasedComponentState
 } from "@responsible-ai/core-ui";
 import { ErrorAnalysisOptions } from "@responsible-ai/error-analysis";
-import { Dictionary } from "lodash";
 
 import { GlobalTabKeys } from "./ModelAssessmentEnums";
 
@@ -19,22 +17,14 @@ export interface IModelAssessmentDashboardState
   modelMetadata: IExplanationModelMetadata;
   modelChartConfig?: IGenericChartProps;
   dataChartConfig?: IGenericChartProps;
-  whatIfChartConfig?: IGenericChartProps;
   dependenceProps?: IGenericChartProps;
   globalImportanceIntercept: number[];
   globalImportance: number[][];
-  importances: number[];
   isGlobalImportanceDerivedFromLocal: boolean;
   sortVector?: number[];
   editingCohortIndex?: number;
-  mapShiftErrorAnalysisOption: ErrorAnalysisOptions;
-  mapShiftVisible: boolean;
   selectedWhatIfIndex: number | undefined;
-  selectedFeatures: string[];
   errorAnalysisOption: ErrorAnalysisOptions;
-  selectedWeightVector: WeightVectorOption;
-  weightVectorOptions: WeightVectorOption[];
-  weightVectorLabels: Dictionary<string>;
   saveCohortVisible: boolean;
 }
 


### PR DESCRIPTION
## Description

Refactor tabs out of RAI dashboard into a separate component.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [x] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
