### PR TITLE
Add more context to download print statement in fetch_dataset

### DIFF
--- a/raiutils/raiutils/dataset/dataset.py
+++ b/raiutils/raiutils/dataset/dataset.py
@@ -41,7 +41,7 @@ def fetch_dataset(url, filename, max_retries=4, retry_delay=60):
     :type retry_delay: int
     """
     retriever = Retriever(url, filename)
-    action_name = "Download"
+    action_name = "Dataset download"
     err_msg = "Failed to download dataset"
     retry_function(retriever.retrieve, action_name, err_msg,
                    max_retries=max_retries, retry_delay=retry_delay)


### PR DESCRIPTION
## Description

It seems in notebook when we call `fetch_dataset()` we print "Download attempt 1 of 4" which is a little misleading in terms of what we are downloading. Hence, adding "Dataset" to provide users context on what we are downloading locally for them.

## Areas changed

<!--- Put an `x` in all boxes that apply. Some changes (e.g., notebook fix) don't require ticking any boxes. -->

npm packages changed:

- [ ] responsibleai/causality
- [ ] responsibleai/core-ui
- [ ] responsibleai/counterfactuals
- [ ] responsibleai/dataset-explorer
- [ ] responsibleai/fairness
- [ ] responsibleai/interpret
- [ ] responsibleai/localization
- [ ] responsibleai/mlchartlib
- [ ] responsibleai/model-assessment

Python packages changed:

- [ ] erroranalysis
- [x] raiutils
- [ ] raiwidgets
- [ ] rai_core_flask
- [ ] responsibleai

## Tests

<!--- Put an `x` in all the boxes that apply: -->

- [x] No new tests required.
- [ ] New tests for the added feature are part of this PR.
- [ ] I validated the changes manually.

## Screenshots (if appropriate):

## Documentation:

<!--- Put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
