### PR TITLE
Fix Inconsistent font size on "All data" cohort

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.styles.ts
@@ -14,7 +14,7 @@ export interface ICohortListStyles {
 export const cohortListStyles = (): IProcessedStyleSet<ICohortListStyles> => {
   return mergeStyleSets<ICohortListStyles>({
     link: {
-      fontSize: "12px"
+      fontSize: "14px"
     }
   });
 };

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
@@ -165,7 +165,7 @@ export class CohortList extends React.Component<
               </Stack>
             );
           }
-          return <span>{fieldContent}</span>;
+          return <span className={style.link}>{fieldContent}</span>;
         case "detailsColumn":
           if (item.details && item.details.length === 2 && index !== 0) {
             return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix Inconsistent font size on "All data" cohort

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
