### PR TITLE
A few UI alignment fixes

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.styles.ts
@@ -24,7 +24,7 @@ export const causalIndividualChartStyles: () => IProcessedStyleSet<ICausalIndivi
     return mergeStyleSets<ICausalIndividualChartStyles>({
       chartWithAxes: {
         paddingTop: "30px",
-        width: "97%"
+        width: "80%"
       },
       chartWithVertical: {
         width: "100%"

--- a/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.styles.ts
+++ b/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.styles.ts
@@ -25,7 +25,7 @@ export const featureImportanceBarStyles: IProcessedStyleSet<IFeatureImportanceBa
       width: "95%"
     },
     chartWithVertical: {
-      width: "100%"
+      width: "80%"
     },
     noData: {
       flex: "1",

--- a/libs/counterfactuals/src/lib/CounterfactualChart.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.styles.ts
@@ -25,7 +25,7 @@ export const counterfactualChartStyles: () => IProcessedStyleSet<ICounterfactual
     return mergeStyleSets<ICounterfactualChartStyles>({
       chartWithAxes: {
         paddingTop: "30px",
-        width: "97%"
+        width: "80%"
       },
       chartWithVertical: {
         width: "100%"

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -26,6 +26,7 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
       errorAnalysis: {
         color: theme.semanticColors.bodyText,
         overflow: "auto",
+        padding: "0 20px 20px",
         width: "100%"
       },
       errorAnalysisWrapper: { paddingLeft: "15px" },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
@@ -77,6 +77,7 @@ export const globalTabStyles: () => IProcessedStyleSet<IGlobalTabStyles> =
       },
       legendAndSort: {
         height: "100%",
+        paddingLeft: "25px",
         paddingTop: "55px",
         width: rightMarginWidth
       },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -204,7 +204,7 @@ export class LocalImportancePlots extends React.Component<
                       onChange={this.setSortIndex}
                     />
                   </Stack.Item>
-                  <Stack.Item>
+                  <Stack.Item className={classNames.absoluteValueToggle}>
                     <Toggle
                       label={localization.Interpret.GlobalTab.absoluteValues}
                       inlineLabel

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -10,6 +10,7 @@ import {
 } from "office-ui-fabric-react";
 
 export interface IWhatIfTabStyles {
+  absoluteValueToggle: IStyle;
   page: IStyle;
   blackIcon: IStyle;
   expandedPanel: IStyle;
@@ -83,6 +84,9 @@ export const whatIfTabStyles: () => IProcessedStyleSet<IWhatIfTabStyles> =
     const legendWidth = "160px";
     const theme = getTheme();
     return mergeStyleSets<IWhatIfTabStyles>({
+      absoluteValueToggle: {
+        width: "170px"
+      },
       blackIcon: {
         color: theme.semanticColors.bodyText
       },

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
@@ -19,7 +19,7 @@ export const modelOverviewStyles: () => IProcessedStyleSet<IModelOverviewStyles>
         width: "400px"
       },
       sectionStack: {
-        padding: "16px 40px 10px 40px"
+        padding: "0 40px 10px 40px"
       }
     });
   };


### PR DESCRIPTION
This PR fixes a few UI alignment issues. Attached detailed explanation and screenshots below.

## Description
1.  Big gap between error analysis title and the pivot tabs (this pr updates every gap under section title to be 16px):
Before:
![image](https://user-images.githubusercontent.com/91754176/163862186-70e6428b-a960-4d33-9ce6-d89ed82ece0a.png)

After:
![image](https://user-images.githubusercontent.com/91754176/163862216-37d4dc34-11c9-4f71-8704-758bafd27c9f.png)

2. View dependence plot text is overlapped by chart:
Before:
![image](https://user-images.githubusercontent.com/91754176/163862412-5426ef29-b5b1-4781-b307-db2e57f97c70.png)

After:
![image](https://user-images.githubusercontent.com/91754176/163862556-0f527a04-7832-4938-be22-7a7802841277.png)

3. word 'absolute' is cut in half:
Before:
![image](https://user-images.githubusercontent.com/91754176/163862634-15370e4e-626f-4076-920a-8ac563fb3382.png)
After:
![image](https://user-images.githubusercontent.com/91754176/163862682-05740f92-06ca-4c71-b482-f0fdb5207f06.png)

4. update counterfactual chart and individual feature importance chart to be width 80%, this fixes the alignment issue when zoom in:
Before:
![image](https://user-images.githubusercontent.com/91754176/163862906-c6795d1c-39f4-4c3a-ad43-f8d01f36fd66.png)

After:
![image](https://user-images.githubusercontent.com/91754176/163863018-a218c2ec-a5cc-4fd9-b50c-fef723ef1cf5.png)



## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [x] responsibleai/causality
- [x] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [x] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [x] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
