### PR TITLE
Loosen requests version requirment to major version 2

### DIFF
--- a/raiutils/requirements.txt
+++ b/raiutils/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.1
+requests<=2


### PR DESCRIPTION
This is to loosen requests version requirement in raiutils. Limiting on major version 2 which should have no breaking change.

## Description

This is to loosen requests version requirement in raiutils. Limiting on major version 2 which should have no breaking change.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
