### PR TITLE
Add missing desired range to counterfactual chart

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -377,6 +377,10 @@ export class CounterfactualChart extends React.PureComponent<
   }
 
   private getCurrentLabel(): string {
+    if (this.context.dataset.task_type === "regression") {
+      return `[${this.props.data.desired_range}]`;
+    }
+
     return this.props.data.desired_class || "";
   }
 


### PR DESCRIPTION
## Description

Seems like desired_range is missing from the counterfactual range.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [x] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [ ] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [ ] No new tests required.
- [x] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):
Before:-
![image](https://user-images.githubusercontent.com/47334368/164354440-98f84e89-543b-471e-89cf-e4f7aa4df6d4.png)

After:-
![image](https://user-images.githubusercontent.com/47334368/164354339-e8b7b7d8-aac6-48af-b88f-82017147ce39.png)

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
