### PR TITLE
Add accuracy as multiclass metric

### DIFF
--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -50,6 +50,11 @@ export enum ClassificationEnum {
   TruePositive = 3
 }
 
+export enum MulticlassClassificationEnum {
+  Correct = 0,
+  Misclassified = 1
+}
+
 // The object that will store user-facing strings and associated metadata
 // It stores the categorical labels for any numeric bins
 export interface IJointMeta {
@@ -297,6 +302,19 @@ export class JointDataset {
           treatAsCategorical: true
         };
       }
+      if (args.metadata.modelType === ModelTypes.Multiclass) {
+        this.metaDict[JointDataset.ClassificationError] = {
+          abbridgedLabel: localization.Interpret.Columns.classificationOutcome,
+          category: ColumnCategories.Outcome,
+          isCategorical: true,
+          label: localization.Interpret.Columns.classificationOutcome,
+          sortedCategoricalValues: [
+            localization.Interpret.Columns.correctlyClassified,
+            localization.Interpret.Columns.misclassified
+          ],
+          treatAsCategorical: true
+        };
+      }
     }
     if (args.localExplanations) {
       this.rawLocalImportance = JointDataset.buildLocalFeatureMatrix(
@@ -395,6 +413,13 @@ export class JointDataset {
       const predictionCategory =
         2 * row[JointDataset.TrueYLabel] + row[JointDataset.PredictedYLabel];
       row[JointDataset.ClassificationError] = predictionCategory;
+      return;
+    }
+    if (modelType === ModelTypes.Multiclass) {
+      row[JointDataset.ClassificationError] =
+        row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
+          ? MulticlassClassificationEnum.Misclassified
+          : MulticlassClassificationEnum.Correct;
       return;
     }
   }

--- a/libs/core-ui/src/lib/util/StatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtils.ts
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { MulticlassClassificationEnum } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 
 import { ModelTypes } from "../Interfaces/IExplanationContext";
 
-import { ClassificationEnum, JointDataset } from "./JointDataset";
+import {
+  ClassificationEnum,
+  JointDataset,
+  MulticlassClassificationEnum
+} from "./JointDataset";
 
 export interface ILabeledStatistic {
   key: string;

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -838,7 +838,9 @@
       "predictedProbabilities": "Prediction probabilities",
       "regressionError": "Regression error",
       "trueNegative": "True negative",
-      "truePositive": "True positive"
+      "truePositive": "True positive",
+      "correctlyClassified": "Correctly classified",
+      "misclassified": "Misclassified"
     },
     "CrossClass": {
       "_enumeratedClassInfo.comment": "explains the weights for selecting a single class",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -13,7 +13,8 @@ import {
   ModelTypes,
   classificationTask,
   FabricStyles,
-  descriptionMaxWidth
+  descriptionMaxWidth,
+  MulticlassClassificationMetrics
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
@@ -70,12 +71,16 @@ export class ModelOverview extends React.Component<
   public componentDidMount(): void {
     let defaultSelectedMetrics: string[] = [];
     if (this.context.dataset.task_type === classificationTask) {
-      defaultSelectedMetrics = [
-        BinaryClassificationMetrics.Accuracy,
-        BinaryClassificationMetrics.FalsePositiveRate,
-        BinaryClassificationMetrics.FalseNegativeRate,
-        BinaryClassificationMetrics.SelectionRate
-      ];
+      if (this.context.jointDataset.getModelType() === ModelTypes.Binary) {
+        defaultSelectedMetrics = [
+          BinaryClassificationMetrics.Accuracy,
+          BinaryClassificationMetrics.FalsePositiveRate,
+          BinaryClassificationMetrics.FalseNegativeRate,
+          BinaryClassificationMetrics.SelectionRate
+        ];
+      } else {
+        defaultSelectedMetrics = [MulticlassClassificationMetrics.Accuracy];
+      }
     } else {
       // task_type === "regression"
       defaultSelectedMetrics = [
@@ -106,7 +111,8 @@ export class ModelOverview extends React.Component<
     const classNames = modelOverviewStyles();
 
     const selectableMetrics = getSelectableMetrics(
-      this.context.dataset.task_type
+      this.context.dataset.task_type,
+      this.context.jointDataset.getModelType() === ModelTypes.Multiclass
     );
 
     const columns: string[] = [

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -7,6 +7,7 @@ import {
   ErrorCohort,
   HighchartsNull,
   ILabeledStatistic,
+  MulticlassClassificationMetrics,
   RegressionMetrics
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
@@ -210,41 +211,48 @@ export function wrapText(
 }
 
 export function getSelectableMetrics(
-  taskType: "classification" | "regression"
+  taskType: "classification" | "regression",
+  isMulticlass: boolean
 ) {
   const selectableMetrics: IDropdownOption[] = [];
   if (taskType === classificationTask) {
-    // TODO: add case for multiclass classification
-    selectableMetrics.push(
-      {
-        key: BinaryClassificationMetrics.Accuracy,
+    if (isMulticlass) {
+      selectableMetrics.push({
+        key: MulticlassClassificationMetrics.Accuracy,
         text: localization.ModelAssessment.ModelOverview.accuracy
-      },
-      {
-        key: BinaryClassificationMetrics.F1Score,
-        text: localization.ModelAssessment.ModelOverview.f1Score
-      },
-      {
-        key: BinaryClassificationMetrics.Precision,
-        text: localization.ModelAssessment.ModelOverview.precision
-      },
-      {
-        key: BinaryClassificationMetrics.Recall,
-        text: localization.ModelAssessment.ModelOverview.recall
-      },
-      {
-        key: BinaryClassificationMetrics.FalsePositiveRate,
-        text: localization.ModelAssessment.ModelOverview.falsePositiveRate
-      },
-      {
-        key: BinaryClassificationMetrics.FalseNegativeRate,
-        text: localization.ModelAssessment.ModelOverview.falseNegativeRate
-      },
-      {
-        key: BinaryClassificationMetrics.SelectionRate,
-        text: localization.ModelAssessment.ModelOverview.selectionRate
-      }
-    );
+      });
+    } else {
+      selectableMetrics.push(
+        {
+          key: BinaryClassificationMetrics.Accuracy,
+          text: localization.ModelAssessment.ModelOverview.accuracy
+        },
+        {
+          key: BinaryClassificationMetrics.F1Score,
+          text: localization.ModelAssessment.ModelOverview.f1Score
+        },
+        {
+          key: BinaryClassificationMetrics.Precision,
+          text: localization.ModelAssessment.ModelOverview.precision
+        },
+        {
+          key: BinaryClassificationMetrics.Recall,
+          text: localization.ModelAssessment.ModelOverview.recall
+        },
+        {
+          key: BinaryClassificationMetrics.FalsePositiveRate,
+          text: localization.ModelAssessment.ModelOverview.falsePositiveRate
+        },
+        {
+          key: BinaryClassificationMetrics.FalseNegativeRate,
+          text: localization.ModelAssessment.ModelOverview.falseNegativeRate
+        },
+        {
+          key: BinaryClassificationMetrics.SelectionRate,
+          text: localization.ModelAssessment.ModelOverview.selectionRate
+        }
+      );
+    }
   } else {
     // task_type === "regression"
     selectableMetrics.push(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes accuracy available as a first multiclass metric through `StatisticsUtils`. As this will likely be replaced by Python-based metrics calculations in the near future I didn't want to spend too much time adding other metrics.

Example:
![image](https://user-images.githubusercontent.com/10245648/164944040-334067e6-bdba-4f44-8ee3-d5f20dee9e29.png)


## Checklist

Doc updates to follow before feature flag is removed.

- [x] I have added screenshots above for all UI changes.
- [x] Documentation was updated if it was needed.
- [x] <s>New tests were added</s> or changes were <b>manually verified</b>.
