### PR TITLE
fix failing to create error report when filter_features is empty list

### DIFF
--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -334,7 +334,7 @@ class BaseAnalyzer(ABC):
                                        num_leaves=num_leaves,
                                        min_child_samples=min_child_samples)
         matrix = None
-        if filter_features is not None:
+        if filter_features:
             matrix = self.compute_matrix(filter_features,
                                          None,
                                          None)

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '1'
+_patch = '2'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -51,7 +51,9 @@ class TestErrorReport(object):
             run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
-    def test_error_report_housing_pandas(self):
+    @pytest.mark.parametrize('filter_features',
+                             [None, [], ['MedInc', 'HouseAge']])
+    def test_error_report_housing_pandas(self, filter_features):
         X_train, X_test, y_train, y_test, feature_names = \
             create_housing_data()
         X_train = create_dataframe(X_train, feature_names)
@@ -61,7 +63,8 @@ class TestErrorReport(object):
         for model in models:
             categorical_features = []
             run_error_analyzer(model, X_test, y_test, feature_names,
-                               categorical_features)
+                               categorical_features,
+                               filter_features=filter_features)
 
 
 def is_valid_uuid(id):
@@ -73,7 +76,8 @@ def is_valid_uuid(id):
 
 
 def run_error_analyzer(model, X_test, y_test, feature_names,
-                       categorical_features, expect_user_warnings=False):
+                       categorical_features, expect_user_warnings=False,
+                       filter_features=None):
     if expect_user_warnings and pd.__version__[0] == '0':
         with pytest.warns(UserWarning,
                           match='which has issues with pandas version'):
@@ -84,7 +88,7 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
         model_analyzer = ModelAnalyzer(model, X_test, y_test,
                                        feature_names,
                                        categorical_features)
-    report1 = model_analyzer.create_error_report(filter_features=None,
+    report1 = model_analyzer.create_error_report(filter_features,
                                                  max_depth=3,
                                                  num_leaves=None,
                                                  compute_importances=True)
@@ -108,6 +112,11 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     assert ea_deserialized.matrix_features == report1.matrix_features
     assert ea_deserialized.importances == report1.importances
     assert ea_deserialized.root_stats == report1.root_stats
+
+    if not filter_features:
+        assert ea_deserialized.matrix is None
+    else:
+        assert ea_deserialized.matrix is not None
 
     # validate error report does not modify original dataset in ModelAnalyzer
     if isinstance(X_test, pd.DataFrame):


### PR DESCRIPTION
## Description

An upstream workflow passed filter_features = [] (empty list) when creating the error report in erroranalysis package, which led to an error because erroranalysis tried to generate the heatmap when no features were specified.  This PR fixes this issue by not generating the error report in case filter_features is either null or empty list.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
