### PR TITLE
Update the way to get the length of elements obtained in e2e tests

### DIFF
--- a/libs/e2e/src/lib/describer/modelAssessment/Constants.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/Constants.ts
@@ -44,6 +44,7 @@ export enum Locators {
   WhatIfScatterChartYAxis = "#IndividualFeatureContainer div[class^='rotatedVerticalBox']",
   WhatIfScatterChartFlyoutCancel = "#AxisConfigPanel button:contains('Cancel')",
   WhatIfScatterChartFlyoutSelect = "#AxisConfigPanel button:contains('Select')",
+  WhatIfScatterChartSelectFeatureCaretButton = "#AxisConfigPanel i[data-icon-name='ChevronDown']",
   WhatIfAxisPanel = "#AxisConfigPanel",
   AxisFeatureDropdown = "#AxisConfigPanel div.ms-ComboBox-container",
   AxisFeatureDropdownOption = "div.ms-ComboBox-optionsContainerWrapper  button[role='option']",

--- a/libs/e2e/src/lib/describer/modelAssessment/causalAnalysis/describeAggregateCausalAffects.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/causalAnalysis/describeAggregateCausalAffects.ts
@@ -59,12 +59,10 @@ export function describeAggregateCausalAffects(
       });
 
       it("should render feature names on x-axis that are passed in from SDK", () => {
-        cy.get(Locators.CausalChartXAxisValues)
-          .its("length")
-          .should(
-            "be",
-            dataShape.causalAnalysisData?.featureListInCausalTable?.length
-          );
+        cy.get(Locators.CausalChartXAxisValues).should(
+          "have.length",
+          dataShape.causalAnalysisData?.featureListInCausalTable?.length
+        );
         cy.get(`${Locators.CausalChartXAxisValues}`)
           .last()
           .invoke("text")

--- a/libs/e2e/src/lib/describer/modelAssessment/featureImportances/individualFeatureImportance/describeSubBarChart.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/featureImportances/individualFeatureImportance/describeSubBarChart.ts
@@ -35,9 +35,10 @@ export function describeSubBarChart(dataShape: IModelAssessmentData): void {
       );
     });
     it("should have right number of x axis labels", () => {
-      cy.get(Locators.IFIXAxisValue)
-        .its("length")
-        .should("be", props.dataShape.featureNames?.length);
+      cy.get(Locators.IFIXAxisValue).should(
+        "have.length",
+        props.dataShape.featureNames?.length
+      );
     });
 
     it("should update x axis labels on changing top features by their importance number", () => {

--- a/libs/e2e/src/lib/describer/modelAssessment/featureImportances/individualFeatureImportance/describeSubLineChart.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/featureImportances/individualFeatureImportance/describeSubLineChart.ts
@@ -24,7 +24,9 @@ export function describeSubLineChart(
         selectRow("Index", "4");
       });
       it("should have more than one point", () => {
-        cy.get(Locators.ICENoOfPoints).its("length").should("be.gte", 1);
+        cy.get(Locators.ICENoOfPoints).then(($noOfPoints) => {
+          expect($noOfPoints).length.to.be.at.least(1);
+        });
       });
 
       it("should update x-axis value when 'Feature' dropdown is changed", () => {

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeAxisFlyouts.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeAxisFlyouts.ts
@@ -22,6 +22,7 @@ export function describeAxisFlyouts(dataShape: IModelAssessmentData): void {
           "have.length",
           dataShape.featureNames?.length
         );
+        cy.get(Locators.WhatIfScatterChartSelectFeatureCaretButton).click();
         cy.get(Locators.WhatIfScatterChartFlyoutCancel).click();
       });
       it("should be able to select different feature", () => {

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeSubBarChart.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeSubBarChart.ts
@@ -30,9 +30,9 @@ export function describeSubBarChart(dataShape: IModelAssessmentData): void {
       ).should("contain.text", "Feature importance");
     });
     it("should have right number of x axis labels", () => {
-      cy.get("#WhatIfFeatureImportanceBar g.highcharts-xaxis-labels text")
-        .its("length")
-        .should("be", props.dataShape.featureNames?.length);
+      cy.get(
+        "#WhatIfFeatureImportanceBar g.highcharts-xaxis-labels text"
+      ).should("have.length", props.dataShape.featureNames?.length);
     });
   });
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCreate.ts
@@ -10,35 +10,35 @@ export function describeWhatIfCreate(
   dataShape: IModelAssessmentData,
   name?: keyof typeof modelAssessmentDatasets
 ): void {
-  describe("What if Create counterfactual", () => {
-    before(() => {
-      cy.get(Locators.WICDatapointDropbox).click();
-      getSpan(
-        dataShape.whatIfCounterfactualsData?.selectedDatapoint || "Index 1"
-      ).click();
-      cy.get(Locators.CreateWhatIfCounterfactualButton)
-        .click()
-        .get(Locators.WhatIfCounterfactualPanel)
-        .should("exist");
-    });
-    after(() => {
-      cy.get(Locators.WhatIfCloseButton).click();
-    });
+  // AML do not need to execute below tests, as these options are not available for static view
+  if (name) {
+    describe("What if Create counterfactual", () => {
+      before(() => {
+        cy.get(Locators.WICDatapointDropbox).click();
+        getSpan(
+          dataShape.whatIfCounterfactualsData?.selectedDatapoint || "Index 1"
+        ).click();
+        cy.get(Locators.CreateWhatIfCounterfactualButton)
+          .click()
+          .get(Locators.WhatIfCounterfactualPanel)
+          .should("exist");
+      });
+      after(() => {
+        cy.get(Locators.WhatIfCloseButton).click();
+      });
 
-    it("should filter by included letters in search query", () => {
-      cy.get(Locators.WhatIfSearchBar).type(
-        dataShape.whatIfCounterfactualsData?.searchBarQuery || ""
-      );
-      cy.get(Locators.WhatIfColumnHeaders)
-        .eq(2)
-        .contains(dataShape.whatIfCounterfactualsData?.searchBarQuery || "");
-      cy.get(Locators.WhatIfSearchBarClearTextButton).click();
-      cy.get(Locators.WhatIfColumnHeaders).contains(
-        dataShape.whatIfCounterfactualsData?.columnHeaderAfterSort || ""
-      );
-    });
-    // AML do not need to execute below tests, as these options are not available for static view
-    if (name) {
+      it("should filter by included letters in search query", () => {
+        cy.get(Locators.WhatIfSearchBar).type(
+          dataShape.whatIfCounterfactualsData?.searchBarQuery || ""
+        );
+        cy.get(Locators.WhatIfColumnHeaders)
+          .eq(2)
+          .contains(dataShape.whatIfCounterfactualsData?.searchBarQuery || "");
+        cy.get(Locators.WhatIfSearchBarClearTextButton).click();
+        cy.get(Locators.WhatIfColumnHeaders).contains(
+          dataShape.whatIfCounterfactualsData?.columnHeaderAfterSort || ""
+        );
+      });
       it("Should have 'Create your own counterfactual' section and it should be editable", () => {
         cy.get(Locators.CreateYourOwnCounterfactualInputField)
           .eq(2)
@@ -72,8 +72,8 @@ export function describeWhatIfCreate(
             dataShape.whatIfCounterfactualsData?.whatIfNameLabelUpdated
           );
       });
-    }
-  });
+    });
+  }
 
   describe.skip("What-If save scenario", () => {
     before(() => {


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

One of the causal test was failing for the way we were getting the length of the elements. This is the updated way to get the length.

![image](https://user-images.githubusercontent.com/33799331/170359531-721a6c85-86cd-46c9-bc8d-101350569505.png)

Add collapse dropdown before clicking on cancel button in panel
## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
