### PR TITLE
Rename _validate_model_analysis_input_parameters() to _validate_rai_insights_input_parameters()

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_base_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_base_insights.py
@@ -74,7 +74,7 @@ class RAIBaseInsights(ABC):
         pass
 
     @abstractmethod
-    def _validate_model_analysis_input_parameters(self, *args):
+    def _validate_rai_insights_input_parameters(self, *args):
         """Abstract method to validate the inputs for the constructor."""
         pass
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -79,7 +79,7 @@ class RAIInsights(RAIBaseInsights):
         :type maximum_rows_for_test: int
         """
         categorical_features = categorical_features or []
-        self._validate_model_analysis_input_parameters(
+        self._validate_rai_insights_input_parameters(
             model=model, train=train, test=test,
             target_column=target_column, task_type=task_type,
             categorical_features=categorical_features,
@@ -142,7 +142,7 @@ class RAIInsights(RAIBaseInsights):
         else:
             return None
 
-    def _validate_model_analysis_input_parameters(
+    def _validate_rai_insights_input_parameters(
             self, model: Any, train: pd.DataFrame, test: pd.DataFrame,
             target_column: str, task_type: str,
             categorical_features: List[str], classes: np.ndarray,


### PR DESCRIPTION
## Description

Seems like this function was not renamed when `RAIInsights` class was created out of `ModelAnalysis` class

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
