### PR TITLE
Add warning message in cohort editor for invalid input value; Update 'Shift cohort' to 'Switch cohort'

### DIFF
--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.styles.ts
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.styles.ts
@@ -45,6 +45,7 @@ export interface ICohortEditorStyles {
   cohortEditor: IStyle;
   saveAndDeleteDiv: IStyle;
   clearFilter: IStyle;
+  invalidValueError: IStyle;
 }
 
 export const cohortEditorStyles: () => IProcessedStyleSet<ICohortEditorStyles> =
@@ -197,6 +198,11 @@ export const cohortEditorStyles: () => IProcessedStyleSet<ICohortEditorStyles> =
         padding: "1px 9px 6px 11px",
         textOverflow: "ellipsis",
         whiteSpace: "nowrap"
+      },
+      invalidValueError: {
+        color: theme.semanticColors.severeWarningIcon,
+        fontSize: "12px",
+        marginTop: "4px"
       },
       leftHalf: {
         height: "344px",

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.tsx
@@ -55,6 +55,8 @@ export interface ICohortEditorState {
   cohortName?: string;
   selectedFilterCategory?: string;
   showConfirmation: boolean;
+  showInvalidMinMaxValueError: boolean;
+  showInvalidValueError: boolean;
 }
 
 export class CohortEditor extends React.PureComponent<
@@ -94,7 +96,9 @@ export class CohortEditor extends React.PureComponent<
       filters: this.props.filterList || [],
       openedFilter: undefined,
       selectedFilterCategory: undefined,
-      showConfirmation: false
+      showConfirmation: false,
+      showInvalidMinMaxValueError: false,
+      showInvalidValueError: false
     };
     this._isInitialized = true;
   }
@@ -153,6 +157,10 @@ export class CohortEditor extends React.PureComponent<
                   setComparison={this.setComparison}
                   setNumericValue={this.setNumericValue}
                   setSelectedProperty={this.setSelectedProperty}
+                  showInvalidValueError={this.state.showInvalidValueError}
+                  showInvalidMinMaxValueError={
+                    this.state.showInvalidMinMaxValueError
+                  }
                   filterIndex={this.state.filterIndex}
                 />
               )}
@@ -428,21 +436,37 @@ export class CohortEditor extends React.PureComponent<
         numberVal > max ||
         numberVal < min
       ) {
+        this.setState({
+          showInvalidMinMaxValueError: false,
+          showInvalidValueError: true
+        });
         return this.state.openedFilter.arg[index].toString();
       }
+      this.setState({ showInvalidValueError: false });
       openArg[index] = numberVal;
     } else {
       const prevVal = openArg[index];
       const newVal = prevVal + delta;
       if (newVal > max || newVal < min) {
+        this.setState({
+          showInvalidMinMaxValueError: false,
+          showInvalidValueError: true
+        });
         return prevVal.toString();
       }
+      this.setState({ showInvalidValueError: false });
       openArg[index] = newVal;
     }
 
     // in the range validation
     if (openArg[1] <= openArg[0]) {
       openArg[1] = max;
+      this.setState({
+        showInvalidMinMaxValueError: true,
+        showInvalidValueError: false
+      });
+    } else {
+      this.setState({ showInvalidMinMaxValueError: false });
     }
 
     this.setState({

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditorFilter.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditorFilter.tsx
@@ -21,11 +21,15 @@ import { FilterMethods, IFilter } from "../../Interfaces/IFilter";
 import { FabricStyles } from "../../util/FabricStyles";
 import { IJointMeta, JointDataset } from "../../util/JointDataset";
 
+import { cohortEditorStyles } from "./CohortEditor.styles";
+
 export interface ICohortEditorFilterProps {
   openedFilter: IFilter;
   jointDataset: JointDataset;
   filterIndex?: number;
   filters: IFilter[];
+  showInvalidMinMaxValueError: boolean;
+  showInvalidValueError: boolean;
   setSelectedProperty(
     ev: React.FormEvent<IComboBox>,
     item?: IComboBoxOption
@@ -99,7 +103,7 @@ export class CohortEditorFilter extends React.Component<ICohortEditorFilterProps
     // filterIndex is set when the filter is editing openedFilter and reset to filters.length otherwise
     const isEditingFilter =
       this.props.filterIndex !== this.props.filters.length;
-
+    const styles = cohortEditorStyles();
     let minVal, maxVal;
     if (selectedMeta.treatAsCategorical || !selectedMeta.featureRange) {
       // Numerical values treated as categorical are stored with the values in the column,
@@ -228,6 +232,17 @@ export class CohortEditorFilter extends React.Component<ICohortEditorFilterProps
                       this.props.setNumericValue(0, selectedMeta, 1, value);
                     }}
                   />
+                  {this.props.showInvalidMinMaxValueError &&
+                    selectedMeta.featureRange && (
+                      <p className={styles.invalidValueError}>
+                        {localization.formatString(
+                          localization.Interpret.CohortEditor
+                            .minimumGreaterThanMaximum,
+                          selectedMeta.featureRange.min,
+                          selectedMeta.featureRange.max
+                        )}
+                      </p>
+                    )}
                 </>
               ) : (
                 <SpinButton
@@ -257,6 +272,15 @@ export class CohortEditorFilter extends React.Component<ICohortEditorFilterProps
                   }}
                 />
               ))}
+            {this.props.showInvalidValueError && selectedMeta.featureRange && (
+              <p className={styles.invalidValueError}>
+                {localization.formatString(
+                  localization.Interpret.CohortEditor.invalidValueError,
+                  selectedMeta.featureRange.min,
+                  selectedMeta.featureRange.max
+                )}
+              </p>
+            )}
           </>
         )}
         <Stack horizontal tokens={{ childrenGap: "l1" }}>

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -82,7 +82,7 @@
       "Unknown": "unknown"
     },
     "ShiftCohort": {
-      "title": "Shift Cohort",
+      "title": "Switch Cohort",
       "subText": "Select a cohort from the cohort list. Apply the cohort to the dashboard."
     },
     "PreBuiltCohort": {
@@ -211,7 +211,7 @@
       "fullscreen": "Fullscreen",
       "heatMap": "Heat map",
       "newCohort": "New cohort",
-      "shiftCohort": "Shift cohort",
+      "shiftCohort": "Switch cohort",
       "treeMap": "Tree map",
       "whatIf": "What-If"
     },
@@ -1265,11 +1265,11 @@
       "deleteCohort": "Deleting {0}?",
       "deleteConfirm": "Are you sure you want to delete this cohort?",
       "selectCohort": "Select a cohort",
-      "shiftCohort": "Shift cohort",
+      "shiftCohort": "Switch cohort",
       "shiftCohortDescription": "Select a cohort from the cohort list. Apply the cohort to the dashboard."
     },
     "CohortInformation": {
-      "ShiftCohort": "Shift cohort",
+      "ShiftCohort": "Switch cohort",
       "NewCohort": "New cohort",
       "DataPoints": "Number of datapoints",
       "DefaultCohort": " (default)",
@@ -1316,7 +1316,7 @@
       "cohortList": "Cohort list",
       "cohortSettings": "Cohort settings",
       "createCohort": "Create cohort",
-      "shiftCohort": "Shift cohort"
+      "shiftCohort": "Switch cohort"
     },
     "Navigation": {
       "modelStatistics": "Model statistics"

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -811,6 +811,8 @@
       "clearAllFilters": "Clear all filters",
       "defaultFilterState": "Select a filter to add parameters to your dataset cohort. Filters from your current viewing cohort are pre-populated.",
       "delete": "Delete",
+      "invalidValueError": "Value should be between {0} and {1}",
+      "minimumGreaterThanMaximum": "Minimum value inputs must be less than maximum value inputs.",
       "noAddedFilters": "No filters",
       "placeholderName": "Cohort {0}",
       "save": "Save",


### PR DESCRIPTION
This PR adds warning messages in cohort editor for invalid input values; This PR also updates wording from 'Shift cohort' to 'Switch cohort'.

## Description

1. Add warning messages in cohort editor for invalid input values: There was a bug created regarding to cohort input field, where manually putting in a value with keyboard does not work. The root cause for this bug is, we limit input value to be in between min value and max value if it is a numeric number. We don't allow users to input invalid values. In the case when user inputs an invalid value, we reset the value back to previous input value. This PR adds warning message to users so that users can understand the reason they are not able to input the value is because the input value is invalid.
![image](https://user-images.githubusercontent.com/91754176/163046043-a5126a2b-1556-4685-90ab-528bf44af2a4.png)
![image](https://user-images.githubusercontent.com/91754176/163045921-f29e472b-ef49-4b81-90ff-8b614caa7988.png)

2. We used to show "Shift cohort" in some places, while "Switch cohort" in others. This PR updates all the wordings from 'Shift cohort' to 'Switch cohort' to be consistent.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [x] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/91754176/163044998-bdc7b97c-c772-4b9a-b862-a8440db19fda.png)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
