### PR TITLE
Fix bug on scatter points in dataset explorer; remove outlier for aggregate feature importance box chart

### DIFF
--- a/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
@@ -49,12 +49,6 @@ export function getFeatureImportanceBoxOptions(
       name: data.name,
       type: "boxplot"
     });
-    boxGroupData.push({
-      color: data.color,
-      data: boxData.outlier,
-      name: data.name,
-      type: "scatter"
-    });
   });
   return {
     chart: {

--- a/libs/dataset-explorer/src/lib/getDatasetBoxOption.ts
+++ b/libs/dataset-explorer/src/lib/getDatasetBoxOption.ts
@@ -24,8 +24,7 @@ export function getDatasetBoxOption(plotlyProps: IPlotlyProperty): any {
     boxGroupData.push({
       data,
       marker: {
-        fillColor: FabricStyles.fabricColorPalette[0],
-        lineWidth: 35
+        fillColor: FabricStyles.fabricColorPalette[0]
       },
       name: localization.ModelAssessment.ModelOverview.BoxPlot.outlierLabel,
       type: "scatter"


### PR DESCRIPTION
This PR:
(1) Fixes bug on scatter points in dataset explorer
(2) Removes outlier for aggregate feature importance box chart

## Description

1. bug: Scatter points in dataset explorer have white circles around them that overlap with neighboring points. Fix is to remove the lineWidth for scatter points
Before:
![image](https://user-images.githubusercontent.com/91754176/164325838-b88d6f1e-3831-4897-8e2a-b457bdd5993a.png)

After:
![image](https://user-images.githubusercontent.com/91754176/164325933-b1ffbffb-da9a-4eff-8ce3-00157cbad775.png)

2. bug: Outlier points display in a vertical line. Each outlier doesn't match its cohort group. Talked to Ke on this, we will remove outlier. (I found a solution to manually add offset for each outlier group, and it will match the box chart for each group no matter zoom in or zoom out. We can add outliers back if needed in the future.)
Before:
![image](https://user-images.githubusercontent.com/91754176/164326150-765134f4-8c29-4222-b565-ccd6d2ea0008.png)

After:
![image](https://user-images.githubusercontent.com/91754176/164325301-31a9e6c0-2a80-463a-ade8-389c3441b4a4.png)

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [x] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
