### PR TITLE
Display outlier in aggregate feature importance box chart

### DIFF
--- a/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SeriesOptionsType } from "highcharts";
-
 import { IGlobalSeries } from "../Highchart/FeatureImportanceBar";
 import { IHighchartsConfig } from "../Highchart/IHighchartsConfig";
 
@@ -17,7 +15,7 @@ export function getFeatureImportanceBoxOptions(
   onFeatureSelection?: (seriesIndex: number, featureIndex: number) => void
 ): IHighchartsConfig {
   const xText = sortArray.map((i) => unsortedX[i]);
-  const boxTempData: any = [];
+  const boxTempData: any[] = [];
   let yAxisMin = Infinity;
 
   unsortedSeries.forEach((series) => {
@@ -40,14 +38,29 @@ export function getFeatureImportanceBoxOptions(
       y
     });
   });
-  const boxGroupData: SeriesOptionsType[] = [];
-  boxTempData.forEach((data: any) => {
+  const boxGroupData: any[] = [];
+  const numberOfCohorts: number = boxTempData.length;
+  const getPointPlacement = (index: number): number => {
+    if (numberOfCohorts % 2) {
+      return 0.14 * (index - Math.floor(numberOfCohorts / 2));
+    }
+    return 0.075 + 0.15 * (index - Math.floor(numberOfCohorts / 2));
+  };
+  boxTempData.forEach((data: any, index: number) => {
     const boxData = getBoxData(data.x, data.y);
     boxGroupData.push({
       color: data.color,
       data: boxData.box,
       name: data.name,
       type: "boxplot"
+    });
+    boxGroupData.push({
+      color: data.color,
+      data: boxData.outlier,
+      linkedTo: data.name,
+      name: data.name,
+      pointPlacement: getPointPlacement(index),
+      type: "scatter"
     });
   });
   return {
@@ -59,6 +72,7 @@ export function getFeatureImportanceBoxOptions(
     },
     plotOptions: {
       boxplot: {
+        groupPadding: 0,
         point: {
           events: {
             click() {


### PR DESCRIPTION
This PR adds outliers in aggregate feature importance box chart. We manually calculated the offset for outliers from different cohorts.


## Description

if cohort count is 6 (even case):
![image](https://user-images.githubusercontent.com/91754176/164345777-7f1aa3ee-82b9-47c7-a23b-747b7f106c2c.png)

if cohort count is 7 (odd case): 
![image](https://user-images.githubusercontent.com/91754176/164345810-9d0f9bae-448b-49fa-bd35-76e04bc282e7.png)


API Reference:
[http://api.highcharts.com/highcharts/pl ... oupPadding](http://api.highcharts.com/highcharts/plotOptions.boxplot.groupPadding)
[http://api.highcharts.com/highcharts/pl ... tPlacement](http://api.highcharts.com/highcharts/plotOptions.series.pointPlacement)

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [x] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
