### PR TITLE
[Bugfix] HeatmapHighChart: Prioritize configOverride over defaultOptions

### DIFF
--- a/libs/core-ui/src/lib/Highchart/HeatmapHighChart.tsx
+++ b/libs/core-ui/src/lib/Highchart/HeatmapHighChart.tsx
@@ -13,7 +13,7 @@ export class HeatmapHighChart extends React.Component<ICommonChartProps> {
   public render(): React.ReactNode {
     const defaultOptions = getDefaultHighchartOptions(getTheme());
     const { className, id, fallback, configOverride = {}, theme } = this.props;
-    const chartOptions = _.merge({}, configOverride, defaultOptions);
+    const chartOptions = _.merge({}, defaultOptions, configOverride);
 
     return (
       <HighchartWrapper


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->

### Context
When trying to create a heatmap using `HeatmapHighChart`, I had set `legend: { enabled : true }` but I was not seeing the legend in the heatmap.

It turns out that `lodash.merge` prioritizes values from right to left. Therefore, we should specify `configOverride` last since we want its values to be prioritzed over `defaultOptions`.

### Showcasing bug

Original code:
![image](https://user-images.githubusercontent.com/64443771/171304180-9f75472c-f2ff-4f23-a630-362c1d7d36b2.png)
![image](https://user-images.githubusercontent.com/64443771/171304265-303bdd4b-cf49-411e-9189-2477e813fa2d.png)

### Showcasing fix

Fix (swap `configOverride` and `defaultOptions`): 
![image](https://user-images.githubusercontent.com/64443771/171304312-0e647ebb-ddd9-4b26-919b-50bfc79ade38.png)
![image](https://user-images.githubusercontent.com/64443771/171304345-7b7bd8ac-2cd3-43dc-be5a-afd26697b9e8.png)


<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] Documentation was updated if it was needed.
- [ ] New tests were added or changes were manually verified.
