### PR TITLE
add a builddebug yarn command to build UX locally which can be debugged in browser e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "auto-version": "node ./scripts/auto-version.js",
     "build": "nx build",
     "buildall": "cross-env NODE_OPTIONS=--max_old_space_size=6144 nx run-many --target=build --configuration=production --all",
+    "builddebug": "cross-env NODE_OPTIONS=--max_old_space_size=6144 nx run-many --target=build --all",
     "ci": "yarn install --frozen-lock-file && yarn testall --codeCoverage && yarn lintall && yarn buildall && yarn e2e",
     "copytest": "node ./scripts/copyTest.js",
     "dep-graph": "nx dep-graph",


### PR DESCRIPTION
## Description

I was using this "yarn builddebug" command locally to debug e2e workflows with the widget and then I realized others may find this command useful as well, hence this small PR.

How to use it:
When debugging e2e workflows with the widget, users can run this

```yarn builddebug```

command and then

```pip install -e .```

inside the raiwidgets folder.  Then they can run the widget in notebooks as usual.  Without this command, trying to debug with F12 is impossible because the code is minified and the whole program is just several lines of javascript.  With this command, I am able to step through the javascript code.

Note this should not be used in production workflows.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
