### PR TITLE
Fix sort by absolute value from local importance chart

### DIFF
--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -111,7 +111,10 @@ export class LocalImportancePlots extends React.Component<
       prevProps.sortingSeriesIndex !== this.props.sortingSeriesIndex
     ) {
       this.setState({
-        sortArray: this.props.sortArray,
+        sortArray: this.getSortedArray(
+          this.props.sortingSeriesIndex,
+          this.state.sortAbsolute
+        ),
         sortingSeriesIndex: this.props.sortingSeriesIndex
       });
     }
@@ -501,21 +504,27 @@ export class LocalImportancePlots extends React.Component<
     checked?: boolean | undefined
   ) => {
     if (checked !== undefined) {
-      let sortArray: number[] = [];
-      if (this.state.sortingSeriesIndex !== undefined) {
-        sortArray = checked
-          ? ModelExplanationUtils.getAbsoluteSortIndices(
-              this.props.includedFeatureImportance[
-                this.state.sortingSeriesIndex
-              ].unsortedAggregateY
-            ).reverse()
-          : ModelExplanationUtils.getSortIndices(
-              this.props.includedFeatureImportance[
-                this.state.sortingSeriesIndex
-              ].unsortedAggregateY
-            ).reverse();
-      }
+      const sortArray = this.getSortedArray(
+        this.state.sortingSeriesIndex,
+        checked
+      );
       this.setState({ sortAbsolute: checked, sortArray });
     }
+  };
+
+  private getSortedArray = (
+    sortIndex: number | undefined,
+    checked: boolean
+  ) => {
+    if (sortIndex !== undefined) {
+      return checked
+        ? ModelExplanationUtils.getAbsoluteSortIndices(
+            this.props.includedFeatureImportance[sortIndex].unsortedAggregateY
+          ).reverse()
+        : ModelExplanationUtils.getSortIndices(
+            this.props.includedFeatureImportance[sortIndex].unsortedAggregateY
+          ).reverse();
+    }
+    return this.props.sortArray;
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix sort by absolute value from local importance chart

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [x] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
