### PR TITLE
Add rai-e2e to CD pipeline

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -199,7 +199,8 @@ jobs:
             interpret,
             localization,
             error-analysis,
-            model-assessment
+            model-assessment,
+            rai-e2e
           ]
 
     steps:


### PR DESCRIPTION
Add rai-e2e to CD pipeline

<!--- Provide a general summary of your changes in the Title above -->

## Description

After PR merge pipeline will automatically publish dev version. E2E doesn't need production version.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
