### PR TITLE
Counterfactual Chart: Correct target description according to task_type

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -327,7 +327,7 @@ export class CounterfactualChart extends React.PureComponent<
                   styles={FabricStyles.smallDropdownStyle}
                 />
                 <div className={classNames.legendLabel}>
-                  <b>{`${localization.Counterfactuals.currentClass}: `}</b>
+                  <b>{`${this.getTargetIdentifier()}: `}</b>
                   {this.getCurrentLabel()}
                 </div>
                 <PrimaryButton
@@ -389,6 +389,13 @@ export class CounterfactualChart extends React.PureComponent<
       );
     }
     return this.props.data.desired_class || "";
+  }
+
+  private getTargetIdentifier(): string {
+    if (this.context.dataset.task_type === "regression") {
+      return localization.Counterfactuals.currentRange;
+    }
+    return localization.Counterfactuals.currentClass;
   }
 
   private buildRowOptions(cohortIndex: number): void {

--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -327,7 +327,7 @@ export class CounterfactualChart extends React.PureComponent<
                   styles={FabricStyles.smallDropdownStyle}
                 />
                 <div className={classNames.legendLabel}>
-                  <b>{`${this.getTargetIdentifier()}: `}</b>
+                  <b>{`${this.getTargetDescription()}: `}</b>
                   {this.getCurrentLabel()}
                 </div>
                 <PrimaryButton
@@ -391,7 +391,7 @@ export class CounterfactualChart extends React.PureComponent<
     return this.props.data.desired_class || "";
   }
 
-  private getTargetIdentifier(): string {
+  private getTargetDescription(): string {
     if (this.context.dataset.task_type === "regression") {
       return localization.Counterfactuals.currentRange;
     }

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -109,7 +109,7 @@
     "createCounterfactual": "Counterfactual",
     "createOwn": "Create your own counterfactual:",
     "currentClass": "Current class",
-    "currentRange": "Current Range",
+    "currentRange": "Current range",
     "decreaseByOne": "Decrease value by 1",
     "desiredClass": "Desired class for counterfactual(s)",
     "header": "What-If counterfactuals",

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -109,6 +109,7 @@
     "createCounterfactual": "Counterfactual",
     "createOwn": "Create your own counterfactual:",
     "currentClass": "Current class",
+    "currentRange": "Current Range",
     "decreaseByOne": "Decrease value by 1",
     "desiredClass": "Desired class for counterfactual(s)",
     "header": "What-If counterfactuals",


### PR DESCRIPTION
## Description

For regression, we say "Current class" which is incorrect. Hence, for regression we display "Current range" and for classification we say "Current class". 

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

Classification output:-
![image](https://user-images.githubusercontent.com/47334368/156921002-d913f57d-3101-4986-ac3b-9b39acdabffe.png)

Regression output:-
![image](https://user-images.githubusercontent.com/47334368/156921023-050dd5bc-6b49-4959-a7ca-933fd4cd86ce.png)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
