### PR TITLE
Update requirements-linting.txt to add flake8-pytest-style

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -7,5 +7,6 @@ flake8-builtins==1.5.3
 flake8-copyright==0.2.2
 flake8-docstrings==1.5.0
 flake8-logging-format==0.6.0
+flake8-pytest-style
 flake8-rst-docstrings==0.0.13
 isort


### PR DESCRIPTION
## Description

Add `flake8-pytest-style` to catch any pytest style issues.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
