### PR TITLE
fix dependency chart axis updating with incorrect values in explanation dashboard

### DIFF
--- a/libs/core-ui/src/lib/util/getDependencyChartOptions.ts
+++ b/libs/core-ui/src/lib/util/getDependencyChartOptions.ts
@@ -28,6 +28,9 @@ export function getDependencyChartOptions(
       type: "scatter",
       zoomType: "xy"
     },
+    custom: {
+      disableUpdate: true
+    },
     plotOptions: {
       scatter: {
         marker: {


### PR DESCRIPTION
## Description

Customer noticed an issue in the explanation dashboard where changing the dependency plot feature in the aggregate feature importances tab causes the x-axis values to sometimes be "mixed", especially when changing between numeric and categorical features.
When debugging, the interesting thing I found is that we don't even pass the x-axis values to highcharts for numeric data, so this is clearly some internal issue with using update in the highcharts code instead of creating a new chart on feature change.

![image](https://user-images.githubusercontent.com/24683184/168916851-26d1d632-000d-47a2-8751-efa75f0f75db.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
