### PR TITLE
Fix cohort name conflict and not run few tests for AML

### DIFF
--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIf.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIf.ts
@@ -42,7 +42,7 @@ export function describeWhatIf(
     ) {
       describeWhatIfCommonFunctionalities(datasetShape);
       describeAxisFlyouts(datasetShape);
-      describeWhatIfCreate(datasetShape);
+      describeWhatIfCreate(datasetShape, name);
     }
   });
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
@@ -54,7 +54,7 @@ export function describeWhatIfCreate(
         dataShape.whatIfCounterfactualsData?.columnHeaderAfterSort || ""
       );
     });
-    // if from AML do not execute these tests, as these are not available for static view
+    // AML do not need to execute below tests, as these options are not available for static view
     if (name) {
       it("Should have 'Create your own counterfactual' section and it should be editable", () => {
         cy.get(Locators.CreateYourOwnCounterfactualInputField)

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
@@ -4,8 +4,12 @@
 import { getSpan } from "../../../../util/getSpan";
 import { Locators } from "../Constants";
 import { IModelAssessmentData } from "../IModelAssessmentData";
+import { modelAssessmentDatasets } from "../modelAssessmentDatasets";
 
-export function describeWhatIfCreate(dataShape: IModelAssessmentData): void {
+export function describeWhatIfCreate(
+  dataShape: IModelAssessmentData,
+  name?: keyof typeof modelAssessmentDatasets
+): void {
   describe("What if Create counterfactual", () => {
     before(() => {
       cy.get(Locators.WICDatapointDropbox).click();
@@ -50,40 +54,42 @@ export function describeWhatIfCreate(dataShape: IModelAssessmentData): void {
         dataShape.whatIfCounterfactualsData?.columnHeaderAfterSort || ""
       );
     });
+    // if from AML do not execute these tests, as these are not available for static view
+    if (name) {
+      it("Should have 'Create your own counterfactual' section and it should be editable", () => {
+        cy.get(Locators.CreateYourOwnCounterfactualInputField)
+          .eq(2)
+          .clear()
+          .type(
+            dataShape.whatIfCounterfactualsData
+              ?.createYourOwnCounterfactualInputFieldUpdated || "25"
+          );
+        cy.get(Locators.CreateYourOwnCounterfactualInputField).eq(2).focus();
+        cy.focused()
+          .should("have.attr", "value")
+          .and(
+            "contain",
+            dataShape.whatIfCounterfactualsData
+              ?.createYourOwnCounterfactualInputFieldUpdated || "25"
+          );
+      });
 
-    it("Should have 'Create your own counterfactual' section and it should be editable", () => {
-      cy.get(Locators.CreateYourOwnCounterfactualInputField)
-        .eq(2)
-        .clear()
-        .type(
-          dataShape.whatIfCounterfactualsData
-            ?.createYourOwnCounterfactualInputFieldUpdated || "25"
+      it("Should have what-if counterfactual name as 'Copy of row <index selected>' by default and should be editable", () => {
+        cy.get(Locators.WhatIfNameLabel)
+          .should("have.attr", "value")
+          .and("contain", dataShape.whatIfCounterfactualsData?.whatIfNameLabel);
+        cy.get(Locators.WhatIfNameLabel).type(
+          dataShape.whatIfCounterfactualsData?.whatIfNameLabelUpdated ||
+            "New Copy of row 1"
         );
-      cy.get(Locators.CreateYourOwnCounterfactualInputField).eq(2).focus();
-      cy.focused()
-        .should("have.attr", "value")
-        .and(
-          "contain",
-          dataShape.whatIfCounterfactualsData
-            ?.createYourOwnCounterfactualInputFieldUpdated || "25"
-        );
-    });
-
-    it("Should have what-if counterfactual name as 'Copy of row <index selected>' by default and should be editable", () => {
-      cy.get(Locators.WhatIfNameLabel)
-        .should("have.attr", "value")
-        .and("contain", dataShape.whatIfCounterfactualsData?.whatIfNameLabel);
-      cy.get(Locators.WhatIfNameLabel).type(
-        dataShape.whatIfCounterfactualsData?.whatIfNameLabelUpdated ||
-          "New Copy of row 1"
-      );
-      cy.get(Locators.WhatIfNameLabel)
-        .should("have.attr", "value")
-        .and(
-          "contain",
-          dataShape.whatIfCounterfactualsData?.whatIfNameLabelUpdated
-        );
-    });
+        cy.get(Locators.WhatIfNameLabel)
+          .should("have.attr", "value")
+          .and(
+            "contain",
+            dataShape.whatIfCounterfactualsData?.whatIfNameLabelUpdated
+          );
+      });
+    }
   });
 
   describe.skip("What-If save scenario", () => {

--- a/libs/e2e/src/util/createCohort.ts
+++ b/libs/e2e/src/util/createCohort.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { Locators } from "../lib/describer/modelAssessment/Constants";
+
 import { generateId } from "./generateId";
 
 export function createCohort(): void {

--- a/libs/e2e/src/util/createCohort.ts
+++ b/libs/e2e/src/util/createCohort.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 import { Locators } from "../lib/describer/modelAssessment/Constants";
+import { generateId } from "./generateId";
 
 export function createCohort(): void {
+  const cohortName = `CohortCreateE2E-${generateId(4)}`;
   cy.get(Locators.CreateNewCohortButton).click();
   cy.get("#cohortEditPanel").should("exist");
-  cy.get(Locators.CohortNameInput).clear().type("CohortCreateE2E");
+  cy.get(Locators.CohortNameInput).clear().type(cohortName);
   cy.get(Locators.CohortFilterSelection).eq(1).check(); // select Dataset
   cy.get(Locators.CohortAddFilterButton).click();
   cy.get(Locators.CohortSaveAndSwitchButton).eq(0).click({ force: true });

--- a/libs/e2e/src/util/generateId.ts
+++ b/libs/e2e/src/util/generateId.ts
@@ -1,7 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 export function generateId(length?: number): string {
+  const len = length === undefined ? 4 : length;
   // tslint:disable-next-line: insecure-random
   return Math.random()
     .toString(36)
     .replace(/[^a-z]+/g, "")
-    .substr(0, length);
+    .slice(0, Math.max(0, len));
 }

--- a/libs/e2e/src/util/generateId.ts
+++ b/libs/e2e/src/util/generateId.ts
@@ -1,0 +1,7 @@
+export function generateId(length?: number): string {
+  // tslint:disable-next-line: insecure-random
+  return Math.random()
+    .toString(36)
+    .replace(/[^a-z]+/g, "")
+    .substr(0, length);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cohort name conflict arise in AML tests as we run all describes in single spec file which is not the case in OSS tests.
Create counterfactuals is not dynamic in AML unless we have compute attached. So skipping these tests for AML.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
