### PR TITLE
Some fixes for data explorer, heatmap, counterfactual components

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -53,7 +53,6 @@ export interface ICounterfactualChartState {
   xDialogOpen: boolean;
   yDialogOpen: boolean;
   isPanelOpen: boolean;
-  editingDataCustomIndex?: number;
   customPoints: Array<{ [key: string]: any }>;
   request?: AbortController;
   selectedPointsIndexes: number[];
@@ -84,7 +83,6 @@ export class CounterfactualChart extends React.PureComponent<
     this.state = {
       customPointIsActive: [],
       customPoints: [],
-      editingDataCustomIndex: undefined,
       isPanelOpen: false,
       originalData: undefined,
       pointIsActive: [],
@@ -795,10 +793,6 @@ export class CounterfactualChart extends React.PureComponent<
   }
 
   private saveAsPoint = (): void => {
-    const editingDataCustomIndex =
-      this.state.editingDataCustomIndex !== undefined
-        ? this.state.editingDataCustomIndex
-        : this.state.customPoints.length;
     const customPoints = [...this.state.customPoints];
     const customPointIsActive = [...this.state.customPointIsActive];
     if (this.temporaryPoint) {
@@ -808,8 +802,7 @@ export class CounterfactualChart extends React.PureComponent<
     this.temporaryPoint = _.cloneDeep(this.temporaryPoint);
     this.setState({
       customPointIsActive,
-      customPoints,
-      editingDataCustomIndex
+      customPoints
     });
   };
 

--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -682,7 +682,10 @@ export class CounterfactualChart extends React.PureComponent<
       dict[JointDataset.IndexLabel] = val;
       return dict;
     });
-    let hovertemplate = "";
+    dictionary.forEach((val, index) => {
+      customdata[index].Name = val.Name ? val.Name : val.Index;
+    });
+    let hovertemplate = `{point.customdata.Name}<br>`;
     if (chartProps.xAxis) {
       const metaX =
         this.context.jointDataset.metaDict[chartProps.xAxis.property];

--- a/libs/counterfactuals/src/lib/getCounterfactualChartOptions.ts
+++ b/libs/counterfactuals/src/lib/getCounterfactualChartOptions.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { FabricStyles } from "@responsible-ai/core-ui";
+import { WhatIfConstants } from "@responsible-ai/interpret";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
 
 export function getCounterfactualChartOptions(
@@ -15,7 +17,11 @@ export function getCounterfactualChartOptions(
         customdata: series?.customdata?.[index],
         marker: {
           fillColor:
-            seriesIndex === 0 ? series?.marker?.color?.[index] : undefined,
+            seriesIndex === 0
+              ? series?.marker?.color?.[index]
+              : FabricStyles.fabricColorPalette[
+                  WhatIfConstants.MAX_SELECTION + 1 + index
+                ],
           lineColor:
             seriesIndex === 0 ? undefined : series?.marker?.line?.color,
           lineWidth: seriesIndex === 0 ? undefined : 3,

--- a/libs/dataset-explorer/src/lib/getDatasetScatterOption.ts
+++ b/libs/dataset-explorer/src/lib/getDatasetScatterOption.ts
@@ -25,11 +25,6 @@ export function getDatasetScatterOption(
         }
       }
     },
-    series: dataSeries,
-    xAxis: {
-      labels: {
-        enabled: false
-      }
-    }
+    series: dataSeries
   };
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixFilter/MatrixFilter.tsx
@@ -124,6 +124,13 @@ export class MatrixFilter extends React.PureComponent<
               </Text>
             </MessageBar>
           )}
+          <MatrixLegend
+            selectedCohort={this.props.selectedCohort}
+            baseCohort={this.props.baseCohort}
+            max={this.state.matrixLegendState.maxMetricValue}
+            isErrorMetric={this.state.matrixLegendState.isErrorMetric}
+            disabledView={this.props.disabledView}
+          />
           <Stack horizontal tokens={stackTokens} horizontalAlign="start">
             <MetricSelector
               isEnabled={this.props.isEnabled && !featuresUnselected}
@@ -161,13 +168,6 @@ export class MatrixFilter extends React.PureComponent<
               />
             </Stack.Item>
           </Stack>
-          <MatrixLegend
-            selectedCohort={this.props.selectedCohort}
-            baseCohort={this.props.baseCohort}
-            max={this.state.matrixLegendState.maxMetricValue}
-            isErrorMetric={this.state.matrixLegendState.isErrorMetric}
-            disabledView={this.props.disabledView}
-          />
           {!this.props.disabledView && (
             <MatrixArea
               theme={this.props.theme}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixLegend/MatrixLegend.styles.ts
@@ -24,7 +24,8 @@ export const matrixLegendStyles: () => IProcessedStyleSet<IMatrixLegendStyles> =
     const commonTextStyles = textStyles();
     return mergeStyleSets<IMatrixLegendStyles>({
       matrixLegend: {
-        padding: "10px"
+        marginTop: "0px !important",
+        padding: "0 10px 10px 10px"
       },
       metricBarBlack: commonMetricStyles.metricBarBlack,
       metricBarGreen: commonMetricStyles.metricBarGreen,


### PR DESCRIPTION
This PR fixes a few P0 bugs:
1. We should display x axis label for data explorer
2. What if counterfactual custom points should match the color of its legend
3. We should display name for what if counterfactual custom points
4. Switch heat map controls with error info

## Description
1. We should display x axis label for data explorer
![image](https://user-images.githubusercontent.com/91754176/167042328-bd13c1e5-008b-494c-8e87-ea4d27a69c46.png)

2. What if counterfactual custom points should match the color of its legend
![image](https://user-images.githubusercontent.com/91754176/167042425-85ef1bfb-f7e0-4635-9dfa-25740199dc20.png)

3. We should display name for what if counterfactual custom points
![image](https://user-images.githubusercontent.com/91754176/167041985-dfe52b9c-54f7-45c0-bd8b-2c9424cb03d2.png)

4. Switch heat map controls with error info:
Before:
![image](https://user-images.githubusercontent.com/91754176/167042661-59781ad3-8032-4efa-b3c8-37f94f80cc7f.png)

After:
![image](https://user-images.githubusercontent.com/91754176/167042278-0146bdc5-0c3a-488a-821d-a8b99aeec848.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [X] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
