### PR TITLE
fix jinja2 build error and remove deprecated codecov parameter

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install package
         run: |
-          pip install -v .
+          pip install -v -e .
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Run tests
@@ -84,6 +84,5 @@ jobs:
           files: ./${{ matrix.packageDirectory }}/coverage.xml
           flags: unittests
           name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
         if: ${{ always() }}

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -r requirements-dev.txt
-          pip install .
+          pip install -v -e .
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Pip freeze
@@ -116,7 +116,6 @@ jobs:
           files: ./${{ matrix.packageDirectory }}/coverage.xml
           flags: unittests
           name: codecov-umbrella
-          path_to_write_report: ./coverage/codecov_report.txt
           verbose: true
         if: ${{ always() }}
 

--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -6,3 +6,4 @@ itsdangerous==2.0.1
 greenlet==1.1.2
 gevent==21.12.0
 markupsafe<2.1.0
+jinja2==2.11.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix build error due to jinja2 dependency and remove deprecated codecov parameter.  Install in editable mode which seems to fix the missing codecov for raiwidgets.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] raiwidgets
- [ ] responsibleai
- [ ] erroranalysis
- [ ] rai_core_flask

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
