### PR TITLE
fix codecov and widget test screenshot uploads

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -111,7 +111,7 @@ jobs:
         run: pytest --durations=10
 
       - name: Upload a Build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -63,7 +63,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -74,14 +74,14 @@ jobs:
 
       - name: Upload notebook test result
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: notebook-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: notebooks
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: raiwidgets-e2e-screen-shot
           path: dist/cypress

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: requirements-dev.txt
           path: ${{ matrix.packageDirectory }}/requirements-dev.txt
@@ -67,7 +67,7 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.packageDirectory }}-code-coverage-results
           path: ${{ matrix.packageDirectory }}/htmlcov

--- a/.github/workflows/CI-typescript.yml
+++ b/.github/workflows/CI-typescript.yml
@@ -32,19 +32,19 @@ jobs:
         run: yarn ci
       - name: Upload unit test code coverage
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: unit-test-coverage-${{ matrix.node-version }}
           path: coverage
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: e2e-screen-shot-${{ matrix.node-version }}
           path: dist/cypress
       - name: Upload yarn error
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: yarn-error.log-${{ matrix.node-version }}
           path: yarn-error.log

--- a/.github/workflows/Ci-raiwigets-python-typescript.yml
+++ b/.github/workflows/Ci-raiwigets-python-typescript.yml
@@ -90,14 +90,15 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: requirements-dev.txt
           path: ${{ matrix.packageDirectory }}/installed-requirements-dev.txt
 
-      - name: Run widget tests
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+        name: Run widget tests
+        id: raiwidgettests
         shell: bash -l {0}
-        if: ${{ matrix.operatingSystem != 'macos-latest' }}
         run: yarn e2e-widget
 
       - name: Run tests
@@ -106,13 +107,13 @@ jobs:
           pytest --durations=10 --junitxml=junit/test-results.xml --cov=${{ matrix.packageDirectory }} --cov-report=xml --cov-report=html
         working-directory: ${{ matrix.packageDirectory }}
 
-      - name: Upload code coverage results
-        uses: actions/upload-artifact@v2
+      # Only try to upload code cov if python tests were run
+      - if: ${{ (steps.raiwidgettests.outcome == 'success') }}
+        name: Upload code coverage results
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.packageDirectory }}-code-coverage-results
           path: ${{ matrix.packageDirectory }}/htmlcov
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
 
       - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
         name: Upload to codecov
@@ -142,12 +143,12 @@ jobs:
           name: codecov-umbrella
           verbose: true
 
-      - name: Upload e2e test screen shot
-        if: always()
-        uses: actions/upload-artifact@v2
+      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+        name: Upload e2e test screen shot
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.packageDirectory }}-e2e-screen-shot
-          path: dist/cypress
+          path: ./dist/cypress
 
       - name: Set codecov status
         if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -142,19 +142,19 @@ jobs:
         run: yarn e2e-widget
 
       - name: Upload a raiwidgets build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.widgetDirectory }}
           path: ${{ env.widgetDirectory }}/dist/
 
       - name: Upload a responsibleai build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.raiDirectory }}
           path: ${{ env.raiDirectory }}/dist/
 
       - name: Upload a typescript build result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.typescriptBuildArtifactName }}
           path: ${{ env.typescriptBuildOutput }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix codecov and widget test screenshot uploads.
While debugging failing pipelines, I noticed some warnings related to codecov and the widget test screenshot:

![image](https://user-images.githubusercontent.com/24683184/168650072-1a4461f7-feba-49fc-9a93-651fb6e29884.png)

This PR fixed the cypress warnings by fixing the path to upload and the htmlcov warnings by only uploading when the python tests have been run (in case the widget tests failed the python tests are not run).

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
