### PR TITLE
move the root all data statistics to ErrorReport and ErrorAnalysisData (part 2)

### DIFF
--- a/.eslintrc/.eslintrc.custom.eslintrc
+++ b/.eslintrc/.eslintrc.custom.eslintrc
@@ -105,6 +105,7 @@
           "rms_error",
           "roc_auc_score_min",
           "root_mean_squared_error",
+          "root_stats",
           "scores_range",
           "selection_rate",
           "shap_deep",

--- a/apps/widget/src/app/ErrorAnalysis.tsx
+++ b/apps/widget/src/app/ErrorAnalysis.tsx
@@ -58,7 +58,6 @@ export class ErrorAnalysis extends React.Component {
         localUrl={config.baseUrl}
         locale={config.locale}
         features={modelData.featureNames}
-        rootStats={modelData.rootStats}
         errorAnalysisData={modelData.errorAnalysisData}
       />
     );

--- a/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
+++ b/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
@@ -11,7 +11,16 @@ export interface IErrorAnalysisData {
   numLeaves: number;
   minChildSamples: number;
   metric: string;
+  root_stats?: IErrorAnalysisRootStats;
 }
+
+export interface IErrorAnalysisRootStats {
+  metricName: string;
+  metricValue: number;
+  totalSize: number;
+  errorCoverage: number;
+}
+
 // Represents the data retrieved from the backend
 export interface IErrorAnalysisTreeNode {
   arg: number | number[] | undefined;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -249,13 +249,13 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     const globalProps = buildGlobalProperties(props.precomputedExplanations);
     // consider taking filters in as param arg for programmatic users
     let metricStats: MetricCohortStats | undefined = undefined;
-    if (props.rootStats) {
+    if (props.errorAnalysisData.root_stats) {
       metricStats = new MetricCohortStats(
-        props.rootStats.totalSize,
-        props.rootStats.totalSize,
-        props.rootStats.metricValue,
-        props.rootStats.metricName,
-        props.rootStats.errorCoverage
+        props.errorAnalysisData.root_stats.totalSize,
+        props.errorAnalysisData.root_stats.totalSize,
+        props.errorAnalysisData.root_stats.metricValue,
+        props.errorAnalysisData.root_stats.metricName,
+        props.errorAnalysisData.root_stats.errorCoverage
       );
     }
     const cohorts = [
@@ -550,9 +550,9 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                         <PivotItem key={props.itemKey} {...props} />
                       ))}
                     </Pivot>
-                    {this.props.rootStats &&
+                    {this.props.errorAnalysisData.root_stats &&
                       this.state.jointDataset.datasetRowCount !==
-                        this.props.rootStats.totalSize && (
+                        this.props.errorAnalysisData.root_stats.totalSize && (
                         <MessageBar messageBarType={MessageBarType.warning}>
                           <Text>{localization.ErrorAnalysis.scaleWarning}</Text>
                         </MessageBar>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardProps.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardProps.ts
@@ -26,13 +26,6 @@ import { IStringsParam } from "./IStringsParam";
  * @property {number[][] | number[]} [probabilityY] - model probabilities for output values. Dim(rows) x [Dim(classes)]
  */
 
-export interface IRootStats {
-  metricName: string;
-  metricValue: number;
-  totalSize: number;
-  errorCoverage: number;
-}
-
 export interface IErrorAnalysisDashboardProps
   extends IExplanationDashboardData,
     IOfficeFabricProps {
@@ -58,7 +51,6 @@ export interface IErrorAnalysisDashboardProps
     abortSignal: AbortSignal
   ) => Promise<any[]>;
   localUrl: string;
-  rootStats?: IRootStats;
   telemetryHook?: (message: ITelemetryMessage) => void;
   errorAnalysisData: IErrorAnalysisData;
 }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -6,13 +6,15 @@ import {
   ISingleClassLocalFeatureImportance,
   JointDataset,
   Cohort,
+  CohortSource,
   IExplanationModelMetadata,
   isThreeDimArray,
   ErrorCohort,
   buildGlobalProperties,
   buildIndexedNames,
   getClassLength,
-  getModelType
+  getModelType,
+  MetricCohortStats
 } from "@responsible-ai/core-ui";
 import { ErrorAnalysisOptions } from "@responsible-ai/error-analysis";
 import { localization } from "@responsible-ai/localization";
@@ -56,13 +58,28 @@ export function buildInitialModelAssessmentContext(
     props.modelExplanationData?.[0]?.precomputedExplanations
   );
 
+  let metricStats: MetricCohortStats | undefined = undefined;
+  if (props.errorAnalysisData?.[0]?.root_stats) {
+    const rootStats = props.errorAnalysisData?.[0]?.root_stats;
+    metricStats = new MetricCohortStats(
+      rootStats.totalSize,
+      rootStats.totalSize,
+      rootStats.metricValue,
+      rootStats.metricName,
+      rootStats.errorCoverage
+    );
+  }
   const defaultErrorCohort = new ErrorCohort(
     new Cohort(
       localization.ErrorAnalysis.Cohort.defaultLabel,
       jointDataset,
       []
     ),
-    jointDataset
+    jointDataset,
+    0,
+    CohortSource.None,
+    false,
+    metricStats
   );
   let errorCohortList: ErrorCohort[] = [defaultErrorCohort];
   const [preBuiltErrorCohortList] = processPreBuiltCohort(props, jointDataset);

--- a/raiwidgets/raiwidgets/explanation_constants.py
+++ b/raiwidgets/raiwidgets/explanation_constants.py
@@ -31,11 +31,6 @@ class ExplanationDashboardInterface(object):
     TRAINING_DATA = "trainingData"
     TRUE_Y = "trueY"
     LOCAL_URL = "localUrl"
-    ROOT_METRIC_NAME = 'metricName'
-    ROOT_METRIC_VALUE = 'metricValue'
-    ROOT_TOTAL_SIZE = 'totalSize'
-    ROOT_ERROR_COVERAGE = 'errorCoverage'
-    ROOT_STATS = 'rootStats'
 
 
 class DatabricksInterfaceConstants(object):

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -70,6 +70,7 @@ class ErrorAnalysisData:
     matrix_features: List[str]
     metric: str
     importances: list
+    root_stats: Dict[str, Any]
 
 
 class CausalMetric:

--- a/responsibleai/responsibleai/_internal/constants.py
+++ b/responsibleai/responsibleai/_internal/constants.py
@@ -39,11 +39,11 @@ class ExplainerManagerKeys(object):
 
 class ErrorAnalysisManagerKeys(object):
     """Provide constants for ErrorAnalysisManager key properties."""
+    FILTER_FEATURES = 'filter_features'
     IS_COMPUTED = 'is_computed'
     MAX_DEPTH = 'max_depth'
-    NUM_LEAVES = 'num_leaves'
     MIN_CHILD_SAMPLES = 'min_child_samples'
-    FILTER_FEATURES = 'filter_features'
+    NUM_LEAVES = 'num_leaves'
     REPORTS = 'reports'
 
 

--- a/responsibleai/responsibleai/_tools/error_analysis/dashboard_schemas/error_analysis_output_v0.0.json
+++ b/responsibleai/responsibleai/_tools/error_analysis/dashboard_schemas/error_analysis_output_v0.0.json
@@ -165,6 +165,25 @@
         }
       ]
     },
+    "root_stats": {
+      "description": "The statistics about the root node.",
+      "type": "object",
+      "properties": {
+        "metricName": {
+          "type": "string"
+        },
+        "metricValue": {
+          "type": "number"
+        },
+        "totalSize": {
+          "type": "number"
+        },
+        "errorCoverage": {
+          "type": "number"
+        }
+      },
+      "required": ["metricName", "metricValue", "totalSize", "errorCoverage"]
+    },
     "metadata": {
       "description": "The metadata about the generated error analysis report.",
       "type": "object",

--- a/responsibleai/responsibleai/managers/error_analysis_manager.py
+++ b/responsibleai/responsibleai/managers/error_analysis_manager.py
@@ -240,7 +240,8 @@ class ErrorAnalysisManager(BaseManager):
                 filter_features, max_depth=max_depth,
                 min_child_samples=min_child_samples,
                 num_leaves=num_leaves,
-                compute_importances=True)
+                compute_importances=True,
+                compute_root_stats=True)
 
             # Validate the serialized output against schema
             schema = ErrorAnalysisManager._get_error_analysis_schema()
@@ -294,21 +295,21 @@ class ErrorAnalysisManager(BaseManager):
         :return: A array of ErrorAnalysisConfig.
         :rtype: List[ErrorAnalysisConfig]
         """
+        report_props = zip(self.get(), self.list()[Keys.REPORTS])
         return [
-            self._get_error_analysis(i) for i in self.list()["reports"]]
+            self._get_error_analysis(report,
+                                     props) for report, props in report_props]
 
-    def _get_error_analysis(self, report):
+    def _get_error_analysis(self, report, props):
         error_analysis = ErrorAnalysisData()
-        error_analysis.maxDepth = report[Keys.MAX_DEPTH]
-        error_analysis.numLeaves = report[Keys.NUM_LEAVES]
-        error_analysis.minChildSamples = report[Keys.MIN_CHILD_SAMPLES]
-        error_analysis.tree = self._analyzer.compute_error_tree(
-            self._feature_names, None, None, error_analysis.maxDepth,
-            error_analysis.numLeaves, error_analysis.minChildSamples)
-        error_analysis.matrix = self._analyzer.compute_matrix(
-            self._feature_names, None, None)
-        error_analysis.importances = self._analyzer.compute_importances()
+        error_analysis.maxDepth = props[Keys.MAX_DEPTH]
+        error_analysis.numLeaves = props[Keys.NUM_LEAVES]
+        error_analysis.minChildSamples = props[Keys.MIN_CHILD_SAMPLES]
+        error_analysis.tree = report.tree
+        error_analysis.matrix = report.matrix
+        error_analysis.importances = report.importances
         error_analysis.metric = metric_to_display_name[self._analyzer.metric]
+        error_analysis.root_stats = report.root_stats
         return error_analysis
 
     @property


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Note: this is part 2 of the change, which is for responsibleai and the UI after erroranalysis package has been published.

Move the root all data statistics to ErrorReport and ErrorAnalysisData.
Currently we pass the root data statistics only in the error analysis dashboard, which is the data set on the "all data" cohort when it is first initialized. This PR moved the root data statistics to ErrorReport and ErrorAnalysisData in order to make it consistent with other error analysis properties. This also resolves the issue where error rate statistics are shown for the regression scenario when the RAI dashboard is first loaded.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
