### PR TITLE
Add supported models, data types and capability matrix to README.md responsibleai

### DIFF
--- a/responsibleai/README.md
+++ b/responsibleai/README.md
@@ -11,5 +11,19 @@ Highlights of the package include:
 - `error_analysis.add()` runs error analysis
 - `causal.add()` runs causal analysis
 
+### Supported scenarios, models and datasets
+
+`responsibleai` supports computation of Responsible AI insights for `scikit-learn` models that are trained on `pandas.DataFrame`. The `responsibleai` accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the `scikit-learn` convention. If not compatible, you can wrap your model's prediction function into a wrapper class that transforms the output into the format that is supported (`predict` or `predict_proba` of `scikit-learn`), and pass that wrapper class to modules in `responsibleai`.
+
+Currently, we support datasets having numerical and categorical features. The following table provides the scenarios supported for each of the four responsible AI insights:-
+
+| RAI insight | Binary classification | Multi-class classification | Multilabel classification | Regression | Timeseries forecasting | Categorical features | Text features | Image Features | Recommender Systems | Reinforcement Learning |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | -- |
+| Explainability | Yes | Yes | No | Yes | No | Yes | No | No | No | No |
+| Error Analysis | Yes | Yes | No | Yes | No | Yes | No | No | No | No |
+| Causal Analysis | Yes | No | No | Yes | No | Yes (max 5 features due to expensiveness) | No | No | No | No |
+| Counterfactual | Yes | Yes | No | Yes | No | Yes | No | No | No | No |
+
+
 The source code can be found here:
-https://github.com/microsoft/responsible-ai-widgets
+https://github.com/microsoft/responsible-ai-toolbox/tree/main/responsibleai


### PR DESCRIPTION
## Description

This is based on one of the customer feedback that responsibleai lacked the supported models and data type information. 

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [x] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
