### PR TITLE
Change the counterfactual text color from black to grey

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
@@ -209,7 +209,7 @@ export class CounterfactualPanel extends React.Component<
           />
         </Stack.Item>
         <Stack.Item align="end" grow={3}>
-          <Text variant={"medium"}>
+          <Text variant={"medium"} className={classes.saveDescription}>
             {localization.Counterfactuals.saveDescription}
           </Text>
         </Stack.Item>

--- a/libs/counterfactuals/src/lib/CounterfactualPanelStyles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualPanelStyles.ts
@@ -33,6 +33,7 @@ export interface ICounterfactualPanelStyles {
   stackHeader: IStyle;
   counterfactualName: IStyle;
   tooltipHostDisplay: IStyle;
+  saveDescription: IStyle;
 }
 
 export const counterfactualPanelStyles: () => IProcessedStyleSet<ICounterfactualPanelStyles> =
@@ -104,6 +105,7 @@ export const counterfactualPanelStyles: () => IProcessedStyleSet<ICounterfactual
       predictedLink: {
         color: theme.palette.blue
       },
+      saveDescription: { color: theme.semanticColors.buttonTextDisabled },
       searchBox: {
         width: "210px"
       },


### PR DESCRIPTION
## Description

Make the counterfactual text to stand out less by changing the color from black to grey.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):
Before:-
![image](https://user-images.githubusercontent.com/47334368/162845858-2a1d180c-1a02-4c11-bc5f-abb6e400f67a.png)

After:-
![image](https://user-images.githubusercontent.com/47334368/162845747-cbd4dae0-2058-4a4d-9b93-e3998b0ce1a2.png)

![image](https://user-images.githubusercontent.com/47334368/162845647-c31be778-2086-4328-a085-19038f8bd03b.png)

![image](https://user-images.githubusercontent.com/47334368/162845701-f3c16ed4-fa43-468a-acbd-b3277ef1d1b8.png)


## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
