### PR TITLE
remove duplicate code in explanation dashboard

### DIFF
--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -398,7 +398,7 @@ export class JointDataset {
     }
   }
 
-  private static buildLocalFeatureMatrix(
+  public static buildLocalFeatureMatrix(
     localExplanationRaw: number[][] | number[][][],
     modelType: ModelTypes
   ): number[][][] {


### PR DESCRIPTION
## Description

Remove duplicate code in explanation dashboard.
Specifically, removes the methods transposeLocalImportanceMatrix and buildLocalFeatureMatrix which are exact copies of the same methods in JointDataset.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
