### PR TITLE
Disable column header highlighting on hover in IndividualFeatureImportanceView

### DIFF
--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IColumn } from "office-ui-fabric-react";
+import { ColumnActionsMode, IColumn } from "office-ui-fabric-react";
 
 import { JointDataset } from "../util/JointDataset";
 
@@ -84,7 +84,8 @@ export function constructCols(
     key: "column0",
     maxWidth: 100,
     minWidth: 50,
-    name: "Index"
+    name: "Index",
+    columnActionsMode: ColumnActionsMode.disabled
   });
   let index = 1;
   if (hasColors) {
@@ -94,7 +95,8 @@ export function constructCols(
       key: "color",
       maxWidth: 100,
       minWidth: 50,
-      name: "Color"
+      name: "Color",
+      columnActionsMode: ColumnActionsMode.disabled
     });
     index++;
   }
@@ -105,7 +107,8 @@ export function constructCols(
       key: `column${index}`,
       maxWidth: 100,
       minWidth: 50,
-      name: "TrueY"
+      name: "TrueY",
+      columnActionsMode: ColumnActionsMode.disabled
     });
     index++;
   }
@@ -116,7 +119,8 @@ export function constructCols(
       key: `column${index}`,
       maxWidth: 100,
       minWidth: 50,
-      name: "PredictedY"
+      name: "PredictedY",
+      columnActionsMode: ColumnActionsMode.disabled
     });
     index++;
   }
@@ -127,7 +131,8 @@ export function constructCols(
       key: `column${index}`,
       maxWidth: 200,
       minWidth: 100,
-      name: featureNames[i]
+      name: featureNames[i],
+      columnActionsMode: ColumnActionsMode.disabled
     });
     index += 1;
   }

--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -79,60 +79,60 @@ export function constructCols(
 ): IColumn[] {
   const columns: IColumn[] = [];
   columns.push({
+    columnActionsMode: ColumnActionsMode.disabled,
     fieldName: "0",
     isResizable: true,
     key: "column0",
     maxWidth: 100,
     minWidth: 50,
-    name: "Index",
-    columnActionsMode: ColumnActionsMode.disabled
+    name: "Index"
   });
   let index = 1;
   if (hasColors) {
     columns.push({
+      columnActionsMode: ColumnActionsMode.disabled,
       fieldName: `${index}`,
       isResizable: true,
       key: "color",
       maxWidth: 100,
       minWidth: 50,
-      name: "Color",
-      columnActionsMode: ColumnActionsMode.disabled
+      name: "Color"
     });
     index++;
   }
   if (!isCustomPointsView && jointDataset.hasTrueY) {
     columns.push({
+      columnActionsMode: ColumnActionsMode.disabled,
       fieldName: `${index}`,
       isResizable: true,
       key: `column${index}`,
       maxWidth: 100,
       minWidth: 50,
-      name: "TrueY",
-      columnActionsMode: ColumnActionsMode.disabled
+      name: "TrueY"
     });
     index++;
   }
   if (!isCustomPointsView && jointDataset.hasPredictedY) {
     columns.push({
+      columnActionsMode: ColumnActionsMode.disabled,
       fieldName: `${index}`,
       isResizable: true,
       key: `column${index}`,
       maxWidth: 100,
       minWidth: 50,
-      name: "PredictedY",
-      columnActionsMode: ColumnActionsMode.disabled
+      name: "PredictedY"
     });
     index++;
   }
   for (let i = 0; i < viewedCols; i++) {
     columns.push({
+      columnActionsMode: ColumnActionsMode.disabled,
       fieldName: `${index}`,
       isResizable: true,
       key: `column${index}`,
       maxWidth: 200,
       minWidth: 100,
-      name: featureNames[i],
-      columnActionsMode: ColumnActionsMode.disabled
+      name: featureNames[i]
     });
     index += 1;
   }


### PR DESCRIPTION
## Description

The column header is currently highlighted when hovering:
![image](https://user-images.githubusercontent.com/10245648/158491471-becd0df5-492c-4c9a-b236-fb59ba2c113b.png)

This PR changes that (cursor not visible but the highlight on hover is gone):

![image](https://user-images.githubusercontent.com/10245648/158491532-4880f8d7-a51f-4da6-bf76-88d174819e83.png)


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

see above

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
