### PR TITLE
block empty cohort creation in RAI Dashboard

### DIFF
--- a/apps/dashboard-e2e/src/describer/interpret/cohort/describeCreateCohort.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/cohort/describeCreateCohort.ts
@@ -10,6 +10,10 @@ export function describeCreateCohort(dataShape: IInterpretData): void {
       .get('#cohortEditPanel span:contains("No filters")')
       .should("exist");
   });
+  it("should have save and save and switch buttons disabled by default", () => {
+    cy.get('button:contains("Save")').should("be.disabled");
+    cy.get('button:contains("Save and switch")').should("be.disabled");
+  });
   it("should able to add filter", () => {
     cy.get("#cohortEditPanel input:eq(0)").clear().type("CohortCreateE2E");
     cy.get('#cohortEditPanel [type="radio"]').first().check();
@@ -54,6 +58,17 @@ export function describeCreateCohort(dataShape: IInterpretData): void {
     cy.get('button:contains("Add filter")').click();
     cy.get('button:contains("Save and switch")').click();
     cy.get("#cohortEditPanel").should("exist");
+  });
+  it("should not allow creating empty cohort", () => {
+    cy.get("#cohortEditPanel input:eq(0)").clear().type("CohortCreateE2E");
+    cy.get('#cohortEditPanel [type="radio"]').first().check();
+    cy.get("#cohortEditPanel input[class^='ms-spinButton-input']")
+      .clear()
+      .type("0");
+    cy.get('button:contains("Add filter")').click();
+    cy.get('button:contains("Save and switch")').click();
+    cy.get(".emptyCohortDialog button").click();
+    cy.get("#removeFilterBtn-2").click();
   });
   it("should create New cohort", () => {
     cy.get("#cohortEditPanel input:eq(0)").clear().type("CohortCreateE2E");

--- a/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/Constants.ts
@@ -4,6 +4,7 @@
 export enum Locators {
   SelectButton = "button:contains('Select')",
   CancelButton = "button:contains('Cancel')",
+  YesButton = "button:contains('Yes')",
   SaveAsNewCohortButton = "button:contains('Save as a new cohort')",
   ClearSelectionButton = "button:contains('Clear selection')",
   IFIPredictionSpan = "span[class^='headerCount']", // IFI - Individual feature importance
@@ -33,7 +34,9 @@ export enum Locators {
   CohortDatasetValueInput = "#cohortEditPanel input[class^='ms-spinButton-input']",
   CohortFilterSelection = "#cohortEditPanel [type='radio']",
   CohortAddFilterButton = "button:contains('Add filter')",
+  CohortSaveButton = "button:contains('Save')",
   CohortSaveAndSwitchButton = "button:contains('Save and switch')",
+  CohortEmptyDialogCloseButton = ".emptyCohortDialog button",
   NewCohortSpan = "span:contains('CohortCreateE2E')",
   WICDatapointDropbox = "#IndividualFeatureContainer div[class^='ms-Stack legendAndText'] div[class^='ms-ComboBox-container']",
   WICLocalImportanceDescription = "#LocalImportanceDescription",

--- a/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
+++ b/apps/widget-e2e/src/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
@@ -15,6 +15,23 @@ export function describeCohortFunctionality(
         dataShape.cohortDefaultName
       );
     });
+    it("should have save and save and switch buttons disabled by default", () => {
+      cy.get(Locators.CreateNewCohortButton).click();
+      cy.get(Locators.CohortSaveButton).should("be.disabled");
+      cy.get(Locators.CohortSaveAndSwitchButton).should("be.disabled");
+      cy.get(Locators.CancelButton).click();
+      cy.get(Locators.YesButton).click();
+    });
+    it("should not allow creating empty cohort", () => {
+      cy.get(Locators.CreateNewCohortButton).click();
+      cy.get(Locators.CohortFilterSelection).first().check();
+      cy.get(Locators.CohortDatasetValueInput).clear().type("0");
+      cy.get(Locators.CohortAddFilterButton).click();
+      cy.get(Locators.CohortSaveAndSwitchButton).click();
+      cy.get(Locators.CohortEmptyDialogCloseButton).click();
+      cy.get(Locators.CancelButton).click();
+      cy.get(Locators.YesButton).click();
+    });
     it("Should update dataset selection with new cohort when a new cohort is created", () => {
       cy.get(Locators.CreateNewCohortButton).click();
       cy.get("#cohortEditPanel").should("exist");

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/EmptyCohortDialog.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/EmptyCohortDialog.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { localization } from "@responsible-ai/localization";
+import { Dialog, DialogType } from "office-ui-fabric-react";
+import React from "react";
+
+export interface IEmptyCohortDialogProps {
+  onClose(): void;
+}
+
+export class EmptyCohortDialog extends React.Component<IEmptyCohortDialogProps> {
+  public render(): React.ReactNode {
+    const dialogContentProps = {
+      className: "emptyCohortDialog",
+      subText: localization.Core.EmptyCohortDialog.subText,
+      title: localization.Core.EmptyCohortDialog.title,
+      type: DialogType.normal
+    };
+    const modalProps = {
+      isBlocking: true
+    };
+    return (
+      <Dialog
+        maxWidth={"480px"}
+        minWidth={"480px"}
+        hidden={false}
+        dialogContentProps={dialogContentProps}
+        modalProps={modalProps}
+        onDismiss={() => this.props.onClose()}
+      />
+    );
+  }
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -88,6 +88,10 @@
     "PreBuiltCohort": {
       "featureNameNotFound": "Feature name not found in the dataset",
       "notACategoricalFeature": "Feature is not categorical"
+    },
+    "EmptyCohortDialog": {
+      "title": "Dataset cohort contains no datapoints",
+      "subText": "It seems your dataset cohort contains no datapoints, adjust your filters to include at least one datapoint in your dataset cohort before saving."
     }
   },
   "Counterfactuals": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We should block user from creating empty cohorts by checking if there is no datapoint in the cohort that user is going to create.
If user creates new cohort but has not added any filters yet, we should disable the "Save" and "Save and switch" buttons
If user adds filters that have no datapoints, have a pop up that blocks user when they click "Save" or "Save and switch"

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [x] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/24683184/162840296-a7a07494-554c-4ff0-b347-da218e1efb81.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
