### PR TITLE
Re-enable counterfactual sub-bar UI tests

### DIFF
--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeSubBarChart.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeSubBarChart.ts
@@ -27,7 +27,10 @@ export function describeSubBarChart(dataShape: IModelAssessmentData): void {
     it.skip("should have y axis with matched value", () => {
       cy.get(
         '#WhatIfFeatureImportanceBar div[class^="rotatedVerticalBox-"]'
-      ).should("contain.text", "Feature importance");
+      ).should(
+        "contain.text",
+        "Percentage of counterfactuals that varied the feature"
+      );
     });
     it("should have right number of x axis labels", () => {
       cy.get(

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIf.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIf.ts
@@ -9,6 +9,7 @@ import {
 import { modelAssessmentDatasets } from "../modelAssessmentDatasets";
 
 import { describeAxisFlyouts } from "./describeAxisFlyouts";
+import { describeSubBarChart } from "./describeSubBarChart";
 import { describeWhatIfCommonFunctionalities } from "./describeWhatIfCommonFunctionalities";
 import { describeWhatIfCreate } from "./describeWhatIfCreate";
 
@@ -43,6 +44,12 @@ export function describeWhatIf(
       describeWhatIfCommonFunctionalities(datasetShape);
       describeAxisFlyouts(datasetShape);
       describeWhatIfCreate(datasetShape, name);
+    }
+    if (
+      !datasetShape.featureImportanceData?.noLocalImportance &&
+      !datasetShape.featureImportanceData?.noFeatureImportance
+    ) {
+      describeSubBarChart(datasetShape);
     }
   });
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCommonFunctionalities.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/whatIfCounterfactuals/describeWhatIfCommonFunctionalities.ts
@@ -8,8 +8,6 @@ import { ScatterHighchart } from "../../../../util/ScatterHighchart";
 import { Locators } from "../Constants";
 import { IModelAssessmentData } from "../IModelAssessmentData";
 
-// import { describeSubBarChart } from "./describeSubBarChart";
-
 export function describeWhatIfCommonFunctionalities(
   dataShape: IModelAssessmentData
 ): void {
@@ -58,12 +56,5 @@ export function describeWhatIfCommonFunctionalities(
         cy.get(Locators.WICLocalImportanceDescription).contains("Row 1");
       });
     });
-
-    // if (
-    //   !dataShape.featureImportanceData?.noLocalImportance &&
-    //   !dataShape.featureImportanceData?.noFeatureImportance
-    // ) {
-    //   describeSubBarChart(dataShape);
-    // }
   });
 }


### PR DESCRIPTION
## Description

It seems these were disabled for high chart work. Re-enabling them now.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
