### PR TITLE
Counterfactual flyout top section need to be moved to left & Error analysis move side content to align with description text

### DIFF
--- a/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.styles.ts
+++ b/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.styles.ts
@@ -19,7 +19,7 @@ export const cohortInfoStyles: () => IProcessedStyleSet<ICohortInfoStyles> =
         minWidth: "120px"
       },
       container: {
-        padding: `65px 0 0 20px`
+        padding: "65px 0 0 20px"
       }
     });
   };

--- a/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.styles.ts
+++ b/libs/core-ui/src/lib/Cohort/CohortInfo/CohortInfo.styles.ts
@@ -19,7 +19,7 @@ export const cohortInfoStyles: () => IProcessedStyleSet<ICohortInfoStyles> =
         minWidth: "120px"
       },
       container: {
-        padding: "0 0 0 20px"
+        padding: `65px 0 0 20px`
       }
     });
   };

--- a/libs/counterfactuals/src/lib/CounterfactualPanel.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualPanel.styles.ts
@@ -90,7 +90,10 @@ export const counterfactualPanelStyles: () => IProcessedStyleSet<ICounterfactual
             paddingLeft: 24,
             paddingRight: 24
           },
-          ".scrollableContent": { height: "100%", paddingTop: 1 }
+          ".scrollableContent": { height: "100%", paddingTop: 1 },
+          ".ms-Panel-navigation": {
+            justifyContent: "space-between"
+          }
         }
       },
       positiveNumber: {

--- a/libs/counterfactuals/src/lib/CounterfactualPanel.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualPanel.styles.ts
@@ -90,10 +90,10 @@ export const counterfactualPanelStyles: () => IProcessedStyleSet<ICounterfactual
             paddingLeft: 24,
             paddingRight: 24
           },
-          ".scrollableContent": { height: "100%", paddingTop: 1 },
           ".ms-Panel-navigation": {
             justifyContent: "space-between"
-          }
+          },
+          ".scrollableContent": { height: "100%", paddingTop: 1 }
         }
       },
       positiveNumber: {


### PR DESCRIPTION
Counterfactual flyout top section need to be moved to left & Error analysis move side content to align with description text

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

Before:
Counterfactual panel:
![image](https://user-images.githubusercontent.com/33799331/163470108-7ab5345f-7ddd-456b-a23a-cab737088adf.png)

Error analysis:
![image](https://user-images.githubusercontent.com/33799331/163470175-0f3fdac6-58c7-4bd0-ba5d-f5a38230f7e9.png)


After:
Counterfactual panel:
![image](https://user-images.githubusercontent.com/33799331/163470259-8e396bc2-5f4e-492e-a557-aa2ae59fdbcf.png)

Error analysis:
![image](https://user-images.githubusercontent.com/33799331/163470224-70c76c90-602f-4cb0-9744-7703ce153fe5.png)



## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
