### PR TITLE
Fix feature selection state carry-over bug in model overview

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
@@ -70,7 +70,7 @@ export class FeatureConfigurationFlyout extends React.Component<
     super(props);
 
     this._selection = new Selection({
-      onSelectionChanged: () => {
+      onSelectionChanged: (): void => {
         const selectedIndices = this._selection.getSelectedIndices().slice();
         this.setState({ newlySelectedFeatures: selectedIndices });
       }
@@ -94,15 +94,15 @@ export class FeatureConfigurationFlyout extends React.Component<
   }
 
   componentDidUpdate(prevProps: IFeatureConfigurationFlyoutProps) {
-    if (
-      this.props.selectedFeatures.length !==
-        prevProps.selectedFeatures.length ||
-      this.props.selectedFeatures.some(
-        (featureIndex, index) =>
-          featureIndex !== prevProps.selectedFeatures[index]
-      )
-    ) {
-      this.setState({ newlySelectedFeatures: this.props.selectedFeatures });
+    // Update selected features in state whenever the flyout is opened.
+    // At other times we can't update with props since they may be outdated compared to the state.
+    if (this.props.isOpen && !prevProps.isOpen) {
+      this.setState(
+        { newlySelectedFeatures: this.props.selectedFeatures },
+        () => {
+          this.updateSelection();
+        }
+      );
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previously, selections in the feature dropdown didn't always carry over to the feature flyout since it tracks its own state via an `ISelection`. The missing piece was that we didn't update the selection when reopening the flyout, but only updated the state (which is separate). This PR changes this and simplifies the if-condition of `componentDidUpdate`.


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
