### PR TITLE
disable causal treatment whatif in static view

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalWhatIf.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalWhatIf.tsx
@@ -101,6 +101,7 @@ export class CausalWhatIf extends React.Component<
                 value={this.state.newTreatmentValue}
                 onChange={this.onTreatmentValueChange}
                 valueFormat={this.showNewTreatmentRawValue}
+                disabled={!this.context.requestCausalWhatIf}
               />
               <Text variant="small" className={classNames.treatmentValue}>
                 {localization.formatString(
@@ -122,16 +123,18 @@ export class CausalWhatIf extends React.Component<
                     value={this.state.currentOutcome}
                   />
                 </Stack.Item>
-                <Stack.Item className={classNames.newOutcome}>
-                  <Outcome
-                    label={
-                      localization.CausalAnalysis.IndividualView.newOutcome
-                    }
-                    value={this.state.newOutcome?.point_estimate}
-                    lower={this.state.newOutcome?.ci_lower}
-                    upper={this.state.newOutcome?.ci_upper}
-                  />
-                </Stack.Item>
+                {this.context.requestCausalWhatIf !== undefined && (
+                  <Stack.Item className={classNames.newOutcome}>
+                    <Outcome
+                      label={
+                        localization.CausalAnalysis.IndividualView.newOutcome
+                      }
+                      value={this.state.newOutcome?.point_estimate}
+                      lower={this.state.newOutcome?.ci_lower}
+                      upper={this.state.newOutcome?.ci_upper}
+                    />
+                  </Stack.Item>
+                )}
               </Stack>
             </Stack.Item>
           </Stack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In static view of RAI Dashboard, disable the causal treatment whatif by disabling the slider and hiding the treatment new outcome section.

![image](https://user-images.githubusercontent.com/24683184/167140093-2fd427e0-0717-4277-a2e2-2a4285291c3e.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
