### PR TITLE
Alignment and style fixes for causal

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregate.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregate.styles.ts
@@ -27,7 +27,8 @@ export const CausalAggregateStyles: () => IProcessedStyleSet<ICausalAggregateSty
         margin: "-5px 0 0 -15px"
       },
       container: {
-        height: "100%"
+        height: "100%",
+        marginTop: "0px !important"
       },
       description: {
         display: "flex",
@@ -56,10 +57,11 @@ export const CausalAggregateStyles: () => IProcessedStyleSet<ICausalAggregateSty
         textAlign: "left"
       },
       leftPane: {
-        padding: "10px",
+        padding: "0 10px 10px 10px",
         width: "70%"
       },
       rightPane: {
+        paddingTop: "16px",
         width: "25%"
       },
       table: {

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividual.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividual.styles.ts
@@ -23,8 +23,8 @@ export const CausalIndividualStyles: () => IProcessedStyleSet<ICausalIndividualS
   () => {
     return mergeStyleSets<ICausalIndividualStyles>({
       aggregateChart: {
-        display: "flex",
-        height: "100%"
+        height: "100%",
+        width: "80%"
       },
       callout: {
         margin: "-5px 0 0 -15px"
@@ -39,19 +39,19 @@ export const CausalIndividualStyles: () => IProcessedStyleSet<ICausalIndividualS
         flex: "1",
         fontSize: 14,
         maxWidth: descriptionMaxWidth,
-        paddingBottom: "15px",
         textAlign: "left"
       },
       header: {
         fontSize: 14,
         fontWeight: "600",
-        paddingTop: "70px"
+        marginTop: "0px !important"
       },
       individualChart: {
         width: "100%"
       },
       individualTable: {
-        width: "70%"
+        marginTop: "0px !important",
+        width: "80%"
       },
       lasso: {
         display: "inline-block",

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.styles.ts
@@ -23,7 +23,6 @@ export const causalIndividualChartStyles: () => IProcessedStyleSet<ICausalIndivi
     const legendWidth = "400px";
     return mergeStyleSets<ICausalIndividualChartStyles>({
       chartWithAxes: {
-        paddingTop: "30px",
         width: "80%"
       },
       chartWithVertical: {

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentTable.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentTable.styles.ts
@@ -16,6 +16,8 @@ export interface ITreatmentTableStyles {
   spinButtonText: IStyle;
   table: IStyle;
   label: IStyle;
+  leftTable: IStyle;
+  tableDescription: IStyle;
   treatmentBarContainer: IStyle;
 }
 
@@ -23,17 +25,18 @@ export const TreatmentTableStyles: () => IProcessedStyleSet<ITreatmentTableStyle
   () => {
     return mergeStyleSets<ITreatmentTableStyles>({
       description: {
-        paddingTop: "10px",
-        width: "45%"
+        padding: "10px 20px 0 0",
+        width: "20%"
       },
       detailsList: {
-        width: "75%"
+        width: "80%"
       },
       detailsListDescription: {
         fontSize: "14px",
         fontStyle: "normal",
         fontWeight: "normal",
-        paddingTop: "50px"
+        marginLeft: "0px !important",
+        padding: "50px 20px 0 0"
       },
       dropdown: {
         width: "220px"
@@ -46,6 +49,9 @@ export const TreatmentTableStyles: () => IProcessedStyleSet<ITreatmentTableStyle
         paddingBottom: "10px",
         paddingLeft: "30px",
         textAlign: "left"
+      },
+      leftTable: {
+        width: "80%"
       },
       spinButton: {
         paddingLeft: "10px",
@@ -61,12 +67,12 @@ export const TreatmentTableStyles: () => IProcessedStyleSet<ITreatmentTableStyle
           border: "1px",
           borderStyle: "solid"
         },
-        textAlign: "center",
-        width: "50vw"
+        textAlign: "center"
       },
+      tableDescription: { width: "20%" },
       treatmentBarContainer: {
-        hight: "100%",
-        width: "100%"
+        height: "100%",
+        width: "80%"
       }
     });
   };

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentTableSection.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentTableSection.tsx
@@ -39,10 +39,10 @@ export class TreatmentTableSection extends React.Component<ITreatmentTableSectio
         </Stack.Item>
         <Stack.Item>
           <Stack horizontal grow tokens={{ padding: "l1" }}>
-            <Stack.Item>
+            <Stack.Item className={styles.leftTable}>
               <TreatmentTable data={this.props.data.policy_tree} />
             </Stack.Item>
-            <Stack.Item>
+            <Stack.Item className={styles.tableDescription}>
               <Text variant={"medium"} className={styles.label}>
                 {localization.CausalAnalysis.TreatmentPolicy.TableDescription}
               </Text>


### PR DESCRIPTION
This PR fixes a few alignment and style issues for causal component.

## Description
1. Remove a few white space, wide gaps, such as:
![image](https://user-images.githubusercontent.com/91754176/167202831-6277a652-23bd-42f7-a857-654355fafc43.png)
![image](https://user-images.githubusercontent.com/91754176/167202847-ccc69b6c-dc84-45f1-9652-80491b981fed.png)

2. make table and graph to be consistent width with scatter plot for both individual causal what if and treatment policy:
**For individual causal what if tab:**
before:
![image](https://user-images.githubusercontent.com/91754176/167202545-8392397d-78dd-4e14-91ce-c01fcbc6625d.png)

after:
![image](https://user-images.githubusercontent.com/91754176/167202607-e64c9804-de3a-484e-b10f-538024b9e4d5.png)

**For treatment policy tab:**
before:
![image](https://user-images.githubusercontent.com/91754176/167202680-84415191-e61d-44f0-8f45-d9e472a01e8a.png)

after:
![image](https://user-images.githubusercontent.com/91754176/167202939-903b350a-c5f0-4615-8b8b-fad74cb90569.png)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
