### PR TITLE
Add to_json() and from_json() methods to Cohort class

### DIFF
--- a/raiwidgets/raiwidgets/cohort.py
+++ b/raiwidgets/raiwidgets/cohort.py
@@ -3,6 +3,7 @@
 
 """Module for defining cohorts in raiwidgets package."""
 
+import json
 from typing import Any, List, Optional
 
 import numpy as np
@@ -396,6 +397,75 @@ class Cohort:
             )
         self.name = name
         self.cohort_filter_list = None
+
+    @staticmethod
+    def _cohort_serializer(obj):
+        """The function to serialize the Cohort class object.
+
+        :param obj: Any member of the Cohort class object.
+        :type: Any
+        :return: Python dictionary.
+        :rtype: dict[Any, Any]
+        """
+        return obj.__dict__
+
+    def to_json(self):
+        """Returns a serialized JSON string for the Cohort object.
+
+        :return: The JSON string for the cohort.
+        :rtype: str
+        """
+        return json.dumps(self, default=Cohort._cohort_serializer)
+
+    @staticmethod
+    def _get_cohort_object(json_dict):
+        """Method to read a JSON dictionary and return a Cohort object.
+
+        :param json_dict: JSON dictionary containing cohort data.
+        :type: dict[str, str]
+        :return: The Cohort object.
+        :rtype: Cohort
+        """
+        if "name" not in json_dict:
+            raise UserConfigValidationException(
+                "No name field found for cohort deserialization")
+        if "cohort_filter_list" not in json_dict:
+            raise UserConfigValidationException(
+                "No cohort_filter_list field found for cohort deserialization")
+        if not isinstance(json_dict['cohort_filter_list'], list):
+            raise UserConfigValidationException(
+                "Field cohort_filter_list not of type list for "
+                "cohort deserialization")
+
+        deserialized_cohort = Cohort(json_dict['name'])
+        for serialized_cohort_filter in json_dict['cohort_filter_list']:
+            if "method" not in serialized_cohort_filter:
+                raise UserConfigValidationException(
+                    "Field method not found for cohort filter deserialization")
+            if "arg" not in serialized_cohort_filter:
+                raise UserConfigValidationException(
+                    "Field arg not found for cohort filter deserialization")
+            if "column" not in serialized_cohort_filter:
+                raise UserConfigValidationException(
+                    "Field column not found for cohort filter deserialization")
+            cohort_filter = CohortFilter(
+                method=serialized_cohort_filter['method'],
+                arg=serialized_cohort_filter['arg'],
+                column=serialized_cohort_filter['column'])
+            deserialized_cohort.add_cohort_filter(cohort_filter=cohort_filter)
+        return deserialized_cohort
+
+    @staticmethod
+    def from_json(json_str):
+        """Method to read a json string and return a Cohort object.
+
+        :param json_str: Serialized JSON string.
+        :type: str
+        :return: The Cohort object.
+        :rtype: Cohort
+        """
+        json_dict = json.loads(json_str)
+        return Cohort._get_cohort_object(json_dict)
 
     def add_cohort_filter(self, cohort_filter: CohortFilter):
         """Add a cohort filter into the cohort.

--- a/raiwidgets/raiwidgets/cohort.py
+++ b/raiwidgets/raiwidgets/cohort.py
@@ -111,6 +111,11 @@ class CohortFilter:
         self.arg = arg
         self.column = column
 
+    def __eq__(self, cohort_filter: Any):
+        return self.method == cohort_filter.method and \
+            self.arg == cohort_filter.arg and \
+            self.column == cohort_filter.column
+
     def _validate_cohort_filter_parameters(
             self, method: str, arg: List[Any], column: str):
         """Validate the input values for the cohort filter.
@@ -398,6 +403,32 @@ class Cohort:
         self.name = name
         self.cohort_filter_list = None
 
+    def __eq__(self, cohort: Any):
+        same_name = self.name == cohort.name
+        if self.cohort_filter_list is None and \
+                cohort.cohort_filter_list is None:
+            return same_name
+        elif self.cohort_filter_list is not None and \
+                cohort.cohort_filter_list is None:
+            return False
+        elif self.cohort_filter_list is None and \
+                cohort.cohort_filter_list is not None:
+            return False
+
+        same_num_cohort_filters = len(self.cohort_filter_list) == \
+            len(cohort.cohort_filter_list)
+        if not same_num_cohort_filters:
+            return False
+
+        same_cohort_filters = True
+        for index in range(0, len(self.cohort_filter_list)):
+            if self.cohort_filter_list[index] != \
+                    cohort.cohort_filter_list[index]:
+                same_cohort_filters = False
+                break
+
+        return same_name and same_cohort_filters
+
     @staticmethod
     def _cohort_serializer(obj):
         """The function to serialize the Cohort class object.
@@ -426,12 +457,13 @@ class Cohort:
         :return: The Cohort object.
         :rtype: Cohort
         """
-        if "name" not in json_dict:
-            raise UserConfigValidationException(
-                "No name field found for cohort deserialization")
-        if "cohort_filter_list" not in json_dict:
-            raise UserConfigValidationException(
-                "No cohort_filter_list field found for cohort deserialization")
+        cohort_fields = ["name", "cohort_filter_list"]
+        for cohort_field in cohort_fields:
+            if cohort_field not in json_dict:
+                raise UserConfigValidationException(
+                    "No {0} field found for cohort deserialization".format(
+                        cohort_field))
+
         if not isinstance(json_dict['cohort_filter_list'], list):
             raise UserConfigValidationException(
                 "Field cohort_filter_list not of type list for "
@@ -439,15 +471,13 @@ class Cohort:
 
         deserialized_cohort = Cohort(json_dict['name'])
         for serialized_cohort_filter in json_dict['cohort_filter_list']:
-            if "method" not in serialized_cohort_filter:
-                raise UserConfigValidationException(
-                    "Field method not found for cohort filter deserialization")
-            if "arg" not in serialized_cohort_filter:
-                raise UserConfigValidationException(
-                    "Field arg not found for cohort filter deserialization")
-            if "column" not in serialized_cohort_filter:
-                raise UserConfigValidationException(
-                    "Field column not found for cohort filter deserialization")
+            cohort_filter_fields = ["method", "arg", "column"]
+            for cohort_filter_field in cohort_filter_fields:
+                if cohort_filter_field not in serialized_cohort_filter:
+                    raise UserConfigValidationException(
+                        "No {0} field found for cohort filter "
+                        "deserialization".format(cohort_filter_field))
+
             cohort_filter = CohortFilter(
                 method=serialized_cohort_filter['method'],
                 arg=serialized_cohort_filter['arg'],

--- a/raiwidgets/tests/test_cohort.py
+++ b/raiwidgets/tests/test_cohort.py
@@ -497,40 +497,46 @@ class TestCohort:
                                        arg=[65], column='age')
         cohort_1 = Cohort(name="Cohort New")
         cohort_1.add_cohort_filter(cohort_filter_1)
-        json_str = json.dumps(cohort_1,
-                              default=cohort_filter_json_converter)
+        json_str = cohort_1.to_json()
 
         assert 'Cohort New' in json_str
         assert method in json_str
         assert '[65]' in json_str
         assert 'age' in json_str
 
-    def test_cohort_serialization_in_range_method(self):
+    def test_cohort_serialization_deserialization_in_range_method(self):
         cohort_filter_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_RANGE,
             arg=[65.0, 70.0], column='age')
         cohort_1 = Cohort(name="Cohort New")
         cohort_1.add_cohort_filter(cohort_filter_1)
-        json_str = json.dumps(cohort_1,
-                              default=cohort_filter_json_converter)
 
+        json_str = cohort_1.to_json()
         assert 'Cohort New' in json_str
         assert CohortFilterMethods.METHOD_RANGE in json_str
         assert '65.0' in json_str
         assert '70.0' in json_str
         assert 'age' in json_str
 
+        cohort_1_new = Cohort.from_json(json_str)
+        assert cohort_1_new.name == cohort_1.name
+        assert len(cohort_1_new.cohort_filter_list) == \
+            len(cohort_1.cohort_filter_list)
+        assert cohort_1_new.cohort_filter_list[0].method == \
+            cohort_1.cohort_filter_list[0].method
+
     @pytest.mark.parametrize('method',
                              [CohortFilterMethods.METHOD_INCLUDES,
                               CohortFilterMethods.METHOD_EXCLUDES])
-    def test_cohort_serialization_include_exclude_methods(self, method):
+    def test_cohort_serialization_deserialization_include_exclude_methods(
+            self, method):
         cohort_filter_str = CohortFilter(method=method,
                                          arg=['val1', 'val2', 'val3'],
                                          column='age')
         cohort_str = Cohort(name="Cohort New Str")
         cohort_str.add_cohort_filter(cohort_filter_str)
-        json_str = json.dumps(cohort_str,
-                              default=cohort_filter_json_converter)
+
+        json_str = cohort_str.to_json()
         assert method in json_str
         assert 'val1' in json_str
         assert 'val2' in json_str
@@ -542,13 +548,20 @@ class TestCohort:
                                          column='age')
         cohort_int = Cohort(name="Cohort New Int")
         cohort_int.add_cohort_filter(cohort_filter_int)
-        json_str = json.dumps(cohort_filter_int,
-                              default=cohort_filter_json_converter)
+
+        json_str = cohort_int.to_json()
         assert method in json_str
         assert '1' in json_str
         assert '2' in json_str
         assert '3' in json_str
         assert 'age' in json_str
+
+        cohort_int_new = Cohort.from_json(json_str)
+        assert cohort_int_new.name == cohort_int.name
+        assert len(cohort_int_new.cohort_filter_list) == \
+            len(cohort_int.cohort_filter_list)
+        assert cohort_int_new.cohort_filter_list[0].method == \
+            cohort_int.cohort_filter_list[0].method
 
 
 class TestCohortList:

--- a/raiwidgets/tests/test_cohort.py
+++ b/raiwidgets/tests/test_cohort.py
@@ -571,7 +571,8 @@ class TestCohort:
         test_dict = {'name': 'Cohort New'}
         with pytest.raises(
                 UserConfigValidationException,
-                match="No cohort_filter_list field found for cohort deserialization"):
+                match="No cohort_filter_list field found for "
+                      "cohort deserialization"):
             Cohort.from_json(json.dumps(test_dict))
 
         test_dict = {'name': 'Cohort New', 'cohort_filter_list': {}}
@@ -583,7 +584,8 @@ class TestCohort:
         test_dict = {'name': 'Cohort New', 'cohort_filter_list': [{}]}
         with pytest.raises(
                 UserConfigValidationException,
-                match="No method field found for cohort filter deserialization"):
+                match="No method field found for cohort filter "
+                      "deserialization"):
             Cohort.from_json(json.dumps(test_dict))
 
         test_dict = {
@@ -599,7 +601,8 @@ class TestCohort:
             'cohort_filter_list': [{"method": "fake_method", "arg": []}]}
         with pytest.raises(
                 UserConfigValidationException,
-                match="No column field found for cohort filter deserialization"):
+                match="No column field found for cohort filter "
+                      "deserialization"):
             Cohort.from_json(json.dumps(test_dict))
 
 


### PR DESCRIPTION
## Description

Add `to_json()` and `from_json()` methods to `Cohort` class.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [x] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
