### PR TITLE
add retry logic to codecov step and only upload results for one python version and platform

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -13,11 +13,11 @@ jobs:
         packageDirectory:
           ["rai_core_flask", "responsibleai", "erroranalysis", "raiutils"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: [3.6, 3.7, 3.8, 3.9]
+        pythonVersion: ["3.6", "3.7", "3.8", "3.9"]
         exclude:
           - packageDirectory: "rai_core_flask"
             operatingSystem: macos-latest
-            pythonVersion: 3.9
+            pythonVersion: "3.9"
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -74,15 +74,39 @@ jobs:
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
-      - name: Upload coverage to Codecov
+      - if: ${{ (matrix.operatingSystem == 'ubuntu-latest') && (matrix.pythonVersion == '3.7') }}
+        name: Upload to codecov
+        id: codecovupload1
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ${{ matrix.packageDirectory }}
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./${{ matrix.packageDirectory }}/coverage.xml
           flags: unittests
           name: codecov-umbrella
           verbose: true
-        if: ${{ always() }}
+
+      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.7') && (matrix.operatingSystem == 'ubuntu-latest') }}
+        name: Retry upload to codecov
+        id: codecovupload2
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ matrix.packageDirectory }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: false
+          files: ./${{ matrix.packageDirectory }}/coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          verbose: true
+
+      - name: Set codecov status
+        if: ${{ (matrix.pythonVersion == '3.7') && (matrix.operatingSystem == 'ubuntu-latest') }}
+        run: |
+          if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then
+            echo fine
+          else
+            exit 1
+          fi

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -106,18 +106,33 @@ jobs:
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
-      - name: Upload coverage to Codecov
+      - if: ${{ (matrix.operatingSystem == 'ubuntu-latest') && (matrix.pythonVersion == '3.7') }}
+        name: Upload to codecov
+        id: codecovupload1
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ${{ matrix.packageDirectory }}
           env_vars: OS,PYTHON
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./${{ matrix.packageDirectory }}/coverage.xml
           flags: unittests
           name: codecov-umbrella
           verbose: true
-        if: ${{ always() }}
+
+      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.7') && (matrix.operatingSystem == 'ubuntu-latest') }}
+        name: Retry upload to codecov
+        id: codecovupload2
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ matrix.packageDirectory }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: false
+          files: ./${{ matrix.packageDirectory }}/coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          verbose: true
 
       - name: Upload e2e test screen shot
         if: always()
@@ -125,3 +140,12 @@ jobs:
         with:
           name: ${{ matrix.packageDirectory }}-e2e-screen-shot
           path: dist/cypress
+
+      - name: Set codecov status
+        if: ${{ (matrix.pythonVersion == '3.7') && (matrix.operatingSystem == 'ubuntu-latest') }}
+        run: |
+          if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then
+            echo fine
+          else
+            exit 1
+          fi

--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -7,3 +7,4 @@ greenlet==1.1.2
 gevent==21.12.0
 markupsafe<2.1.0
 jinja2==2.11.3
+Werkzeug<2.1.0


### PR DESCRIPTION
## Description

Add retry logic to codecov step and only upload results for one python version and platform.
This PR updates CI logic only, no code changes.

Retry logic implemented based on github community forum here:
https://github.community/t/how-to-retry-a-failed-step-in-github-actions-workflow/125880

I changed to use commandline directly instead of github actions as I couldn't use if statements with github actions for some strange reason.

## Areas changed

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
