### PR TITLE
upgrade pytest to 7.0.1, remove mock and upgrade pytest-mock to 3.6.1

### DIFF
--- a/erroranalysis/requirements-dev.txt
+++ b/erroranalysis/requirements-dev.txt
@@ -1,6 +1,6 @@
-pytest==5.0.1
+pytest==7.0.1
 pytest-cov
-pytest-mock==3.1.1
+pytest-mock==3.6.1
 requests==2.25.1
 
 requirements-parser==0.2.0

--- a/rai_core_flask/requirements-dev.txt
+++ b/rai_core_flask/requirements-dev.txt
@@ -1,6 +1,6 @@
-pytest==5.0.1
+pytest==7.0.1
 pytest-cov
-pytest-mock==3.1.1
+pytest-mock==3.6.1
 requests==2.25.1
 
 requirements-parser==0.2.0

--- a/raiutils/requirements-dev.txt
+++ b/raiutils/requirements-dev.txt
@@ -1,6 +1,6 @@
-pytest==5.0.1
+pytest==7.0.1
 pytest-cov
-pytest-mock==3.1.1
+pytest-mock==3.6.1
 requests==2.25.1
 
 requirements-parser==0.2.0

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -1,9 +1,8 @@
 # Requirements for raiwidgets development
 
-pytest==5.0.1
-mock==4.0.1
+pytest==7.0.1
 pytest-cov
-pytest-mock==3.1.1
+pytest-mock==3.6.1
 requests==2.25.1
 
 requirements-parser==0.2.0

--- a/raiwidgets/tests/test_fairness_calculations.py
+++ b/raiwidgets/tests/test_fairness_calculations.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+from pytest import approx
 
 from raiwidgets.fairness_metric_calculation import (compute_wilson_bounds,
                                                     false_negative_rate_wilson,
@@ -58,23 +59,23 @@ def test_false_negative_rate_wilson(sample_binary_data):
 
 def test_mse_standard_normal_binary(sample_binary_data):
     y_true, y_pred = sample_binary_data
-    assert pytest.approx(mse_standard_normal(y_true, y_pred), (0.0160, 0.5840))
+    mse = mse_standard_normal(y_true, y_pred)
+    assert mse == approx((0.0160, 0.5840), rel=1e-3, abs=1e-3)
 
 
 def test_mae_standard_normal_binary(sample_binary_data):
     y_true, y_pred = sample_binary_data
-    assert pytest.approx(mae_standard_normal(y_true, y_pred), (0.0160, 0.5840))
+    mae = mae_standard_normal(y_true, y_pred)
+    assert mae == approx((0.0160, 0.5840), rel=1e-3, abs=1e-3)
 
 
 def test_mse_standard_normal_continuous(sample_continuous_data):
     y_true, y_pred = sample_continuous_data
-    assert pytest.approx(
-        mse_standard_normal(y_true, y_pred), (57.7926, 637.2074)
-    )
+    mse = mse_standard_normal(y_true, y_pred)
+    assert mse == approx((57.7926, 637.2074), rel=1e-3, abs=1e-3)
 
 
 def test_mae_standard_normal_continuous(sample_continuous_data):
     y_true, y_pred = sample_continuous_data
-    assert pytest.approx(
-        mae_standard_normal(y_true, y_pred), (9.4708, 21.9292)
-    )
+    mae = mae_standard_normal(y_true, y_pred)
+    assert mae == approx((9.4708, 21.9292), rel=1e-3, abs=1e-3)

--- a/raiwidgets/tests/test_no_fairlearn.py
+++ b/raiwidgets/tests/test_no_fairlearn.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-import mock
+from unittest.mock import patch
+
 import pytest
 
 from raiwidgets import FairnessDashboard
@@ -9,7 +10,7 @@ from raiwidgets.fairness_metric_calculation import \
     MODULE_NOT_INSTALLED_ERROR_MESSAGE
 
 
-@mock.patch("importlib.import_module")
+@patch("importlib.import_module")
 def test_no_fairlearn(importlib_mock):
     importlib_mock.side_effect = \
         ModuleNotFoundError("No module named 'fairlearn.metrics'")

--- a/raiwidgets/tests/test_responsibleai_dashboard_input.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard_input.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-import mock
+from unittest.mock import patch
 
 from raiwidgets.responsibleai_dashboard_input import \
     ResponsibleAIDashboardInput
@@ -15,7 +15,7 @@ class TestResponsibleAIDashboardInput:
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        with mock.patch.object(knn, "predict_proba") as predict_mock:
+        with patch.object(knn, "predict_proba") as predict_mock:
             test_pred_data = test_data.head(1).drop("Income", axis=1).values
             dashboard_input.on_predict(
                 test_pred_data)

--- a/responsibleai/requirements-dev.txt
+++ b/responsibleai/requirements-dev.txt
@@ -1,9 +1,8 @@
 # Requirements for responsibleai development
 
-pytest==5.0.1
+pytest==7.0.1
 pytest-cov
-mock==4.0.1
-pytest-mock==3.1.1
+pytest-mock==3.6.1
 
 # Required for responsibleai package tests
 deptree~=0.0.10


### PR DESCRIPTION
## Description

Upgrade pytest to 7.0.1.  For some reason, the codecov build sometimes (randomly?) reports 0 coverage for raiwidgets, like here:

https://github.com/microsoft/responsible-ai-toolbox/runs/5631966866?check_suite_focus=true

And I see the output:
"No data was collected. (no-data-collected)"
I am hoping that upgrading pytest may fix this transient issue, since currently the version of pytest we are pinning to is quite old.  pytest 5.0.1 was released in July 2019, almost 3 years ago.  In any case, it's probably a good idea to upgrade pytest.
Also, this PR tries to remove mock, as it is now a part of the python standard library, and it updated pytest-mock to 3.6.1.


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):
Screenshot of bad 0 coverage report that I am seeing appear randomly:
![image](https://user-images.githubusercontent.com/24683184/159720794-f7a313b2-86e8-45c4-88c4-e66054246f72.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
