### PR TITLE
Add disaggregated analysis table/heatmap

### DIFF
--- a/libs/core-ui/src/lib/Interfaces/IDataset.ts
+++ b/libs/core-ui/src/lib/Interfaces/IDataset.ts
@@ -19,3 +19,6 @@ export interface IDatasetSummary {
   classNames?: string[];
   categoricalMap?: { [key: number]: string[] };
 }
+
+export const classificationTask = "classification";
+export const regressionTask = "regression";

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1334,7 +1334,12 @@
       "notAvailable": "N/A",
       "countColumnHeader": "Count",
       "dataCohortsHeatmapHeader": "Dataset cohorts",
+      "disaggregatedAnalysisHeatmapHeader": "Disaggregated analysis",
+      "featuresDropdown": "Feature(s)",
+      "metricChartDropdownSelectionHeader": "Metric",
       "metricSelectionDropdownPlaceholder": "Select metrics to compare your cohorts.",
+      "featureSelectionDropdownPlaceholder": "Select features to use for a disaggregated analysis.",
+      "disaggregatedAnalysisFeatureSelectionPlaceholder": "Select features to generate the disaggregated analysis.",
       "tableCountTooltip": "Cohort {0} contains {1} instances.",
       "tableMetricTooltip": "The model's {0} on cohort {1} is {2}"
     }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/CohortStatsHeatmap.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/CohortStatsHeatmap.tsx
@@ -19,6 +19,7 @@ interface ICohortStatsHeatmapProps {
   cohorts: ErrorCohort[];
   selectableMetrics: IDropdownOption[];
   selectedMetrics: string[];
+  title: string;
 }
 
 class ICohortStatsHeatmapState {}
@@ -70,7 +71,7 @@ export class CohortStatsHeatmap extends React.Component<
           },
           colorAxis: {
             max: 1,
-            maxColor: "#1634F6",
+            maxColor: "#0078D4",
             min: 0,
             minColor: "#FFFFFF"
           },
@@ -91,34 +92,35 @@ export class CohortStatsHeatmap extends React.Component<
           ],
           title: {
             align: "left",
-            text: localization.ModelAssessment.ModelOverview
-              .dataCohortsHeatmapHeader
+            text: this.props.title
           },
           tooltip: {
             formatter() {
               // to avoid semantic error during build cast point to any
+              const pointValue = (this.point as any).value;
               if (
                 this.point.y === undefined ||
-                (this.point as any).value === undefined ||
-                (this.point as any).value === null
+                pointValue === undefined ||
+                pointValue === null
               ) {
                 return undefined;
               }
-              const value = (this.point as any).value;
+
               if (this.point.x === 0) {
                 // Count column
                 return localization.formatString(
                   localization.ModelAssessment.ModelOverview.tableCountTooltip,
                   this.series.yAxis.categories[this.point.y],
-                  value
+                  pointValue
                 );
               }
               // Metric columns
               return localization.formatString(
                 localization.ModelAssessment.ModelOverview.tableMetricTooltip,
+                // make metric name lower case in sentence
                 this.series.xAxis.categories[this.point.x].toLowerCase(),
                 this.series.yAxis.categories[this.point.y],
-                value
+                pointValue
               );
             }
           },
@@ -136,7 +138,6 @@ export class CohortStatsHeatmap extends React.Component<
               formatter() {
                 return wrapYAxisLabels(this.value.toString(), true);
               },
-
               reserveSpace: true
             }
           }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
@@ -5,6 +5,7 @@ import {
   defaultModelAssessmentContext,
   ModelAssessmentContext
 } from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
 import { IDropdownOption } from "office-ui-fabric-react";
 import React from "react";
 
@@ -28,6 +29,9 @@ export class DatasetCohortStatsTable extends React.Component<
   public render(): React.ReactNode {
     return (
       <CohortStatsHeatmap
+        title={
+          localization.ModelAssessment.ModelOverview.dataCohortsHeatmapHeader
+        }
         cohorts={this.context.errorCohorts}
         selectableMetrics={this.props.selectableMetrics}
         selectedMetrics={this.props.selectedMetrics}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisTable.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  defaultModelAssessmentContext,
+  ModelAssessmentContext,
+  ErrorCohort
+} from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+import {
+  ActionButton,
+  IDropdownOption,
+  IDropdown
+} from "office-ui-fabric-react";
+import React from "react";
+
+import { CohortStatsHeatmap } from "./CohortStatsHeatmap";
+
+interface IDisaggregatedAnalysisTableProps {
+  selectableMetrics: IDropdownOption[];
+  selectedMetrics: string[];
+  selectedFeatures: number[];
+  featureBasedCohorts: ErrorCohort[];
+  featureDropdownRef: React.RefObject<IDropdown>;
+}
+
+class IDisaggregatedAnalysisTableState {}
+
+export class DisaggregatedAnalysisTable extends React.Component<
+  IDisaggregatedAnalysisTableProps,
+  IDisaggregatedAnalysisTableState
+> {
+  public static contextType = ModelAssessmentContext;
+  public context: React.ContextType<typeof ModelAssessmentContext> =
+    defaultModelAssessmentContext;
+
+  public render(): React.ReactNode {
+    return (
+      <>
+        {this.props.selectedFeatures.length === 0 && (
+          <ActionButton
+            onClick={() => {
+              this.props.featureDropdownRef.current?.focus(true);
+            }}
+          >
+            {
+              localization.ModelAssessment.ModelOverview
+                .disaggregatedAnalysisFeatureSelectionPlaceholder
+            }
+          </ActionButton>
+        )}
+        {this.props.selectedFeatures.length > 0 && (
+          <CohortStatsHeatmap
+            title={
+              localization.ModelAssessment.ModelOverview
+                .disaggregatedAnalysisHeatmapHeader
+            }
+            cohorts={this.props.featureBasedCohorts}
+            selectableMetrics={this.props.selectableMetrics}
+            selectedMetrics={this.props.selectedMetrics}
+          />
+        )}
+      </>
+    );
+  }
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  Cohort,
+  ErrorCohort,
+  FilterMethods,
+  getCompositeFilterString,
+  ICompositeFilter,
+  IDataset,
+  JointDataset,
+  Operations
+} from "@responsible-ai/core-ui";
+
+function generateFiltersCartesianProduct(
+  filters: ICompositeFilter[][]
+): ICompositeFilter[] {
+  if (filters.length === 0) {
+    return [];
+  }
+  if (filters.length === 1) {
+    // just flatten filters list
+    return filters[0];
+  }
+  return generateFiltersCartesianProduct([
+    filters[0]
+      .map((filter0) => {
+        return filters[1].map((filter1) => {
+          return {
+            compositeFilters: [filter0, filter1],
+            operation: Operations.And
+          } as ICompositeFilter;
+        });
+      })
+      .reduce((list1, list2) => [...list1, ...list2]), // flatten
+    ...filters.slice(2)
+  ]);
+}
+
+export function generateCohortsCartesianProduct(
+  filters: ICompositeFilter[][],
+  jointDataset: JointDataset
+) {
+  return generateFiltersCartesianProduct(filters).map((compositeFilter) => {
+    const cohortName = getCompositeFilterString(
+      [compositeFilter],
+      jointDataset
+    )[0];
+    return new ErrorCohort(
+      new Cohort(cohortName, jointDataset, [], [compositeFilter]),
+      jointDataset
+    );
+  });
+}
+
+export function generateOverlappingFeatureBasedCohorts(
+  jointDataset: JointDataset,
+  dataset: IDataset,
+  selectedFeatures: number[]
+) {
+  // TODO: restrict by current cohort
+  // TODO: make nGroupsPerFeature configurable
+  const nGroupsPerFeature = 3;
+  const filters: ICompositeFilter[][] = [];
+  selectedFeatures.forEach((featureIndex) => {
+    const featureName = dataset.feature_names[featureIndex];
+    const featureMetaName = JointDataset.DataLabelRoot + featureIndex;
+    if (dataset.categorical_features.includes(featureName)) {
+      const featureFilters = jointDataset.metaDict[
+        featureMetaName
+      ].sortedCategoricalValues?.map((_category, categoryIndex) => {
+        return {
+          arg: [categoryIndex],
+          column: featureMetaName,
+          method: FilterMethods.Includes
+        };
+      });
+      if (featureFilters) {
+        filters.push(featureFilters);
+      }
+    } else {
+      let min = Number.MAX_SAFE_INTEGER;
+      let max = Number.MIN_SAFE_INTEGER;
+      dataset.features.forEach((instanceFeatures) => {
+        const featureValue = instanceFeatures[featureIndex];
+        if (typeof featureValue !== "number") {
+          return;
+        }
+        if (featureValue > max) {
+          max = featureValue;
+        }
+        if (featureValue < min) {
+          min = featureValue;
+        }
+      });
+
+      const intervalWidth = (max - min) / nGroupsPerFeature;
+      const featureFilters: ICompositeFilter[] = [
+        {
+          // left-most bin
+          arg: [min + intervalWidth],
+          column: featureMetaName,
+          method: FilterMethods.LessThan
+        }
+      ];
+      for (
+        // middle bins
+        let binIndex = 1;
+        binIndex < nGroupsPerFeature - 1;
+        binIndex++
+      ) {
+        featureFilters.push({
+          compositeFilters: [
+            {
+              arg: [min + intervalWidth * binIndex],
+              column: featureMetaName,
+              method: FilterMethods.GreaterThanEqualTo
+            },
+            {
+              arg: [min + intervalWidth * (binIndex + 1)],
+              column: featureMetaName,
+              method: FilterMethods.LessThan
+            }
+          ],
+          operation: Operations.And
+        });
+      }
+      featureFilters.push({
+        // right-most bin
+        arg: [min + intervalWidth * (nGroupsPerFeature - 1)],
+        column: featureMetaName,
+        method: FilterMethods.GreaterThanEqualTo
+      });
+      filters.push(featureFilters);
+    }
+  });
+
+  return (
+    generateCohortsCartesianProduct(filters, jointDataset)
+      // filter the empty cohorts resulting from overlapping dimensions
+      .filter((errorCohort) => errorCohort.cohortStats.totalCohort > 0)
+  );
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -32,9 +32,6 @@ interface IModelOverviewProps {
 interface IModelOverviewState {
   selectedMetrics: string[];
   selectedFeatures: number[];
-  selectedDatasetCohorts: number[];
-  selectedFeatureBasedCohorts: number[];
-  chartConfigurationIsVisible: boolean;
 }
 
 export class ModelOverview extends React.Component<
@@ -49,9 +46,6 @@ export class ModelOverview extends React.Component<
   constructor(props: IModelOverviewProps) {
     super(props);
     this.state = {
-      chartConfigurationIsVisible: false,
-      selectedDatasetCohorts: [],
-      selectedFeatureBasedCohorts: [],
       selectedFeatures: [],
       selectedMetrics: []
     };
@@ -75,11 +69,6 @@ export class ModelOverview extends React.Component<
       ];
     }
     this.setState({
-      selectedDatasetCohorts: this.context.errorCohorts.map(
-        (_cohort, index) => {
-          return index;
-        }
-      ),
       selectedMetrics: defaultSelectedMetrics
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a disaggregated analysis heatmap/table right below the dataset cohort table for user-defined cohorts. It is controlled via the "Features" dropdown at the top. You can select up to two features. Upon selecting two features the other items turn gray (disabled) and you have to unselect a feature first in order to select any other. The underlying heatmap/table logic is identical to the dataset cohorts table. The new part is only the logic to disaggregate into the various groups. Right now this is hard-coded to three groups (to be improved in a future PR that introduces a configuration flyout to make this customizable) if the feature is not categorical, and if it is categorical it will simply show the categories as groups.

Other changes:
- updated the color of the heatmap
- small fixes that should have gone in the previous PR but got left out due to forgetting to `git push` (inspired by @imatiach-msft 's feedback)

This is still behind a feature flag and therefore not visible to anyone using the RAI dashboard.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [x] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

This will happen in another PR before we remove the feature flag.

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [x] I validated the changes manually.

## Screenshots (if appropriate):


https://user-images.githubusercontent.com/10245648/162556779-31e97f31-5e95-4016-a48b-75b90e15b339.mp4



## Documentation:

This will happen in another PR before we remove the feature flag.

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
