### PR TITLE
take absolute value of error calculation for regression scenario

### DIFF
--- a/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
@@ -70,6 +70,7 @@ export enum Locators {
   WhatIfSetValueButton = "#CounterfactualPanel button:contains('Set Value')",
   DECRotatedVerticalBox = "#DatasetExplorerChart div[class*='rotatedVerticalBox']", // DEC- Data explorer chart
   DECHorizontalAxis = "#DatasetExplorerChart div[class*='horizontalAxis']",
+  DECHorizontalAxisButton = "#DatasetExplorerChart div[class*='horizontalAxis'] button",
   DECChoiceFieldGroup = "#AxisConfigPanel div[class*='ms-ChoiceFieldGroup']",
   DECCloseButton = "#AxisConfigPanel button.ms-Panel-closeButton",
   DECAxisPanel = "#AxisConfigPanel div.ms-Panel-main",
@@ -78,6 +79,8 @@ export enum Locators {
   DEIndividualDatapoints = "#ChartTypeSelection label:contains('Individual datapoints')",
   DEAggregatePlots = "#ChartTypeSelection label:contains('Aggregate plots')",
   DEYAxisPoints = "#DatasetExplorerChart g[class^='cartesianlayer'] g[class^='ytick'] text",
+  DEPoints = "#DatasetExplorerChart .highcharts-scatter-series > path.highcharts-point",
+  DEPointTooltip = ".highcharts-tooltip",
   MSCRotatedVerticalBox = "#OverallMetricChart div[class*='rotatedVerticalBox']", // MSC- Model statistics chart
   MSCHorizontalAxis = "#OverallMetricChart div[class*='horizontalAxis']",
   CausalAnalysisHeader = "#ModelAssessmentDashboard #causalAnalysisHeader",

--- a/apps/widget-e2e/src/describer/modelAssessment/IModelAssessmentData.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/IModelAssessmentData.ts
@@ -11,6 +11,7 @@ export interface IModelAssessmentData {
   featureNames?: string[];
   cohortDefaultName?: string;
   isMulticlass?: boolean;
+  isRegression?: boolean;
 }
 
 export interface IErrorAnalysisData {

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeIndividualDatapoints.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeIndividualDatapoints.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { ScatterHighchart } from "../../../util/ScatterHighchart";
+import { Locators } from "../Constants";
 import { IModelAssessmentData } from "../IModelAssessmentData";
 
 import { describeAxisConfigDialog } from "./describeAxisConfigDialog";
@@ -20,6 +21,30 @@ export function describeIndividualDatapoints(
       ).click();
       props.chart = new ScatterHighchart("#DatasetExplorerChart");
     });
+
+    if (dataShape.isRegression) {
+      it("Should have clickable individual datapoints that are positive for regression error", () => {
+        cy.get(Locators.DEIndividualDatapoints).click();
+        cy.get(`${Locators.DECohortDropdown} span`).should(
+          "contain",
+          dataShape.cohortDefaultName
+        );
+        axisSelection("Error");
+
+        cy.get(Locators.DEPoints).each((point) => {
+          cy.wrap(point).trigger("mouseover", { force: true });
+          cy.get("#DatasetExplorerChart")
+            .find(Locators.DEPointTooltip)
+            .then((tooltip) => {
+              cy.wrap(tooltip).should("contain", "Regression error");
+              cy.wrap(tooltip).should("not.have.value", "Regression error: -");
+            });
+        });
+        axisSelection("Index");
+        cy.get(Locators.DEAggregatePlots).click();
+      });
+    }
+
     describe.skip("Dataset explorer Chart", () => {
       it("should have color label", () => {
         cy.get('#DatasetExplorerChart label:contains("Color value")').should(
@@ -51,4 +76,17 @@ export function describeIndividualDatapoints(
       );
     }
   });
+}
+
+export function axisSelection(label: string): void {
+  cy.get(Locators.DECHorizontalAxisButton)
+    .click()
+    .get(
+      `#AxisConfigPanel div[class*='ms-ChoiceFieldGroup'] label:contains('${label}')`
+    )
+    .click()
+    .get("#AxisConfigPanel")
+    .find("button")
+    .contains("Select")
+    .click();
 }

--- a/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
@@ -169,6 +169,7 @@ const modelAssessmentDatasets = {
       "age",
       "s6"
     ],
+    isRegression: true,
     modelStatisticsData: {
       defaultXAxis: "Error",
       defaultXAxisPanelValue: "Error",

--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -381,8 +381,9 @@ export class JointDataset {
     modelType: ModelTypes
   ): void {
     if (modelType === ModelTypes.Regression) {
-      row[JointDataset.RegressionError] =
-        row[JointDataset.TrueYLabel] - row[JointDataset.PredictedYLabel];
+      row[JointDataset.RegressionError] = Math.abs(
+        row[JointDataset.TrueYLabel] - row[JointDataset.PredictedYLabel]
+      );
       return;
     }
     if (modelType === ModelTypes.Binary) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Based on customer and PM feedback, the "Error" calculation for regression scenario should not have negative values - we should take the absolute value instead.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
