### PR TITLE
Add installation instructions for raiwidgets to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,20 @@ Responsible AI dashboard is designed to achieve the following goals:
 
 This repository contains the Jupyter notebooks with examples to showcase how to use this widget. Get started [here](https://github.com/microsoft/responsible-ai-widgets/blob/main/notebooks/responsibleaidashboard/getting-started.ipynb).
 
+
+### Installation
+
+Use the following pip command to install the Responsible AI Toolbox.
+
+If running in jupyter, please make sure to restart the jupyter kernel after installing.
+
+```
+pip install raiwidgets
+```
+
+
 ### Responsible AI dashboard Customization
 
- 
 The Responsible AI Toolbox’s strength lies in its customizability. It empowers users to design tailored, end-to-end model debugging and decision-making workflows that address their particular needs. Need some inspiration? Here are some examples of how Toolbox components can be put together to analyze scenarios in different ways:
  
 | Responsible AI Dashboard Flow| Use Case  |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add installation instructions for raiwidgets to README.
Resolves issue:
https://github.com/microsoft/responsible-ai-toolbox/issues/1309

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/24683184/161826721-2ccacd0a-c64d-4331-a892-6f146c977d26.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
