### PR TITLE
add pytest-faulthandler to get better error messages during segmentation faults, and increase flask release tests verbosity

### DIFF
--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: rai_core_flask
 
       - name: run rai_core_flask tests
-        run: pytest ./tests/
+        run: pytest ./tests/ -s -v
         working-directory: rai_core_flask
 
       # publish to PyPI

--- a/erroranalysis/requirements-dev.txt
+++ b/erroranalysis/requirements-dev.txt
@@ -6,3 +6,4 @@ requests==2.25.1
 requirements-parser==0.2.0
 xgboost<=1.0.0
 shap>=0.20.0, <=0.39.0
+pytest-faulthandler

--- a/rai_core_flask/requirements-dev.txt
+++ b/rai_core_flask/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-mock==3.6.1
 requests==2.25.1
 
 requirements-parser==0.2.0
+pytest-faulthandler

--- a/raiutils/requirements-dev.txt
+++ b/raiutils/requirements-dev.txt
@@ -6,3 +6,4 @@ requests==2.25.1
 requirements-parser==0.2.0
 
 pandas>=0.25.1
+pytest-faulthandler

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -3,6 +3,7 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
+pytest-faulthandler
 requests==2.25.1
 
 requirements-parser==0.2.0

--- a/responsibleai/requirements-dev.txt
+++ b/responsibleai/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-mock==3.6.1
 # Required for responsibleai package tests
 deptree~=0.0.10
 xgboost<=1.0.0
+pytest-faulthandler


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

The rai-core-flask release seems to be failing when running tests on segfaults that I can't reproduce locally.  See example run:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/2190948840
This PR adds pytest-faulthandler to get better error messages from segfaults when running python (not just to rai-core-flask but indeed to all packages).  It also increases the verbosity via ```-s -v``` flags to get more information during tests.


## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
