### PR TITLE
fix error on machines with pyspark installed where passed dataframe is not spark pandas

### DIFF
--- a/erroranalysis/erroranalysis/_internal/utils.py
+++ b/erroranalysis/erroranalysis/_internal/utils.py
@@ -6,7 +6,7 @@ import random
 import numpy as np
 
 try:
-    import pyspark
+    import pyspark.pandas as ps
     spark_available = True
 except ImportError:
     spark_available = False
@@ -47,4 +47,7 @@ def is_spark(df):
     :return: True if the dataframe is a spark dataframe, False otherwise.
     :rtype: bool
     """
-    return spark_available and isinstance(df, pyspark.pandas.frame.DataFrame)
+    try:
+        return spark_available and isinstance(df, ps.frame.DataFrame)
+    except Exception:
+        return False

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '0'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Description

PM ran into an error when using latest erroranalysis package on a machine with pyspark installed (Compute Instance), but where they were not passing in a spark pandas dataframe.
Strangely, the error was related to the import:

```
AttributeError: module 'pyspark' has no attribute 'pandas'
```

Importing ```import pypark``` worked, but using pyspark.pandas.frame.DataFrame did not - but it started working after explicitly importing ```import pyspark.pandas as ps```.  Note on older versions of pyspark, the namespace pyspark.pandas may not even exist though, so I added try/except just to be very safe and ensure this never causes issues.


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
