### PR TITLE
Limit each component description width up to 750px for readability

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateStyles.ts
@@ -42,6 +42,7 @@ export const CausalAggregateStyles: () => IProcessedStyleSet<ICausalAggregateSty
         display: "inline-block",
         flex: "1",
         fontSize: 14,
+        maxWidth: "750px",
         paddingBottom: "5px",
         textAlign: "left"
       },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateStyles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IProcessedStyleSet,
   IStyle,
@@ -42,7 +43,7 @@ export const CausalAggregateStyles: () => IProcessedStyleSet<ICausalAggregateSty
         display: "inline-block",
         flex: "1",
         fontSize: 14,
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingBottom: "5px",
         textAlign: "left"
       },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualStyles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IProcessedStyleSet,
   IStyle,
@@ -37,7 +38,7 @@ export const CausalIndividualStyles: () => IProcessedStyleSet<ICausalIndividualS
         display: "inline-block",
         flex: "1",
         fontSize: 14,
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingBottom: "15px",
         textAlign: "left"
       },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualStyles.ts
@@ -37,6 +37,7 @@ export const CausalIndividualStyles: () => IProcessedStyleSet<ICausalIndividualS
         display: "inline-block",
         flex: "1",
         fontSize: 14,
+        maxWidth: "750px",
         paddingBottom: "15px",
         textAlign: "left"
       },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentStyles.ts
@@ -41,6 +41,7 @@ export const TreatmentStyles: () => IProcessedStyleSet<ITreatmentStyles> =
       header: {
         fontSize: 14,
         margin: "20px",
+        maxWidth: "750px",
         textAlign: "left"
       },
       label: {

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentStyles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentStyles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IProcessedStyleSet,
   IStyle,
@@ -41,7 +42,7 @@ export const TreatmentStyles: () => IProcessedStyleSet<ITreatmentStyles> =
       header: {
         fontSize: 14,
         margin: "20px",
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         textAlign: "left"
       },
       label: {

--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -40,6 +40,7 @@ export * from "./lib/util/rowErrorSize";
 export * from "./lib/util/getBoxData";
 export * from "./lib/util/getBasicFilterString";
 export * from "./lib/util/getCausalDisplayFeatureName";
+export * from "./lib/util/getCommonStyles";
 export * from "./lib/util/getCompositeFilterString";
 export * from "./lib/util/getErrorBarChartOptions";
 export * from "./lib/util/getFeatureOptions";

--- a/libs/core-ui/src/lib/util/getCommonStyles.ts
+++ b/libs/core-ui/src/lib/util/getCommonStyles.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const descriptionMaxWidth = "750px";

--- a/libs/counterfactuals/src/lib/CounterfactualsTab.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualsTab.styles.ts
@@ -10,6 +10,7 @@ import {
 
 export interface ICounterfactualsTabStyles {
   container: IStyle;
+  infoWithText: IStyle;
 }
 
 export const counterfactualsTabStyles: () => IProcessedStyleSet<ICounterfactualsTabStyles> =
@@ -19,6 +20,7 @@ export const counterfactualsTabStyles: () => IProcessedStyleSet<ICounterfactuals
       container: {
         color: theme.semanticColors.bodyText,
         padding: "0 40px 10px 40px"
-      }
+      },
+      infoWithText: { maxWidth: "750px" }
     });
   };

--- a/libs/counterfactuals/src/lib/CounterfactualsTab.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualsTab.styles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IStyle,
   mergeStyleSets,
@@ -21,6 +22,6 @@ export const counterfactualsTabStyles: () => IProcessedStyleSet<ICounterfactuals
         color: theme.semanticColors.bodyText,
         padding: "0 40px 10px 40px"
       },
-      infoWithText: { maxWidth: "750px" }
+      infoWithText: { maxWidth: descriptionMaxWidth }
     });
   };

--- a/libs/counterfactuals/src/lib/CounterfactualsTab.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualsTab.tsx
@@ -48,7 +48,7 @@ export class CounterfactualsTab extends React.PureComponent<
     const classNames = counterfactualsTabStyles();
     return (
       <Stack grow tokens={{ padding: "l1" }} className={classNames.container}>
-        <Stack.Item>
+        <Stack.Item className={classNames.infoWithText}>
           <Text variant={"medium"}>
             {localization.Counterfactuals.whatifDescription}
           </Text>

--- a/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
@@ -110,6 +110,7 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorer
         width: "23px"
       },
       infoWithText: {
+        maxWidth: "750px",
         paddingLeft: "33px",
         width: "100%"
       },

--- a/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { FabricStyles } from "@responsible-ai/core-ui";
+import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
 import {
   IStyle,
   mergeStyleSets,
@@ -110,7 +110,7 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorer
         width: "23px"
       },
       infoWithText: {
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingLeft: "33px",
         width: "100%"
       },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -16,6 +16,7 @@ export interface ITreeViewRendererStyles {
   clickedNodeDashed: IStyle;
   clickedNodeFull: IStyle;
   filledNodeText: IStyle;
+  infoWithText: IStyle;
   legend: IStyle;
   linkLabel: IStyle;
   node: IStyle;
@@ -56,6 +57,7 @@ export const treeViewRendererStyles = (props?: {
         fill: ColorPalette.ErrorAnalysisLightText
       }
     ]),
+    infoWithText: { maxWidth: "750px" },
     legend: {
       pointerEvents: "none"
     },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import { Property } from "csstype";
 import {
   IStyle,
@@ -57,7 +58,7 @@ export const treeViewRendererStyles = (props?: {
         fill: ColorPalette.ErrorAnalysisLightText
       }
     ]),
-    infoWithText: { maxWidth: "750px" },
+    infoWithText: { maxWidth: descriptionMaxWidth },
     legend: {
       pointerEvents: "none"
     },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -277,7 +277,7 @@ export class TreeViewRenderer extends React.PureComponent<
     const svgHeight = maxY - minY;
     return (
       <Stack tokens={{ childrenGap: "l1", padding: "l1" }}>
-        <Stack.Item>
+        <Stack.Item className={classNames.infoWithText}>
           <Text variant="medium">
             {this.props.getTreeNodes
               ? localization.ErrorAnalysis.TreeView.treeDescription

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IStyle,
   mergeStyleSets,
@@ -69,7 +70,7 @@ export const globalTabStyles: () => IProcessedStyleSet<IGlobalTabStyles> =
         width: "23px"
       },
       infoWithText: {
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
@@ -69,6 +69,7 @@ export const globalTabStyles: () => IProcessedStyleSet<IGlobalTabStyles> =
         width: "23px"
       },
       infoWithText: {
+        maxWidth: "750px",
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IStyle,
   mergeStyleSets,
@@ -21,7 +22,7 @@ export const modelPerformanceTabStyles: () => IProcessedStyleSet<IModelPerforman
         boxSizing: "border-box",
         display: "flex",
         flexDirection: "row",
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
@@ -21,6 +21,7 @@ export const modelPerformanceTabStyles: () => IProcessedStyleSet<IModelPerforman
         boxSizing: "border-box",
         display: "flex",
         flexDirection: "row",
+        maxWidth: "750px",
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { FabricStyles } from "@responsible-ai/core-ui";
+import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
 import {
   IProcessedStyleSet,
   getTheme,
@@ -235,7 +235,7 @@ export const whatIfTabStyles: () => IProcessedStyleSet<IWhatIfTabStyles> =
         boxSizing: "border-box",
         display: "flex",
         flexDirection: "row",
-        maxWidth: "750px",
+        maxWidth: descriptionMaxWidth,
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -235,6 +235,7 @@ export const whatIfTabStyles: () => IProcessedStyleSet<IWhatIfTabStyles> =
         boxSizing: "border-box",
         display: "flex",
         flexDirection: "row",
+        maxWidth: "750px",
         paddingLeft: "25px",
         width: "100%"
       },

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.styles.ts
@@ -13,6 +13,7 @@ export interface IFeatureImportanceStyles {
   header: IStyle;
   headerCount: IStyle;
   headerTitle: IStyle;
+  infoWithText: IStyle;
   selectionCounter: IStyle;
 }
 
@@ -45,6 +46,7 @@ export const individualFeatureImportanceViewStyles: () => IProcessedStyleSet<IFe
           paddingTop: 4
         }
       ],
+      infoWithText: { maxWidth: "750px" },
       selectionCounter: {
         paddingTop: 12
       }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.styles.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { descriptionMaxWidth } from "@responsible-ai/core-ui";
 import {
   IStyle,
   mergeStyleSets,
@@ -46,7 +47,7 @@ export const individualFeatureImportanceViewStyles: () => IProcessedStyleSet<IFe
           paddingTop: 4
         }
       ],
-      infoWithText: { maxWidth: "750px" },
+      infoWithText: { maxWidth: descriptionMaxWidth },
       selectionCounter: {
         paddingTop: 12
       }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
@@ -162,7 +162,7 @@ export class IndividualFeatureImportanceView extends React.Component<
 
     return (
       <Stack tokens={{ padding: "l1" }}>
-        <Stack.Item>
+        <Stack.Item className={classNames.infoWithText}>
           <Text variant="medium">
             {localization.ModelAssessment.FeatureImportances.IndividualFeature}
           </Text>

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -8,7 +8,8 @@ import {
   OverallMetricChart,
   BinaryClassificationMetrics,
   RegressionMetrics,
-  classificationTask
+  classificationTask,
+  descriptionMaxWidth
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
@@ -120,7 +121,7 @@ export class ModelOverview extends React.Component<
 
     return (
       <Stack tokens={{ childrenGap: "10px", padding: "16px 40px 10px 40px" }}>
-        <Text variant="medium" style={{ maxWidth: "750px" }}>
+        <Text variant="medium" style={{ maxWidth: descriptionMaxWidth }}>
           {localization.Interpret.ModelPerformance.helperText}
         </Text>
         {!this.props.showNewModelOverviewExperience && <OverallMetricChart />}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -120,7 +120,7 @@ export class ModelOverview extends React.Component<
 
     return (
       <Stack tokens={{ childrenGap: "10px", padding: "16px 40px 10px 40px" }}>
-        <Text variant="medium">
+        <Text variant="medium" style={{ maxWidth: "750px" }}>
           {localization.Interpret.ModelPerformance.helperText}
         </Text>
         {!this.props.showNewModelOverviewExperience && <OverallMetricChart />}


### PR DESCRIPTION
This PR adds maxWidth limit to 750px for each RAI component for readability.

## Description
Attached GIF in section below for detailed UI changes.


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [x] responsibleai/causality
- [x] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [x] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [x] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):
![OSSDescriptionWidth](https://user-images.githubusercontent.com/91754176/162842291-83fac5bb-0236-4940-a178-4c466a2392ea.gif)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
