### PR TITLE
Change warning message to user exception for model type and task type mismatch

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -323,8 +323,8 @@ class RAIInsights(RAIBaseInsights):
 
                 if task_type == ModelTask.REGRESSION:
                     if hasattr(model, SKLearn.PREDICT_PROBA):
-                        warnings.warn(
-                            'INVALID-TASK-TYPE-WARNING: The regression model'
+                        raise UserConfigValidationException(
+                            'The regression model'
                             'provided has a predict_proba function. '
                             'Please check the task_type.')
         else:

--- a/responsibleai/tests/test_model_analysis_validations.py
+++ b/responsibleai/tests/test_model_analysis_validations.py
@@ -10,7 +10,6 @@ import pandas as pd
 import pytest
 
 from responsibleai.exceptions import UserConfigValidationException
-from responsibleai.modelanalysis import model_analysis
 from responsibleai.modelanalysis.model_analysis import ModelAnalysis
 
 from .common_utils import (create_binary_classification_dataset,

--- a/responsibleai/tests/test_model_analysis_validations.py
+++ b/responsibleai/tests/test_model_analysis_validations.py
@@ -10,11 +10,13 @@ import pandas as pd
 import pytest
 
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.modelanalysis import model_analysis
 from responsibleai.modelanalysis.model_analysis import ModelAnalysis
 
 from .common_utils import (create_binary_classification_dataset,
-                           create_cancer_data, create_iris_data,
-                           create_lightgbm_classifier)
+                           create_cancer_data, create_housing_data,
+                           create_iris_data, create_lightgbm_classifier,
+                           create_sklearn_random_forest_regressor)
 
 
 class TestModelAnalysisValidations:
@@ -234,10 +236,10 @@ class TestModelAnalysisValidations:
         X_train['target'] = y_train
         X_test['target'] = y_test
 
-        err_msg = ('INVALID-TASK-TYPE-WARNING: The regression model'
+        err_msg = ('The regression model'
                    'provided has a predict_proba function. '
                    'Please check the task_type.')
-        with pytest.warns(UserWarning, match=err_msg):
+        with pytest.raises(UserConfigValidationException, match=err_msg):
             ModelAnalysis(
                 model=model,
                 train=X_train,
@@ -424,18 +426,20 @@ class TestCounterfactualUserConfigValidations:
                 method='random')
 
     def test_desired_range_not_set(self):
-        X_train, y_train, X_test, y_test, _ = \
-            create_binary_classification_dataset()
+        X_train, X_test, y_train, y_test, feature_names = \
+            create_housing_data()
 
-        model = create_lightgbm_classifier(X_train, y_train)
-        X_train['target'] = y_train
-        X_test['target'] = y_test
+        model = create_sklearn_random_forest_regressor(X_train, y_train)
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        X_train['TARGET'] = y_train
+        X_test['TARGET'] = y_test
 
         model_analysis = ModelAnalysis(
             model=model,
             train=X_train,
             test=X_test,
-            target_column='target',
+            target_column='TARGET',
             task_type='regression')
         with pytest.raises(
                 UserConfigValidationException,

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -13,8 +13,9 @@ from responsibleai import RAIInsights
 from responsibleai.exceptions import UserConfigValidationException
 
 from .common_utils import (create_binary_classification_dataset,
-                           create_cancer_data, create_iris_data,
-                           create_lightgbm_classifier)
+                           create_cancer_data, create_housing_data,
+                           create_iris_data, create_lightgbm_classifier,
+                           create_sklearn_random_forest_regressor)
 
 TARGET = 'target'
 
@@ -236,10 +237,10 @@ class TestRAIInsightsValidations:
         X_train[TARGET] = y_train
         X_test[TARGET] = y_test
 
-        err_msg = ('INVALID-TASK-TYPE-WARNING: The regression model'
+        err_msg = ('The regression model'
                    'provided has a predict_proba function. '
                    'Please check the task_type.')
-        with pytest.warns(UserWarning, match=err_msg):
+        with pytest.raises(UserConfigValidationException, match=err_msg):
             RAIInsights(
                 model=model,
                 train=X_train,
@@ -502,10 +503,12 @@ class TestCounterfactualUserConfigValidations:
                 method='random')
 
     def test_desired_range_not_set(self):
-        X_train, y_train, X_test, y_test, _ = \
-            create_binary_classification_dataset()
+        X_train, X_test, y_train, y_test, feature_names = \
+            create_housing_data()
 
-        model = create_lightgbm_classifier(X_train, y_train)
+        model = create_sklearn_random_forest_regressor(X_train, y_train)
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
         X_train[TARGET] = y_train
         X_test[TARGET] = y_test
 


### PR DESCRIPTION
## Description

It seems RAI dashboard may show incorrect insights if we do regression based RAI computation for a classification model. Hence, changing the warning to a user exception.
 
## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [x] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
