### PR TITLE
Cache and serialize the counterfactual explainer

### DIFF
--- a/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
+++ b/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
@@ -2,9 +2,13 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import os
+
 import pytest
 
 from responsibleai import RAIInsights
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
 
 from ..common_utils import create_iris_data, create_lightgbm_classifier
 
@@ -105,3 +109,24 @@ class TestCounterfactualAdvancedFeatures(object):
         assert len(rai_insights_copy.counterfactual.get()) == 2
         cf_obj = rai_insights_copy.counterfactual.get()[0]
         assert cf_obj is not None
+
+        # Delete the dice-ml explainer directory so that the dice-ml
+        # explainer can be re-trained rather being loaded from the
+        # disc
+        counterfactual_path = save_dir / "counterfactual"
+        all_cf_dirs = DirectoryManager.list_sub_directories(
+            counterfactual_path)
+        for counterfactual_config_dir in all_cf_dirs:
+            directory_manager = DirectoryManager(
+                parent_directory_path=counterfactual_path,
+                sub_directory_name=counterfactual_config_dir)
+            explainer_pkl_path = \
+                directory_manager.get_generators_directory() / "explainer.pkl"
+            os.remove(explainer_pkl_path)
+
+        rai_insights_copy_new = RAIInsights.load(save_dir)
+        counterfactual_config_list = \
+            rai_insights_copy_new.counterfactual._counterfactual_config_list
+        assert len(counterfactual_config_list) == 2
+        assert counterfactual_config_list[0].explainer is not None
+        assert counterfactual_config_list[1].explainer is not None

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -289,7 +289,7 @@ def validate_state_directory(path, manager_type):
         elif manager_type == ManagerNames.COUNTERFACTUAL:
             assert config_path.exists()
             assert data_path.exists()
-            assert not generators_path.exists()
+            assert generators_path.exists()
         elif manager_type == ManagerNames.ERROR_ANALYSIS:
             assert config_path.exists()
             assert data_path.exists()

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -316,7 +316,7 @@ def validate_component_state_directory(path, manager_type):
         elif manager_type == ManagerNames.COUNTERFACTUAL:
             assert config_path.exists()
             assert data_path.exists()
-            assert not generators_path.exists()
+            assert generators_path.exists()
         elif manager_type == ManagerNames.ERROR_ANALYSIS:
             assert config_path.exists()
             assert data_path.exists()


### PR DESCRIPTION
## Description

Caching the counterfactual explainer will help us generate the counterfactuals from the what-if panel in the RAI dashboard.
Serializing the explainer will help the save() and load() scenario from azureml.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
