### PR TITLE
upgrade numpy to fix random segfault test failures

### DIFF
--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -45,8 +45,10 @@ jobs:
         run: yarn buildall
 
       - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-        name: Use Homebrew to install libomp on MacOS for lightgbm
-        run: brew install https://publictestdatasets.blob.core.windows.net/data/libomp-11.1.0.catalina.bottle.tar.gz
+        name: Install latest numpy from conda-forge for MacOS
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet -c conda-forge numpy
 
       - if: ${{ matrix.operatingSystem != 'macos-latest' }}
         name: Install pytorch on non-MacOS
@@ -59,6 +61,12 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install --yes --quiet pytorch torchvision captum -c pytorch
+
+      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
+        name: Install latest lightgbm from conda-forge for MacOS
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet lightgbm -c conda-forge
 
       - name: Setup tools
         shell: bash -l {0}

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -9,9 +9,6 @@ requirements-parser==0.2.0
 
 wheel
 
-# Required for interpret-community 0.18.0
-lightgbm==2.3.0
-
 fairlearn==0.6.0
 
 # Jupyter dependency that fails with python 3.6


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I'm seeing random segfaults happening when running pytest.  This PR upgrades numpy from conda-forge channel to fix random pytest segfault test failures.

EDIT: The pytest test failures seemed to be resolved, but now some tests are getting stuck on macos.  It seems installing lightgbm from conda-forge fixes this somehow on macos.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
