### PR TITLE
Remove "Set Value" blurb in case it is not availble in counterfactualual panel

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualPanel.tsx
@@ -135,7 +135,9 @@ export class CounterfactualPanel extends React.Component<
           </Stack.Item>
           <Stack.Item>
             <Text variant={"medium"}>
-              {localization.Counterfactuals.panelDescription}
+              {this.context.requestPredictions
+                ? localization.Counterfactuals.panelDescription
+                : localization.Counterfactuals.panelDescriptionWithoutSetValue}
             </Text>
           </Stack.Item>
           <Stack.Item className={classes.buttonRow}>

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -130,6 +130,7 @@
     "noData": "No data",
     "noFeatures": "No features available",
     "panelDescription": "Browse counterfactuals and create your own. Search features to see suggested values from a diverse set of counterfactual examples. Set suggested counterfactual feature values by clicking “Set Value” text under each counterfactual name. Name your counterfactual and save it.",
+    "panelDescriptionWithoutSetValue": "Browse counterfactuals and create your own. Search features to see suggested values from a diverse set of counterfactual examples.",
     "whatIfPanelHeader": "What-if counterfactuals",
     "panelHeader": "Counterfactuals",
     "recommendedPolicy": "Recommended policy gain",


### PR DESCRIPTION
## Description

In case of static dashboard in AML, we don't provide the full what-if capability and guide users to "Set Value" when this capability is not available. Hence, removing the "Set Value" text when we give static dashboard experience to the users.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
