### PR TITLE
Use global cohort for disaggregated analysis

### DIFF
--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1375,7 +1375,9 @@
       "chartConfigCancel": "Cancel",
       "chartConfigDatasetCohortSelectionPlaceholder": "Select dataset cohorts",
       "chartConfigFeatureBasedCohortSelectionPlaceholder": "Select feature-based cohorts",
-      "nA": "N/A"
+      "nA": "N/A",
+      "disaggregatedAnalysisBaseCohortDislaimer": "The cohorts in the following disaggregated analysis are based on the global cohort, {0}.",
+      "disaggregatedAnalysisBaseCohortWarning": "Unlike the {0} cohort, {1} includes filters. As a consequence, it only captures a subset of the whole dataset and insights may not generalize to the full dataset."
     }
   }
 }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
@@ -39,7 +39,8 @@ function generateFiltersCartesianProduct(
 
 export function generateCohortsCartesianProduct(
   filters: ICompositeFilter[][],
-  jointDataset: JointDataset
+  jointDataset: JointDataset,
+  globalCohort: ErrorCohort
 ) {
   return generateFiltersCartesianProduct(filters).map((compositeFilter) => {
     const cohortName = getCompositeFilterString(
@@ -47,18 +48,18 @@ export function generateCohortsCartesianProduct(
       jointDataset
     )[0];
     return new ErrorCohort(
-      new Cohort(cohortName, jointDataset, [], [compositeFilter]),
+      new Cohort(cohortName, jointDataset, [], [compositeFilter, ...globalCohort.cohort.compositeFilters]),
       jointDataset
     );
   });
 }
 
 export function generateOverlappingFeatureBasedCohorts(
+  globalCohort: ErrorCohort,
   jointDataset: JointDataset,
   dataset: IDataset,
   selectedFeatures: number[]
 ) {
-  // TODO: restrict by current cohort
   // TODO: make nGroupsPerFeature configurable
   const nGroupsPerFeature = 3;
   const filters: ICompositeFilter[][] = [];
@@ -136,7 +137,7 @@ export function generateOverlappingFeatureBasedCohorts(
   });
 
   return (
-    generateCohortsCartesianProduct(filters, jointDataset)
+    generateCohortsCartesianProduct(filters, jointDataset, globalCohort)
       // filter the empty cohorts resulting from overlapping dimensions
       .filter((errorCohort) => errorCohort.cohortStats.totalCohort > 0)
   );

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisUtils.ts
@@ -48,7 +48,12 @@ export function generateCohortsCartesianProduct(
       jointDataset
     )[0];
     return new ErrorCohort(
-      new Cohort(cohortName, jointDataset, [], [compositeFilter, ...globalCohort.cohort.compositeFilters]),
+      new Cohort(
+        cohortName,
+        jointDataset,
+        [],
+        [compositeFilter, ...globalCohort.cohort.compositeFilters]
+      ),
       jointDataset
     );
   });

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -24,7 +24,8 @@ import {
   IComboBox,
   IComboBoxOption,
   ComboBox,
-  ActionButton
+  ActionButton,
+  MessageBar
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -133,6 +134,7 @@ export class ModelOverview extends React.Component<
 
     // generate table contents for selected feature cohorts
     const featureBasedCohorts = generateOverlappingFeatureBasedCohorts(
+      this.context.baseErrorCohort,
       this.context.jointDataset,
       this.context.dataset,
       this.state.selectedFeatures
@@ -221,6 +223,29 @@ export class ModelOverview extends React.Component<
               className={classNames.dropdown}
               styles={FabricStyles.limitedSizeMenuDropdown}
             />
+            {this.state.selectedFeatures.length > 0 && (
+              <>
+                <Text>
+                  {localization.formatString(
+                    localization.ModelAssessment.ModelOverview
+                      .disaggregatedAnalysisBaseCohortDislaimer,
+                    this.context.baseErrorCohort.cohort.name
+                  )}
+                </Text>
+                {this.context.baseErrorCohort.cohort.filters.length +
+                  this.context.baseErrorCohort.cohort.compositeFilters.length >
+                  0 && (
+                  <MessageBar>
+                    {localization.formatString(
+                      localization.ModelAssessment.ModelOverview
+                        .disaggregatedAnalysisBaseCohortWarning,
+                      localization.ErrorAnalysis.Cohort.defaultLabel,
+                      this.context.baseErrorCohort.cohort.name
+                    )}
+                  </MessageBar>
+                )}
+              </>
+            )}
             <DisaggregatedAnalysisTable
               selectableMetrics={selectableMetrics}
               selectedMetrics={this.state.selectedMetrics}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before this PR, we used the "All Data" cohort (full dataset) for the disaggregated analysis. With this PR, this changes. From now on we use the currently active global cohort (or base cohort as it's called in the code). Naturally, this flexibility may lead to confusion so I've added an explanation and a little `MessageBar` warning for the user. Let me know what you think! 

@minthigpen @mesameki 

Before selecting any features:
![image](https://user-images.githubusercontent.com/10245648/164803372-2e709c7f-627d-48e6-b095-7afc1635c369.png)

After selecting a feature with "All Data" (note the text under the dropdown):
![image](https://user-images.githubusercontent.com/10245648/164803395-ce509a30-ba9c-4806-b4d1-c9b1350ce10d.png)


With a cohort other than "All Data" (note the text and info box under the dropdown):
![image](https://user-images.githubusercontent.com/10245648/164803178-16e60dec-8dbc-4442-8998-966c2f7b5dad.png)


## Checklist

Tests to follow before the feature flag is removed. Manual validation done! No documentation changes necessary due to feature flag.

- [x] I have added screenshots above for all UI changes.
- [x] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
