### PR TITLE
Fix locators logic for string features - data explorer component

### DIFF
--- a/libs/e2e/src/lib/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/dataExplorer/describeCohortFunctionality.ts
@@ -37,9 +37,13 @@ export function describeCohortFunctionality(
       cy.get("#cohortEditPanel").should("exist");
       cy.get(Locators.CohortNameInput).clear().type(cohortName);
       cy.get(Locators.CohortFilterSelection).eq(1).check(); // select Dataset
-      cy.get(Locators.CohortDatasetValueInput)
-        .clear()
-        .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || "");
+      cy.get(Locators.CohortDatasetValueInput).then(($input) => {
+        if ($input.length > 0) {
+          cy.get(Locators.CohortDatasetValueInput)
+            .clear()
+            .type(dataShape.datasetExplorerData?.cohortDatasetNewValue || "");
+        }
+      });
       cy.get(Locators.CohortAddFilterButton).click();
       cy.get(Locators.CohortSaveAndSwitchButton).eq(0).click({ force: true });
       cy.get(Locators.NewCohortSpan).should("exist");


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix locators logic for data explorer. This was happening because it couldn't find input field for string features. String features will have filters added directly.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
