### PR TITLE
show shift to an empty cohort in tree view as an empty node

### DIFF
--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -4,12 +4,13 @@
 import numpy as np
 import pandas as pd
 
-from erroranalysis._internal.constants import (METHOD, PRED_Y, ROW_INDEX,
-                                               TRUE_Y, CohortFilterMethods,
-                                               ModelTask)
+from erroranalysis._internal.constants import (ARG, COLUMN, COMPOSITE_FILTERS,
+                                               METHOD, OPERATION, PRED_Y,
+                                               ROW_INDEX, TRUE_Y,
+                                               CohortFilterMethods,
+                                               CohortFilterOps, ModelTask)
 from erroranalysis._internal.metrics import get_ordered_classes
 
-COLUMN = 'column'
 MODEL = 'model'
 CLASSIFICATION_OUTCOME = 'Classification outcome'
 
@@ -168,7 +169,7 @@ def build_query(filters, categorical_features, categories):
     for filter in filters:
         if METHOD in filter:
             method = filter[METHOD]
-            arg0 = str(filter['arg'][0])
+            arg0 = str(filter[ARG][0])
             colname = filter[COLUMN]
             if method == CohortFilterMethods.METHOD_GREATER:
                 queries.append("`" + colname + "` > " + arg0)
@@ -179,7 +180,7 @@ def build_query(filters, categorical_features, categories):
             elif method == CohortFilterMethods.METHOD_GREATER_AND_EQUAL:
                 queries.append("`" + colname + "` >= " + arg0)
             elif method == CohortFilterMethods.METHOD_RANGE:
-                arg1 = str(filter['arg'][1])
+                arg1 = str(filter[ARG][1])
                 queries.append("`" + colname + "` >= " + arg0 +
                                ' & `' + colname + "` <= " + arg1)
             elif method == CohortFilterMethods.METHOD_INCLUDES or \
@@ -194,7 +195,7 @@ def build_query(filters, categorical_features, categories):
                     is_categorical = colname in categorical_features
                 if is_categorical:
                     cat_idx = categorical_features.index(colname)
-                    arg0i = filter['arg'][0]
+                    arg0i = filter[ARG][0]
                     arg_cat = categories[cat_idx][arg0i]
                     if isinstance(arg_cat, str):
                         queries.append("`{}` == '{}'".format(colname, arg_cat))
@@ -207,11 +208,11 @@ def build_query(filters, categorical_features, categories):
                     "Unsupported method type: {}".format(method))
         else:
             cqueries = []
-            for composite_filter in filter['compositeFilters']:
+            for composite_filter in filter[COMPOSITE_FILTERS]:
                 cqueries.append(build_query([composite_filter],
                                             categorical_features,
                                             categories))
-            if filter['operation'] == 'and':
+            if filter[OPERATION] == CohortFilterOps.AND:
                 queries.append('(' + ') & ('.join(cqueries) + ')')
             else:
                 queries.append('(' + ') | ('.join(cqueries) + ')')
@@ -245,7 +246,7 @@ def build_bounds_query(filter, colname, method,
     is_categorical = False
     if categorical_features:
         is_categorical = colname in categorical_features
-    for arg in filter['arg']:
+    for arg in filter[ARG]:
         if is_categorical:
             cat_idx = categorical_features.index(colname)
             if isinstance(categories[cat_idx][arg], str):

--- a/erroranalysis/erroranalysis/_internal/constants.py
+++ b/erroranalysis/erroranalysis/_internal/constants.py
@@ -3,14 +3,18 @@
 
 from enum import Enum
 
-PRED_Y = 'pred_y'
-ROW_INDEX = 'Index'
-TRUE_Y = 'true_y'
+ARG = 'arg'
+COLUMN = 'column'
+COMPOSITE_FILTERS = 'compositeFilters'
 DIFF = 'diff'
-SPLIT_INDEX = 'split_index'
-SPLIT_FEATURE = 'split_feature'
 LEAF_INDEX = 'leaf_index'
 METHOD = 'method'
+OPERATION = 'operation'
+PRED_Y = 'pred_y'
+ROW_INDEX = 'Index'
+SPLIT_FEATURE = 'split_feature'
+SPLIT_INDEX = 'split_index'
+TRUE_Y = 'true_y'
 
 
 class CohortFilterMethods:
@@ -25,6 +29,14 @@ class CohortFilterMethods:
     METHOD_LESS_AND_EQUAL = 'less and equal'
     METHOD_GREATER_AND_EQUAL = 'greater and equal'
     METHOD_RANGE = 'in the range of'
+
+
+class CohortFilterOps:
+    """Cohort filter operations.
+    """
+
+    AND = 'and'
+    OR = 'or'
 
 
 class ModelTask(str, Enum):

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -3,6 +3,6 @@
 
 name = 'erroranalysis'
 _major = '0'
-_minor = '1'
-_patch = '31'
+_minor = '2'
+_patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Description

Show shift to an empty cohort in tree view as an empty node.
If an empty cohort is passed to the tree view, we return an empty node (see screenshot below).

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [x] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/24683184/161810052-cf843566-3ac9-4c7c-97b2-e9ceceba10e1.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
