### PR TITLE
add toggle for switching classes in binary classification case

### DIFF
--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -434,13 +434,7 @@ export class JointDataset {
           featureArray.map((val) => [val])
         );
       }
-      case ModelTypes.Binary: {
-        return JointDataset.transposeLocalImportanceMatrix(
-          localExplanationRaw as number[][][]
-        ).map((featuresByClasses) =>
-          featuresByClasses.map((classArray) => classArray.slice(0, 1))
-        );
-      }
+      case ModelTypes.Binary:
       case ModelTypes.Multiclass:
       default: {
         return JointDataset.transposeLocalImportanceMatrix(
@@ -598,8 +592,7 @@ export class JointDataset {
       Number.MIN_SAFE_INTEGER
     );
     switch (this._modelMeta.modelType) {
-      case ModelTypes.Regression:
-      case ModelTypes.Binary: {
+      case ModelTypes.Regression: {
         // no need to flatten what is already flat
         this.rawLocalImportance.forEach((featuresByClasses, rowIndex) => {
           featuresByClasses.forEach((classArray, featureIndex) => {
@@ -621,6 +614,7 @@ export class JointDataset {
         });
         break;
       }
+      case ModelTypes.Binary:
       case ModelTypes.Multiclass: {
         this.rawLocalImportance.forEach((featuresByClasses, rowIndex) => {
           featuresByClasses.forEach((classArray, featureIndex) => {

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
@@ -82,7 +82,8 @@ export class SidePanel extends React.Component<
           onChange={this.onChartTypeChange}
           id="ChartTypeSelection"
         />
-        {this.props.metadata.modelType === ModelTypes.Multiclass &&
+        {(this.props.metadata.modelType === ModelTypes.Multiclass ||
+          this.props.metadata.modelType === ModelTypes.Binary) &&
           this.state.weightOptions && (
             <div>
               <LabelWithCallout
@@ -136,7 +137,10 @@ export class SidePanel extends React.Component<
   };
 
   private getWeightOptions(): IDropdownOption[] | undefined {
-    if (this.props.metadata.modelType === ModelTypes.Multiclass) {
+    if (
+      this.props.metadata.modelType === ModelTypes.Multiclass ||
+      this.props.metadata.modelType === ModelTypes.Binary
+    ) {
       return this.props.weightOptions.map((option) => {
         return {
           key: option,

--- a/libs/interpret/src/lib/MLIDashboard/Controls/Scatter/ExplanationExploration.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/Scatter/ExplanationExploration.tsx
@@ -75,9 +75,10 @@ export class ExplanationExploration extends React.PureComponent<
         dropdownOptions
       );
       const weightContext = this.props.dashboardContext.weightContext;
+      const modelType =
+        this.props.dashboardContext.explanationContext.modelMetadata.modelType;
       const includeWeightDropdown =
-        this.props.dashboardContext.explanationContext.modelMetadata
-          .modelType === ModelTypes.Multiclass;
+        modelType === ModelTypes.Multiclass || modelType === ModelTypes.Binary;
       let plotProp = ScatterUtils.populatePlotlyProps(
         projectedData,
         _.cloneDeep(this.plotlyProps)

--- a/libs/interpret/src/lib/MLIDashboard/Controls/SinglePointFeatureImportance.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/SinglePointFeatureImportance.tsx
@@ -214,9 +214,10 @@ export class SinglePointFeatureImportance extends React.PureComponent<
     // if (!this.props.explanationContext.testDataset.predictedY) {
     //     return result;
     // }
+    const modelType = this.props.explanationContext.modelMetadata.modelType;
     if (
-      this.props.explanationContext.modelMetadata.modelType !==
-      ModelTypes.Multiclass
+      modelType !== ModelTypes.Multiclass &&
+      modelType !== ModelTypes.Binary
     ) {
       result.push({
         key: FeatureKeys.AbsoluteLocal,
@@ -224,8 +225,8 @@ export class SinglePointFeatureImportance extends React.PureComponent<
       });
     }
     if (
-      this.props.explanationContext.modelMetadata.modelType ===
-      ModelTypes.Multiclass
+      modelType === ModelTypes.Multiclass ||
+      modelType === ModelTypes.Binary
     ) {
       result.push(
         ...this.props.explanationContext.modelMetadata.classNames.map(
@@ -243,8 +244,9 @@ export class SinglePointFeatureImportance extends React.PureComponent<
     if (!this.props.explanationContext.testDataset.predictedY) {
       return FeatureKeys.AbsoluteGlobal;
     }
-    return this.props.explanationContext.modelMetadata.modelType ===
-      ModelTypes.Multiclass
+    const modelType = this.props.explanationContext.modelMetadata.modelType;
+    return modelType === ModelTypes.Multiclass ||
+      modelType === ModelTypes.Binary
       ? this.props.explanationContext.testDataset.predictedY[
           this.props.selectedRow
         ]

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -84,7 +84,11 @@ export class LocalImportancePlots extends React.Component<
     if (!this.props.jointDataset.hasDataset) {
       return;
     }
-    if (this.props.metadata.modelType === ModelTypes.Multiclass) {
+    const modelType = this.props.metadata.modelType;
+    if (
+      modelType === ModelTypes.Multiclass ||
+      modelType === ModelTypes.Binary
+    ) {
       this.weightOptions = this.props.weightOptions.map((option) => {
         return {
           key: option,
@@ -214,7 +218,8 @@ export class LocalImportancePlots extends React.Component<
                   </Stack.Item>
                 </Stack>
 
-                {this.props.metadata.modelType === ModelTypes.Multiclass && (
+                {(this.props.metadata.modelType === ModelTypes.Multiclass ||
+                  this.props.metadata.modelType === ModelTypes.Binary) && (
                   <div>
                     <div className={classNames.multiclassWeightLabel}>
                       <Text

--- a/libs/interpret/src/lib/MLIDashboard/ExplanationDashboard.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/ExplanationDashboard.tsx
@@ -481,8 +481,7 @@ export class ExplanationDashboard extends React.Component<
       return undefined;
     }
     switch (modelType) {
-      case ModelTypes.Regression:
-      case ModelTypes.Binary: {
+      case ModelTypes.Regression: {
         // no need to flatten what is already flat
         return localExplanations.map((featuresByClasses) => {
           return featuresByClasses.map((classArray) => {
@@ -491,6 +490,7 @@ export class ExplanationDashboard extends React.Component<
         });
       }
       case ModelTypes.Multiclass:
+      case ModelTypes.Binary:
       default: {
         return localExplanations.map((featuresByClasses, rowIndex) => {
           return featuresByClasses.map((classArray) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the binary classification case for the aggregate feature importances and local importances (in the explanation component which is used in the RAI Dashboard, explanation dashboard, and error analysis dashboard), this PR adds the same drop-down as in multiclass case to allow the user to switch between the two binary classes.  Please see long-standing item:

https://github.com/microsoft/responsible-ai-toolbox/issues/374


Previously we would only show class 0 to users which was really, really confusing them a lot.

Screenshot for aggregate feature importances view:

![image](https://user-images.githubusercontent.com/24683184/169848442-c097d333-a35b-4031-a1bf-510b5c7455c9.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
