### PR TITLE
fix dataset explorer plot with count not displaying

### DIFF
--- a/libs/dataset-explorer/src/lib/getDatasetBar.ts
+++ b/libs/dataset-explorer/src/lib/getDatasetBar.ts
@@ -24,10 +24,11 @@ export function getDatasetBar(
     chartProps?.xAxis.property &&
     jointData.metaDict[chartProps.xAxis.property].sortedCategoricalValues
       ?.length;
+  const noneGroup = "none";
 
   if (customData && xData) {
     for (const [i, customDatum] of customData.entries()) {
-      const yValue = (customDatum as any).Y;
+      const yValue = (customDatum as any).Y ?? noneGroup;
       if (!groupedData[yValue]) {
         groupedData[yValue] = new Array(xDataTypeCount).fill(0);
       }
@@ -36,9 +37,9 @@ export function getDatasetBar(
   }
 
   if (chartProps?.yAxis.property) {
-    jointData.metaDict[
-      chartProps.yAxis.property
-    ].sortedCategoricalValues?.forEach((value) => {
+    const groups = jointData.metaDict[chartProps.yAxis.property]
+      .sortedCategoricalValues ?? [noneGroup];
+    groups.forEach((value) => {
       result.push({
         data: groupedData[value],
         name: value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed issue https://github.com/microsoft/responsible-ai-toolbox/issues/1453 where count plot is not displaying.

The main problem was that count uses "none" as the metadata name, which does not have any sorted categorical values (see https://github.com/microsoft/responsible-ai-toolbox/blob/bc7a9f91445db86e41784c9355bc7b9d230c7cb2/libs/core-ui/src/lib/util/JointDataset.ts#L739 which sets treatAsCategorical=True, but does not specify categorical values).  However, when creating the highchart options, we skip the step to pass the values of the "none" group, since we iterate over all categorical values.  There are several possible fixes here (another I had was to insert an array with some dummy "count" value for the categoricals values in JointDataset which also worked), but I felt this was the least intrusive and safest one.


Screenshot of fixed plot:
![image](https://user-images.githubusercontent.com/24683184/171205488-ffbec23f-759b-457f-92ee-c6194e0fe878.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [x] New tests were added or changes were manually verified.
