### PR TITLE
Expand the counterfactual flyout to cover the full page

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
@@ -74,7 +74,8 @@ export class CounterfactualPanel extends React.Component<
       <Panel
         id="CounterfactualPanel"
         isOpen={this.props.isPanelOpen}
-        type={PanelType.largeFixed}
+        type={PanelType.custom}
+        customWidth={"100%"}
         onDismiss={this.onClosePanel}
         closeButtonAriaLabel="Close"
         isFooterAtBottom


### PR DESCRIPTION
## Description

Currently the flyout only takes up half the page, which wastes a lot of space and forces user to scroll horizontally. Hence, extending the flyout all the way to cover the full page. 

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):
Before the changes:-
![image](https://user-images.githubusercontent.com/47334368/161617802-366c1ff8-fa00-476e-8ca8-97ed313f7119.png)

After the changes:-
![image](https://user-images.githubusercontent.com/47334368/161617898-278dce1d-9098-4f18-b2c1-cfa5b2cd398c.png)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
