### PR TITLE
Disable save as new cohort button if nothing is selected in error tree

### DIFF
--- a/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
@@ -4,6 +4,8 @@
 export enum Locators {
   SelectButton = "button:contains('Select')",
   CancelButton = "button:contains('Cancel')",
+  SaveAsNewCohortButton = "button:contains('Save as a new cohort')",
+  ClearSelectionButton = "button:contains('Clear selection')",
   IFIPredictionSpan = "span[class^='headerCount']", // IFI - Individual feature importance
   IFIExpandCollapseButton = "[aria-label='expand collapse group']",
   IFITableRowSelected = 'div[class^="ms-List-page"] div[class^="ms-DetailsRow"] div[class^="ms-Check is-checked"]',
@@ -82,6 +84,7 @@ export enum Locators {
   MSCRotatedVerticalBox = "#OverallMetricChart div[class*='rotatedVerticalBox']", // MSC- Model statistics chart
   MSCHorizontalAxis = "#OverallMetricChart div[class*='horizontalAxis']",
   CausalAnalysisHeader = "#ModelAssessmentDashboard #causalAnalysisHeader",
+  ErrorAnalysisHeader = "#ModelAssessmentDashboard #errorAnalysisHeader",
   MSSideBarCards = "#OverallMetricChart div[class^='statsBox']",
   MSSideBarNumberOfBinsInput = "#AxisConfigPanel input[class^='ms-spinButton-input']",
   MSScrollable = "#OverallMetricChart div[class^='scrollableWrapper']",

--- a/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysis.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysis.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Locators } from "../Constants";
+import { RAINotebookNames } from "../IModelAssessmentData";
+import { modelAssessmentDatasets } from "../modelAssessmentDatasets";
+
+import { describeErrorAnalysisCohortInfo } from "./describeErrorAnalysisCohortInfo";
+import { describeErrorAnalysisTreeMap } from "./describeErrorAnalysisTreeMap";
+
+const testName = "Error Analysis";
+
+export function describeErrorAnalysis(
+  name: keyof typeof modelAssessmentDatasets
+): void {
+  const datasetShape = modelAssessmentDatasets[name];
+  describe(testName, () => {
+    let fileName: string;
+    before(() => {
+      const hosts = Cypress.env().hosts;
+      const hostDetails = hosts.find((obj: { file: string }) => {
+        fileName = RAINotebookNames[name];
+        return obj.file === fileName;
+      });
+      cy.task("log", hostDetails.host);
+      cy.visit(hostDetails.host);
+      cy.get("#ModelAssessmentDashboard").should("exist");
+    });
+
+    it("should not have error analysis for causal decision making", () => {
+      if (!datasetShape.errorAnalysisData?.hasErrorAnalysisComponent) {
+        cy.get(Locators.ErrorAnalysisHeader).should("not.exist");
+      }
+    });
+
+    it("should have error analysis for model debugging", () => {
+      if (datasetShape.errorAnalysisData?.hasErrorAnalysisComponent) {
+        cy.get(Locators.ErrorAnalysisHeader).should("exist");
+      }
+    });
+
+    if (datasetShape.errorAnalysisData?.hasErrorAnalysisComponent) {
+      describeErrorAnalysisCohortInfo();
+      describeErrorAnalysisTreeMap();
+    }
+  });
+}

--- a/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysisCohortInfo.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysisCohortInfo.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Locators } from "../Constants";
+
+export function describeErrorAnalysisCohortInfo(): void {
+  describe("Cohort info", () => {
+    it("should have save cohort button disabled", () => {
+      cy.get(Locators.ErrorAnalysisHeader)
+        .get(Locators.SaveAsNewCohortButton)
+        .should("exist")
+        .should("be.disabled");
+    });
+  });
+}

--- a/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysisTreeMap.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/errorAnalysis/describeErrorAnalysisTreeMap.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Locators } from "../Constants";
+
+export function describeErrorAnalysisTreeMap(): void {
+  describe("Tree Map", () => {
+    it("should have clear selection button disabled", () => {
+      cy.get(Locators.ErrorAnalysisHeader)
+        .get(Locators.ClearSelectionButton)
+        .should("exist")
+        .should("be.disabled");
+    });
+  });
+}

--- a/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/modelAssessmentDatasets.ts
@@ -24,6 +24,9 @@ const modelAssessmentDatasets = {
       defaultXAxis: "Index",
       defaultYAxis: "age"
     },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: true
+    },
     featureImportanceData: {
       datapoint: 500,
       dropdownRowName: "Row 34",
@@ -92,6 +95,9 @@ const modelAssessmentDatasets = {
       defaultXAxis: "Index",
       defaultYAxis: "age"
     },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: false
+    },
     featureImportanceData: {
       datapoint: 89,
       hasFeatureImportanceComponent: false
@@ -144,6 +150,9 @@ const modelAssessmentDatasets = {
       datasetBarLabel: ["0 - 17", "18 - 35", "36 - 52", "53 - 70", "71 - 88"],
       defaultXAxis: "Index",
       defaultYAxis: "age"
+    },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: true
     },
     featureImportanceData: {
       datapoint: 89,
@@ -212,6 +221,9 @@ const modelAssessmentDatasets = {
       ],
       defaultXAxis: "Index",
       defaultYAxis: "LotFrontage"
+    },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: true
     },
     featureImportanceData: {
       datapoint: 730,
@@ -311,6 +323,9 @@ const modelAssessmentDatasets = {
       defaultXAxis: "Index",
       defaultYAxis: "LotFrontage"
     },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: false
+    },
     featureImportanceData: {
       hasFeatureImportanceComponent: false
     },
@@ -367,6 +382,9 @@ const modelAssessmentDatasets = {
       datasetBarLabel: ["0 - 17", "18 - 35", "36 - 52", "53 - 70", "71 - 88"],
       defaultXAxis: "Index",
       defaultYAxis: "alcohol"
+    },
+    errorAnalysisData: {
+      hasErrorAnalysisComponent: true
     },
     featureImportanceData: {
       datapoint: 500,

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxClassificationModelAssessment/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxClassificationModelAssessment/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("ClassificationModelDebugging");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesDecisionMaking/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesDecisionMaking/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("DiabetesDecisionMaking");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesModelDebugging/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxDiabetesModelDebugging/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("DiabetesRegressionModelDebugging");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingClassification/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingClassification/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("HousingClassificationModelDebugging");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingDecisionMaking/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxHousingDecisionMaking/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("HousingDecisionMaking");

--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxMulticlassDnnModelDebugging/errorAnalysis.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxMulticlassDnnModelDebugging/errorAnalysis.spec.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describeErrorAnalysis } from "../../../describer/modelAssessment/errorAnalysis/describeErrorAnalysis";
+
+describeErrorAnalysis("MulticlassDnnModelDebugging");

--- a/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.tsx
+++ b/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.tsx
@@ -28,7 +28,9 @@ export class CohortInfo extends React.PureComponent<ICohortInfoProps> {
           className={classNames.button}
           text={localization.ErrorAnalysis.CohortInfo.saveCohort}
           onClick={(): any => this.props.onSaveCohortClick()}
-          disabled={this.props.disabledView}
+          disabled={
+            this.props.disabledView || !this.props.currentCohort.isTemporary
+          }
         />
         <Stack>
           <Label>


### PR DESCRIPTION
## Description

Disable save as new cohort button if nothing is selected in error tree.
Also adds UI tests for error analysis to validate this button and the clear selection button are working.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
