### PR TITLE
fix notebook build failures due to pywinpty dependency release failing in python 3.6

### DIFF
--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -41,6 +41,12 @@ jobs:
         run: |
           conda install --yes --quiet pytorch torchvision captum -c pytorch
 
+      - if: ${{ matrix.operatingSystem == 'windows-latest' }}
+        name: build pywinpty from conda
+        shell: bash -l {0}
+        run: |
+          conda install -c conda-forge pywinpty
+
       - name: Setup tools
         shell: bash -l {0}
         run: |

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -45,7 +45,7 @@ jobs:
         name: build pywinpty from conda
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge pywinpty
+          conda install -c conda-forge pywinpty>=1.1.0
 
       - name: Setup tools
         shell: bash -l {0}

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -41,12 +41,6 @@ jobs:
         run: |
           conda install --yes --quiet pytorch torchvision captum -c pytorch
 
-      - if: ${{ matrix.operatingSystem == 'windows-latest' }}
-        name: build pywinpty from conda
-        shell: bash -l {0}
-        run: |
-          conda install -c conda-forge pywinpty>=1.1.0
-
       - name: Setup tools
         shell: bash -l {0}
         run: |

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -15,6 +15,9 @@ lightgbm==2.3.0
 
 fairlearn==0.6.0
 
+# Jupyter dependency that fails with python 3.6
+pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'windows'
+
 # Required for notebook tests
 nbformat
 papermill

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -16,7 +16,7 @@ lightgbm==2.3.0
 fairlearn==0.6.0
 
 # Jupyter dependency that fails with python 3.6
-pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'windows'
+pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'
 
 # Required for notebook tests
 nbformat

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -15,9 +15,6 @@ lightgbm==2.3.0
 
 fairlearn==0.6.0
 
-# Jupyter dependency that fails with python 3.6
-pywinpty==2.0.2; python_version <= '3.6'
-
 # Required for notebook tests
 nbformat
 papermill

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -15,6 +15,9 @@ lightgbm==2.3.0
 
 fairlearn==0.6.0
 
+# Jupyter dependency that fails with python 3.6
+pywinpty==2.0.2; python_version <= '3.6'
+
 # Required for notebook tests
 nbformat
 papermill


### PR DESCRIPTION
## Description

fix notebook build failures due to pywinpty dependency release failing in python 3.6
related issue:
https://github.com/spyder-ide/pywinpty/issues/218

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
