### PR TITLE
Reorder "Sort by" controls in local feature importance chart

### DIFF
--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -28,7 +28,8 @@ import {
   Dropdown,
   IDropdownOption,
   Label,
-  Toggle
+  Toggle,
+  Stack
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -186,30 +187,29 @@ export class LocalImportancePlots extends React.Component<
                 topK={this.state.topK}
               />
               <div className={classNames.featureImportanceLegend}>
-                <Text
-                  variant={"medium"}
-                  className={classNames.cohortPickerLabel}
-                >
-                  {localization.Interpret.GlobalTab.sortBy}
-                </Text>
-                <Toggle
-                  label={localization.Interpret.GlobalTab.absoluteValues}
-                  inlineLabel
-                  checked={this.state.sortAbsolute}
-                  onChange={this.toggleSortAbsolute}
-                />
-                <Text
-                  variant={"medium"}
-                  className={classNames.cohortPickerLabel}
-                >
-                  {localization.Interpret.GlobalTab.datapoint}
-                </Text>
-                <Dropdown
-                  styles={{ dropdown: { width: 150 } }}
-                  options={featureImportanceSortOptions}
-                  selectedKey={this.state.sortingSeriesIndex}
-                  onChange={this.setSortIndex}
-                />
+                <Stack horizontal={false} tokens={{ childrenGap: "m1" }}>
+                  <Stack.Item className={classNames.cohortPickerLabel}>
+                    <Text variant={"medium"}>
+                      {localization.Interpret.GlobalTab.sortBy}
+                    </Text>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Dropdown
+                      styles={{ dropdown: { width: 150 } }}
+                      options={featureImportanceSortOptions}
+                      selectedKey={this.state.sortingSeriesIndex}
+                      onChange={this.setSortIndex}
+                    />
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Toggle
+                      label={localization.Interpret.GlobalTab.absoluteValues}
+                      inlineLabel
+                      checked={this.state.sortAbsolute}
+                      onChange={this.toggleSortAbsolute}
+                    />
+                  </Stack.Item>
+                </Stack>
 
                 {this.props.metadata.modelType === ModelTypes.Multiclass && (
                   <div>

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -135,7 +135,7 @@ export const whatIfTabStyles: () => IProcessedStyleSet<IWhatIfTabStyles> =
       },
       cohortPickerLabel: {
         fontWeight: "600",
-        paddingRight: "8px"
+        padding: "0 8px 10px 0"
       },
       cohortPickerWrapper: {
         alignItems: "center",

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -967,7 +967,7 @@
       "_topAtoB.comment": "label on a slider, will tell user the index of the features they are currently seeing, like Top 5-10 features",
       "_viewDependencePlotFor.comment": "label for dropdown to select feature to be shown in a dependence plot (a kind of graph)",
       "_weightOptions.comment": "Weight how importance values are averaged https://en.wikipedia.org/wiki/Weighted_arithmetic_mean",
-      "absoluteValues": "Absolute values",
+      "absoluteValues": "View as absolute values",
       "aggregateFeatureImportance": "Aggregate feature importance",
       "collapsedHelperText": "Explore the top k important features that impact your overall model predictions.",
       "datapoint": "Datapoint",
@@ -980,7 +980,7 @@
       "helperText": "Explore the top-k important features that impact your overall model predictions (a.k.a. global explanation). Use the slider to show descending feature importances. All cohorts’ feature importances are shown side by side and can be toggled off by selecting the cohort in the legend. Click on any of the features in the graph to see a density plot below of how values of the selected feature affect prediction.",
       "legendHelpText": "Toggle cohorts on and off in the plot by clicking on the legend items.",
       "missingParameters": "This tab requires the local feature importance parameter be supplied.",
-      "sortBy": "Sort by",
+      "sortBy": "Sort by datapoint",
       "topAtoB": "Top {0} features by their importance",
       "viewDependencePlotFor": "View dependence plot for:",
       "weightOptions": "Class importance weights"

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
@@ -141,7 +141,7 @@ export class IndividualFeatureImportanceView extends React.Component<
           </Text>
         </Stack.Item>
         <Stack.Item className="tabularDataView">
-          <div style={{ height: "800px", position: "relative" }}>
+          <div style={{ height: "500px", position: "relative" }}>
             <Fabric>
               <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
                 <MarqueeSelection selection={this.selection}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Reorder "Sort by" controls in local feature importance chart

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
