### PR TITLE
release rai-core-flask 0.3.0

### DIFF
--- a/rai_core_flask/setup.py
+++ b/rai_core_flask/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 # The version must be incremented every time we push an update to pypi (but
 # not before)
-VERSION = "0.2.5"
+VERSION = "0.3.0"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Release rai-core-flask 0.3.0 to pypi.
Changes since 0.2.5 release:
https://github.com/microsoft/responsible-ai-toolbox/commits/main/rai_core_flask

- [update several required dependencies](https://github.com/microsoft/responsible-ai-toolbox/commit/11ee5caefedcf774e4e9d4ed81532aed93447933)
- [Pin markupsafe and itsdangerous to unblock gates](https://github.com/microsoft/responsible-ai-toolbox/commit/4185c9f2284690394f5be92063a8b91c16a3ee16)
- [upgrade pytest to 7.0.1, remove mock and updgrade pytest-mock to 3.6.1](https://github.com/microsoft/responsible-ai-toolbox/commit/615c9ed18700e15a5acae92e96db1d09e6a4615a)
- [remove deprecated codecov parameter](https://github.com/microsoft/responsible-ai-toolbox/commit/6510717dbcf19df9010a51cb0505dcfcac68fe46)
- [add retry logic to codecov step and only upload results for one python version](https://github.com/microsoft/responsible-ai-toolbox/commit/d96dad8077c2f1ec4a4c75f2a1f510d5d2ca66b9)

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
