### PR TITLE
upgrade python version used with flask CI to fix segfault error

### DIFF
--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The rai-core-flask release seems to be failing when running tests on segfaults that I can't reproduce locally. See example run:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/2190948840
This PR attempts to fix the segfault error.
This seems to be fixed now according to this build:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/2191270942
Upgrading python version seems to resolve the segfault.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
