### PR TITLE
fix random node download failures by upgrading to latest github action with retry logic

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node-version }}
 
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node-version }}
       - id: download

--- a/.github/workflows/CI-codescan.yml
+++ b/.github/workflows/CI-codescan.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.operatingSystem }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.operatingSystem }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.pythonVersion }}
         uses: actions/setup-python@v2

--- a/.github/workflows/CI-typescript.yml
+++ b/.github/workflows/CI-typescript.yml
@@ -21,9 +21,9 @@ jobs:
         node-version: [12.x, 14.x, 16.8]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install yarn

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.operatingSystem }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -31,7 +31,7 @@ jobs:
           python-version: ${{ matrix.pythonVersion }}
 
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node-version }}
 

--- a/.github/workflows/GitHubPages.yml
+++ b/.github/workflows/GitHubPages.yml
@@ -10,7 +10,7 @@ jobs:
   website-build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.7
         uses: actions/setup-python@v2

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/release-erroranalysis.yml
+++ b/.github/workflows/release-erroranalysis.yml
@@ -20,7 +20,7 @@ jobs:
           exit 1
 
       # build wheel
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -20,7 +20,7 @@ jobs:
           exit 1
 
       # build wheel
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Only Test or Prod can be used."
           exit 1
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -35,7 +35,7 @@ jobs:
           python-version: 3.7
 
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node-version }}
 
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ env.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node-version }}
 

--- a/.github/workflows/release-raiutils.yml
+++ b/.github/workflows/release-raiutils.yml
@@ -20,7 +20,7 @@ jobs:
           exit 1
 
       # build wheel
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION

## Description

Fix random node download failures by upgrading to latest github action with retry logic.

While running builds I am often seeing node setup failures like:

```
> Run actions/setup-node@v1
Unexpected HTTP response: 500
Waiting [12](https://github.com/microsoft/responsible-ai-toolbox/runs/5834933514?check_suite_focus=true#step:4:12) seconds before trying again
Unexpected HTTP response: 500
Waiting 16 seconds before trying again
Error: Unexpected HTTP response: 500
```

Based on issue for this setup-node github action:
https://github.com/actions/setup-node/issues/133

It is recommended to update to the latest github action which has caching and better retry logic, which should resolve this issue.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
