### PR TITLE
fix race condition in tree view update code which can cause root stats to be ignored on selected cohort in RAI dashboard static view

### DIFF
--- a/apps/dashboard/src/error-analysis/utils.ts
+++ b/apps/dashboard/src/error-analysis/utils.ts
@@ -74,6 +74,13 @@ export function getJsonTreeBoston(featureNames: string[]): any {
   };
 }
 
+export function getJsonTreeWine(featureNames: string[]): any {
+  return {
+    data: getJsonTree(DatasetName.Wine),
+    features: featureNames
+  };
+}
+
 export function getJsonTree(dataset: DatasetName): any {
   if (dataset === DatasetName.BreastCancer) {
     return _.cloneDeep(dummyTreeBreastCancerData);

--- a/apps/dashboard/src/model-assessment/App.tsx
+++ b/apps/dashboard/src/model-assessment/App.tsx
@@ -21,7 +21,9 @@ import {
   generateJsonTreeAdultCensusIncome,
   generateJsonTreeWine,
   getJsonMatrix,
-  getJsonTreeAdultCensusIncome
+  getJsonTreeAdultCensusIncome,
+  getJsonTreeBoston,
+  getJsonTreeWine
 } from "../error-analysis/utils";
 
 interface IAppProps extends IModelAssessmentData {
@@ -89,9 +91,16 @@ export class App extends React.Component<IAppProps> {
           );
       }
     } else {
-      const staticTree = getJsonTreeAdultCensusIncome(
+      let staticTree = getJsonTreeAdultCensusIncome(
         this.props.dataset.feature_names
       );
+      if (this.props.classDimension === 1) {
+        // Boston
+        staticTree = getJsonTreeBoston(this.props.dataset.feature_names);
+      } else if (this.props.classDimension !== 2) {
+        // Wine
+        staticTree = getJsonTreeWine(this.props.dataset.feature_names);
+      }
       const staticMatrix = getJsonMatrix();
       modelAssessmentDashboardProps = {
         ...this.props,

--- a/apps/dashboard/src/model-assessment/__mock_data__/bostonData.ts
+++ b/apps/dashboard/src/model-assessment/__mock_data__/bostonData.ts
@@ -3448,7 +3448,13 @@ export const bostonErrorAnalysisData: IErrorAnalysisData = {
   maxDepth: 3,
   metric: Metrics.MeanSquaredError,
   minChildSamples: 21,
-  numLeaves: 11
+  numLeaves: 11,
+  root_stats: {
+    errorCoverage: 100,
+    metricName: Metrics.MeanSquaredError,
+    metricValue: 34.93,
+    totalSize: 253
+  }
 };
 
 export const bostonCohortDataContinuous: IPreBuiltCohort = {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -551,20 +551,21 @@ export class TreeViewRenderer extends React.PureComponent<
         treeNodes
       };
     };
-    this.setState(reloadDataFunc);
-    // Clear filters
-    const filters: IFilter[] = [];
-    let cohortStats: MetricCohortStats | undefined = undefined;
-    if (this.state.root) {
-      cohortStats = this.calculateCohortStats(this.state.root.data);
-    }
-    this.props.updateSelectedCohort(
-      filters,
-      [],
-      CohortSource.None,
-      0,
-      cohortStats
-    );
+    this.setState(reloadDataFunc, () => {
+      // Clear filters
+      const filters: IFilter[] = [];
+      let cohortStats: MetricCohortStats | undefined = undefined;
+      if (this.state.root) {
+        cohortStats = this.calculateCohortStats(this.state.root.data);
+      }
+      this.props.updateSelectedCohort(
+        filters,
+        [],
+        CohortSource.None,
+        0,
+        cohortStats
+      );
+    });
   }
 
   private getTextBB(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix race condition in tree view update code which can cause root stats to be ignored on selected cohort in RAI dashboard static view.
There is a race condition where the tree view may not be updated correctly because the setState is not chained- basically, this.state.root would be undefined sometimes because the state hasn't been updated yet.  This can cause the RAI dashboard to show the wrong metric in regression scenario when using the static view.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
