### PR TITLE
Fix description for model overview

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -213,10 +213,14 @@ export class ModelOverview extends React.Component<
         className={classNames.sectionStack}
         tokens={{ childrenGap: "10px" }}
       >
-        <Text variant="medium" className={classNames.descriptionText}>
-          {localization.ModelAssessment.ModelOverview.topLevelDescription}
-        </Text>
-        {!this.props.showNewModelOverviewExperience && <OverallMetricChart />}
+        {!this.props.showNewModelOverviewExperience && (
+          <>
+            <Text variant="medium" className={classNames.descriptionText}>
+              {localization.Interpret.ModelPerformance.helperText}
+            </Text>
+            <OverallMetricChart />
+          </>
+        )}
         {this.props.showNewModelOverviewExperience && (
           <Stack tokens={{ childrenGap: "10px" }}>
             <Pivot onLinkClick={this.handleViewPivot}>

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -223,6 +223,9 @@ export class ModelOverview extends React.Component<
         )}
         {this.props.showNewModelOverviewExperience && (
           <Stack tokens={{ childrenGap: "10px" }}>
+            <Text variant="medium" className={classNames.descriptionText}>
+              {localization.ModelAssessment.ModelOverview.topLevelDescription}
+            </Text>
             <Pivot onLinkClick={this.handleViewPivot}>
               <PivotItem
                 headerText={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to a recent change we're showing the new model overview description even in the old model overview. To avoid that, this PR moves the description inside the "if" cases.

The new "old" description:
![image](https://user-images.githubusercontent.com/10245648/168158069-8320cf2c-328a-4cf5-ba1c-69065263b11d.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
