### PR TITLE
Allow duplicating cohorts multiple times

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
@@ -220,8 +220,17 @@ export class CohortList extends React.Component<
     const all = this.getAllCohort();
     if (index >= 0 && index < all.length) {
       const originCohort = all[index];
+      const duplicatedCohortNameStub = originCohort.cohort.name + localization.Interpret.CohortBanner.copy;
+      let duplicatedCohortName = duplicatedCohortNameStub;
+      let cohortCopyIndex = 0;
+      while (all.some((errorCohort) => {
+        return errorCohort.cohort.name === duplicatedCohortName
+      })){
+        cohortCopyIndex++;
+        duplicatedCohortName = `${duplicatedCohortNameStub}(${cohortCopyIndex})`;
+      }
       const newCohort = new Cohort(
-        `${originCohort.cohort.name} copy`,
+        duplicatedCohortName,
         this.context.jointDataset,
         originCohort.cohort.filters
       );

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
@@ -220,12 +220,11 @@ export class CohortList extends React.Component<
     const all = this.getAllCohort();
     if (index >= 0 && index < all.length) {
       const originCohort = all[index];
-      const duplicatedCohortNameStub = originCohort.cohort.name + localization.Interpret.CohortBanner.copy;
+      const duplicatedCohortNameStub =
+        originCohort.cohort.name + localization.Interpret.CohortBanner.copy;
       let duplicatedCohortName = duplicatedCohortNameStub;
       let cohortCopyIndex = 0;
-      while (all.some((errorCohort) => {
-        return errorCohort.cohort.name === duplicatedCohortName
-      })){
+      while (this.existsCohort(all, duplicatedCohortName)) {
         cohortCopyIndex++;
         duplicatedCohortName = `${duplicatedCohortNameStub}(${cohortCopyIndex})`;
       }
@@ -236,6 +235,12 @@ export class CohortList extends React.Component<
       );
       this.context.addCohort(newCohort);
     }
+  }
+
+  private existsCohort(cohorts: ErrorCohort[], name: string): boolean {
+    return cohorts.some((errorCohort) => {
+      return errorCohort.cohort.name === name;
+    });
   }
 
   private onEditCohortClick(index: number): void {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, hitting "Duplicate" for a cohort results in duplication exactly once. After that it finds that the original name with " copy" appended already exists as a cohort and simply returns without doing anything. This is not desirable behavior.

Hitting "Duplicate" should yield the following outcome after this PR:
![image](https://user-images.githubusercontent.com/10245648/158505016-221f6451-dff0-4f29-80b9-78a917f1d47b.png)


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

see above

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
