### PR TITLE
add clear temporary cohort button to error analysis

### DIFF
--- a/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfoPanel.tsx
+++ b/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfoPanel.tsx
@@ -12,7 +12,6 @@ import { CohortInfo } from "./CohortInfo";
 export interface ICohortInfoPanelProps {
   isOpen: boolean;
   currentCohort: ErrorCohort;
-  // hostId: string
   onDismiss: () => void;
   onSaveCohortClick: () => void;
 }
@@ -35,9 +34,9 @@ export class CohortInfoPanel extends React.PureComponent<ICohortInfoPanelProps> 
         onDismiss={this.props.onDismiss}
       >
         <CohortInfo
-          onSaveCohortClick={this.props.onSaveCohortClick}
           currentCohort={this.props.currentCohort}
           disabledView={false}
+          onSaveCohortClick={this.props.onSaveCohortClick}
         />
       </Panel>
     );

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
@@ -36,6 +36,7 @@ export interface IErrorAnalysisViewProps {
   matrix?: IErrorAnalysisMatrix;
   matrixFeatures?: string[];
   errorAnalysisOption: ErrorAnalysisOptions;
+  onClearCohortSelectionClick: () => void;
   updateSelectedCohort: (
     filters: IFilter[],
     compositeFilters: ICompositeFilter[],
@@ -65,6 +66,7 @@ export class ErrorAnalysisView extends React.Component<IErrorAnalysisViewProps> 
             tree={this.props.tree}
             features={this.props.features}
             selectedFeatures={this.props.selectedFeatures}
+            onClearCohortSelectionClick={this.props.onClearCohortSelectionClick}
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
@@ -38,6 +38,7 @@ export interface IErrorAnalysisViewTabProps extends IErrorAnalysisViewProps {
   ) => void;
   selectFeatures: (features: string[]) => void;
   importances: number[];
+  onClearCohortSelectionClick: () => void;
   onSaveCohortClick: () => void;
   selectedKey: ErrorAnalysisOptions;
 }
@@ -111,6 +112,7 @@ export class ErrorAnalysisViewTab extends React.Component<
             matrix={this.props.matrix}
             matrixFeatures={this.props.matrixFeatures}
             errorAnalysisOption={this.props.errorAnalysisOption}
+            onClearCohortSelectionClick={this.props.onClearCohortSelectionClick}
             updateSelectedCohort={this.props.updateSelectedCohort}
             selectedCohort={this.props.selectedCohort}
             baseCohort={this.props.baseCohort}
@@ -132,8 +134,8 @@ export class ErrorAnalysisViewTab extends React.Component<
         <Stack className={classNames.cohortInfo} tokens={{ padding: "l1" }}>
           <CohortInfo
             currentCohort={this.context.selectedErrorCohort}
-            onSaveCohortClick={this.props.onSaveCohortClick}
             disabledView={this.props.disabledView}
+            onSaveCohortClick={this.props.onSaveCohortClick}
           />
         </Stack>
       </Stack>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.styles.ts
@@ -10,6 +10,7 @@ import {
 import { metricStyles, textStyles } from "../../Styles/CommonStyles.styles";
 
 export interface ITreeLegendStyles {
+  button: IStyle;
   metricBarBlack: IStyle;
   metricBarGreen: IStyle;
   metricBarRed: IStyle;
@@ -26,6 +27,9 @@ export const treeLegendStyles: () => IProcessedStyleSet<ITreeLegendStyles> =
     const commonMetricStyles = metricStyles();
     const commonTextStyles = textStyles();
     return mergeStyleSets<ITreeLegendStyles>({
+      button: {
+        maxWidth: "136px"
+      },
       metricBarBlack: commonMetricStyles.metricBarBlack,
       metricBarGreen: commonMetricStyles.metricBarGreen,
       metricBarRed: commonMetricStyles.metricBarRed,

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeLegend/TreeLegend.tsx
@@ -3,7 +3,12 @@
 
 import { ErrorCohort, Metrics } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
-import { IStackTokens, Stack, Text } from "office-ui-fabric-react";
+import {
+  DefaultButton,
+  IStackTokens,
+  Stack,
+  Text
+} from "office-ui-fabric-react";
 import React from "react";
 
 import { ColorPalette } from "../../ColorPalette";
@@ -16,20 +21,22 @@ import { INodeDetail } from "../TreeViewRenderer/TreeViewState";
 import { treeLegendStyles } from "./TreeLegend.styles";
 
 export interface ITreeLegendProps {
-  selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;
-  nodeDetail: INodeDetail;
-  minPct: number;
-  max: number;
-  showCohortName: boolean;
+  disabledView: boolean;
   isErrorMetric: boolean;
   isEnabled: boolean;
+  minPct: number;
+  max: number;
+  nodeDetail: INodeDetail;
+  onClearCohortSelectionClick: () => void;
+  selectedCohort: ErrorCohort;
   setMetric: (metric: string) => void;
-  disabledView: boolean;
+  showCohortName: boolean;
 }
 
 const stackTokens: IStackTokens = { childrenGap: 5 };
 const cellTokens: IStackTokens = { padding: 10 };
+const innerStackTokens: IStackTokens = { childrenGap: 15 };
 
 export class TreeLegend extends React.Component<ITreeLegendProps> {
   private readonly _metricIconId = "metricIconId";
@@ -45,10 +52,21 @@ export class TreeLegend extends React.Component<ITreeLegendProps> {
               Cohort: {this.props.baseCohort.cohort.name}
             </Text>
           )}
-          <MetricSelector
-            isEnabled={this.props.isEnabled}
-            setMetric={this.props.setMetric}
-          />
+          <Stack tokens={innerStackTokens}>
+            <MetricSelector
+              isEnabled={this.props.isEnabled}
+              setMetric={this.props.setMetric}
+            />
+            <DefaultButton
+              className={classNames.button}
+              text={localization.ErrorAnalysis.TreeLegend.clearSelection}
+              onClick={(): any => this.props.onClearCohortSelectionClick()}
+              disabled={
+                this.props.disabledView ||
+                this.props.selectedCohort.isTemporary === false
+              }
+            />
+          </Stack>
           <Stack>
             <Stack horizontal>
               <div className={classNames.metricBarBlack} />

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewProps.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewProps.tsx
@@ -24,6 +24,7 @@ export interface ITreeViewRendererProps {
     abortSignal: AbortSignal
   ) => Promise<IErrorAnalysisTreeNode[]>;
   tree?: IErrorAnalysisTreeNode[];
+  onClearCohortSelectionClick: () => void;
   updateSelectedCohort: (
     filters: IFilter[],
     compositeFilters: ICompositeFilter[],

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -517,6 +517,9 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                     }
                     getTreeNodes={this.props.requestDebugML}
                     getMatrix={this.props.requestMatrix}
+                    onClearCohortSelectionClick={(): void =>
+                      this.clearCohortSelection()
+                    }
                     updateSelectedCohort={this.updateSelectedCohort.bind(this)}
                     disabledView={false}
                     features={this.props.features}
@@ -723,6 +726,17 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       selectedCohort
     });
   }
+
+  private clearCohortSelection = (): void => {
+    const cohorts = this.state.cohorts.filter(
+      (errorCohort) => !errorCohort.isTemporary
+    );
+    this.setState({
+      cohorts,
+      selectedCohort: this.state.baseCohort
+    });
+    this.context.selectedErrorCohort = this.state.baseCohort;
+  };
 
   private handleGlobalTabClick = (item: PivotItem | undefined): void => {
     if (item?.props.itemKey) {

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -182,6 +182,9 @@
       "minDataInLeafInfoText": "The minimum number of data required to create one leaf",
       "minDataInLeafTitle": "Additional information on minimum number of samples in one leaf"
     },
+    "TreeLegend": {
+      "clearSelection": "Clear selection"
+    },
     "FilterTooltip": {
       "correctNum": "Correct (#): ",
       "countNum": "Count (#): ",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -147,6 +147,9 @@ export class TabsView extends React.PureComponent<
                         this.setState({ selectedFeatures: features })
                       }
                       importances={this.state.importances}
+                      onClearCohortSelectionClick={(): void => {
+                        this.props.onClearCohortSelectionClick();
+                      }}
                       onSaveCohortClick={(): void => {
                         this.props.setSaveCohortVisible();
                       }}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsViewProps.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsViewProps.ts
@@ -38,6 +38,7 @@ export interface ITabsViewProps {
   baseCohort: ErrorCohort;
   selectedCohort: ErrorCohort;
   dataset: IDataset;
+  onClearCohortSelectionClick: () => void;
   requestPredictions?: (
     request: any[],
     abortSignal: AbortSignal

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -108,6 +108,7 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
               baseCohort={this.state.baseCohort}
               selectedCohort={this.state.selectedCohort}
               dataset={this.props.dataset}
+              onClearCohortSelectionClick={this.clearCohortSelection}
               requestPredictions={this.props.requestPredictions}
               requestDebugML={this.props.requestDebugML}
               requestImportances={this.props.requestImportances}
@@ -174,6 +175,16 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
   private setSelectedCohort = (cohort: ErrorCohort): void => {
     this.setState({
       selectedCohort: cohort
+    });
+  };
+
+  private clearCohortSelection = (): void => {
+    const cohorts = this.state.cohorts.filter(
+      (errorCohort) => !errorCohort.isTemporary
+    );
+    this.setState({
+      cohorts,
+      selectedCohort: this.state.baseCohort
     });
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a button to clear the temporary cohort in error analysis.  This is both for the all-in-one RAI Dashboard and the individual EA Dashboard.

Update: this was at first added to the cohort info panel, but after discussion with PM it was decided to put it in tree view only, since heatmap already has a clear all button.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/24683184/162035462-10b652a6-6933-4da8-b5c4-570e0c460acd.png)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
