### PR TITLE
Add DataBalanceAnalysis module to ResponsibleAI package to be consumed by visualizations

### DIFF
--- a/responsibleai/responsibleai/databalanceanalysis/__init__.py
+++ b/responsibleai/responsibleai/databalanceanalysis/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Tools to help understand imbalance and potential bias in data."""
+
+from .aggregate_balance_measures import AggregateBalanceMeasures
+from .distribution_balance_measures import DistributionBalanceMeasures
+from .feature_balance_measures import FeatureBalanceMeasures
+
+__all__ = [
+    "AggregateBalanceMeasures",
+    "FeatureBalanceMeasures",
+    "DistributionBalanceMeasures",
+]

--- a/responsibleai/responsibleai/databalanceanalysis/aggregate_balance_measures.py
+++ b/responsibleai/responsibleai/databalanceanalysis/aggregate_balance_measures.py
@@ -1,0 +1,176 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from typing import Callable, Dict, List
+
+import numpy as np
+import pandas as pd
+
+from responsibleai.databalanceanalysis.balance_measures import BalanceMeasures
+from responsibleai.databalanceanalysis.constants import Measures
+
+
+def _get_generalized_entropy_index(
+    benefits: np.array,
+    alpha: float,
+    use_abs_val: bool,
+    error_tolerance: float = 1e-12,
+) -> float:
+    """
+    Returns the general entropy index, a measure of redundancy in the data.
+    https://en.wikipedia.org/wiki/Generalized_entropy_index
+
+    :param benefits: The probabilities of each feature value combination
+        occurring in the data.
+    :type benefits: np.array
+    :param alpha: A parameter which regulates the weight given to distances
+        between benefits at different parts of the distribution.
+    :type alpha: float
+    :param use_abs_val: Whether to use the absolute value of the benefits
+        or not.
+    :type use_abs_val: bool
+    :param error_tolerance: The error tolerance to use when calculating
+        the generalized entropy index.
+    :type error_tolerance: float
+    :return: The generalized entropy index.
+    :rtype: float
+    """
+    if use_abs_val:
+        benefits = np.absolute(benefits)
+
+    benefits_mean = np.mean(benefits)
+    norm_benefits = benefits / benefits_mean
+    count = norm_benefits.size
+
+    if abs(alpha - 1.0) < error_tolerance:
+        gei = np.sum(norm_benefits * np.log(norm_benefits)) / count
+    elif abs(alpha) < error_tolerance:
+        gei = np.sum(-np.log(norm_benefits)) / count
+    else:
+        gei = np.sum(np.power(norm_benefits, alpha) - 1.0) / (
+            count * alpha * (alpha - 1.0)
+        )
+
+    return gei
+
+
+def get_atkinson_index(
+    benefits: np.array,
+    epsilon: float = 1.0,
+    error_tolerance: float = 1e-12,
+) -> float:
+    """
+    Returns the Atkinson Index, a measure of income inequality that
+    indicates the percentage of the data that needs to be foregone
+    to have equal shares of income.
+    https://en.wikipedia.org/wiki/Atkinson_index
+
+    :param benefits: The probabilities of each feature value combination
+        occurring in the data.
+    :type benefits: np.array
+    :param epsilon: A parameter that regulates the weight given
+        to the distances between benefits.
+    :type epsilon: float
+    :param error_tolerance: The error tolerance to use when calculating
+        the Atkinson Index.
+    :type error_tolerance: float
+    :return: The Atkinson Index.
+    :rtype: float
+    """
+    count = benefits.size
+    benefits_mean = np.mean(benefits)
+    norm_benefits = benefits / benefits_mean
+    alpha = 1 - epsilon
+
+    if abs(alpha) < error_tolerance:
+        ati = 1.0 - np.power(np.prod(norm_benefits), 1.0 / count)
+    else:
+        power_mean = np.sum(np.power(norm_benefits, alpha)) / count
+        ati = 1.0 - np.power(power_mean, 1.0 / alpha)
+
+    return ati
+
+
+def get_theil_t_index(benefits: np.array) -> float:
+    """
+    Returns Theil T Index, a measure of income inequality that is more
+    sensitive to differences at the top of the distribution.
+    https://en.wikipedia.org/wiki/Theil_index
+
+    :param benefits: The probabilities of each feature value combination
+        occurring in the data.
+    :type benefits: np.array
+    :return: The Theil T Index.
+    :rtype: float
+    """
+    return _get_generalized_entropy_index(
+        benefits=benefits, alpha=1.0, use_abs_val=True
+    )
+
+
+def get_theil_l_index(benefits: np.array) -> float:
+    """
+    Returns Theil L Index, a measure of income inequality that is
+    more sensitive to differences at the lower end of the distribution.
+    https://en.wikipedia.org/wiki/Theil_index
+
+    :param benefits: The probabilities of each feature value combination
+        occurring in the data.
+    :type benefits: np.array
+    :return: The Theil L Index.
+    :rtype: float
+    """
+    return _get_generalized_entropy_index(
+        benefits=benefits, alpha=0.0, use_abs_val=True
+    )
+
+
+class AggregateBalanceMeasures(BalanceMeasures):
+    """
+    This class computes a set of aggregated balance measures that represents
+    how balanced the given dataset is along the given columns of interest.
+    """
+
+    AGGREGATE_METRICS: Dict[Measures, Callable[[np.array], float]] = {
+        Measures.THEIL_L_INDEX: get_theil_l_index,
+        Measures.THEIL_T_INDEX: get_theil_t_index,
+        Measures.ATKINSON_INDEX: get_atkinson_index,
+    }
+
+    def __init__(self, cols_of_interest: List[str]) -> None:
+        """
+        Construct a AggregateBalanceMeasures class for calculating
+        aggregate balance measures on a dataset.
+
+        :param cols_of_interest: The list of columns to compute
+            aggregate balance measures on.
+        :type cols_of_interest: List[str]
+        """
+        super().__init__(cols_of_interest=cols_of_interest)
+
+    def measures(self, dataset: pd.DataFrame) -> pd.DataFrame:
+        """
+        Returns aggregate balance measures for the given dataset and
+        columns of interest.
+
+        The following measures are computed:
+        * Atkinson Index - https://en.wikipedia.org/wiki/Atkinson_index
+        * Theil Index (L and T) - https://en.wikipedia.org/wiki/Theil_index
+
+        :param dataset: The dataset to compute aggregate measures on.
+        :type dataset: pd.DataFrame
+        :return: A pandas DataFrame that contains the names and values of
+            aggregate balance measures for the given dataset and
+            columns of interest.
+        :rtype: pd.DataFrame
+        """
+        aggregate_measures_dict = {}
+        benefits = (
+            dataset.groupby(self.cols_of_interest).size() / dataset.shape[0]
+        )
+
+        for measure, func in self.AGGREGATE_METRICS.items():
+            aggregate_measures_dict[measure.value] = [func(benefits)]
+
+        aggregate_measures = pd.DataFrame.from_dict(aggregate_measures_dict)
+        return aggregate_measures

--- a/responsibleai/responsibleai/databalanceanalysis/balance_measures.py
+++ b/responsibleai/responsibleai/databalanceanalysis/balance_measures.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from abc import ABC, abstractmethod
+from typing import List
+
+import pandas as pd
+
+
+class BalanceMeasures(ABC):
+    """
+    An abstract class that computes measures for a given dataset
+    and given columns of interest.
+    """
+
+    def __init__(self, cols_of_interest: List[str]) -> None:
+        """
+        Construct a BalanceMeasures class for calculating
+        measures on the given columns of interest.
+
+        :param cols_of_interest: The list of columns to compute measures on.
+        :type cols_of_interest: List[str]
+        """
+        self.cols_of_interest = cols_of_interest
+
+    @abstractmethod
+    def measures(self, dataset: pd.DataFrame) -> pd.DataFrame:
+        """
+        Returns measures for the given dataset and columns of interest.
+
+        :param dataset: The dataset to compute measures on.
+        :type dataset: pd.DataFrame
+        :return: A pandas DataFrame containing the measures.
+        :rtype: pd.DataFrame
+        """
+        ...

--- a/responsibleai/responsibleai/databalanceanalysis/constants.py
+++ b/responsibleai/responsibleai/databalanceanalysis/constants.py
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from enum import Enum
+
+
+class Constants(Enum):
+    """
+    Enum providing general constants that are not measures.
+    """
+
+    FEATURE_NAME = "FeatureName"
+
+
+class Measures(Enum):
+    """
+    Enum providing the supported data imbalance measures. Its values are used
+    to denote dataframe column names, and don't contain spaces
+    so that measures can be accessed via dot notation (i.e. `df.measure`).
+    """
+
+    # Feature Balance Measures
+    STATISTICAL_PARITY = "StatisticalParity"
+    POINTWISE_MUTUAL_INFO = "PointwiseMutualInfo"
+    SD_COEF = "SorensonDiceCoeff"
+    JACCARD_INDEX = "JaccardIndex"
+    KR_CORRELATION = "KendallRankCorrelation"
+    LOG_LIKELIHOOD = "LogLikelihoodRatio"
+    TTEST = "TTest"
+    TTEST_PVALUE = "TTestPValue"
+
+    # Aggregate Balance Measures
+    ATKINSON_INDEX = "AtkinsonIndex"
+    THEIL_L_INDEX = "TheilLIndex"
+    THEIL_T_INDEX = "TheilTIndex"
+
+    # Distribution Balance Measures
+    CROSS_ENTROPY = "CrossEntropy"
+    KL_DIVERGENCE = "KLDivergence"
+    JS_DISTANCE = "JensenShannonDist"
+    WS_DISTANCE = "WassersteinDist"
+    INF_NORM_DIST = "InfiniteNormDist"
+    TOTAL_VAR_DIST = "TotalVarianceDist"
+    CHISQ_STATISTIC = "ChiSquareStat"
+    CHISQ_PVALUE = "ChiSquarePValue"

--- a/responsibleai/responsibleai/databalanceanalysis/distribution_balance_measures.py
+++ b/responsibleai/responsibleai/databalanceanalysis/distribution_balance_measures.py
@@ -1,0 +1,274 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from typing import Callable, Dict, List
+
+import numpy as np
+import pandas as pd
+import scipy
+
+from responsibleai.databalanceanalysis.balance_measures import BalanceMeasures
+from responsibleai.databalanceanalysis.constants import Constants, Measures
+
+
+def get_cross_entropy(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the cross entropy between two probability distributions.
+    https://en.wikipedia.org/wiki/Cross_entropy
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The cross entropy between the two probability distributions.
+    :rtype: float
+    """
+    return -np.sum(ref * np.log2(obs))
+
+
+def get_kl_divergence(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the Kullback-Leibler (KL) divergence, a measure of how one
+    probability distribution is different from another.
+    https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The KL divergence between the two probability distributions.
+    :rtype: float
+    """
+    return scipy.stats.entropy(obs, qk=ref)
+
+
+def get_js_distance(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the Jenson-Shannon Distance, a measure that is the
+    symmetrized and smoothed version of the KL divergence.
+    https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The JS Distance between the two probability distributions.
+    :rtype: float
+    """
+    avg = (obs + ref) / 2
+    divergence = (
+        scipy.stats.entropy(obs, avg) + scipy.stats.entropy(ref, avg)
+    ) / 2
+    distance = np.sqrt(divergence)
+    return distance
+
+
+def get_ws_distance(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the Wasserstein Distance, a measure that symbolizes the
+    minimum cost to turn one probability distribution into another.
+    https://en.wikipedia.org/wiki/Wasserstein_metric
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The Wasserstein Distance between the two probability
+        distributions.
+    :rtype: float
+    """
+    return scipy.stats.wasserstein_distance(obs, ref)
+
+
+def get_inf_norm_dist(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the Infinity norm distance (AKA the Chebyshev distance),
+    a measure of the maximum absolute difference between two probability
+    distributions.
+    https://en.wikipedia.org/wiki/Chebyshev_distance
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The Infinity norm distance between the two probability
+        distributions.
+    :rtype: float
+    """
+    return scipy.spatial.distance.chebyshev(obs, ref)
+
+
+def get_total_var_dist(obs: np.array, ref: np.array) -> float:
+    """
+    Returns the total variation distance, a measure similar to the KL
+    divergence in specifying the distance between two probability
+    distributions.
+    https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures
+
+    :param obs: The observed probability distribution.
+    :type obs: np.array
+    :param ref: The reference probability distribution.
+    :type ref: np.array
+    :return: The total variation distance between the two probability
+        distributions.
+    :rtype: float
+    """
+    return 0.5 * np.sum(np.abs(obs - ref))
+
+
+def get_chisq_statistic(f_obs: np.array, f_ref: np.array) -> float:
+    """
+    Returns the Chi-Square test statistic, a measure that determines the
+    statistical significant difference between two frequencies.
+    https://en.wikipedia.org/wiki/Chi-squared_test
+
+    :param f_obs: Frequencies of the observed probability distribution.
+    :type f_obs: np.array
+    :param f_ref: Frequencies of the reference probability distribution.
+    :type f_ref: np.array
+    :return: The Chi-Square test statistic between the frequencies of the
+        two probability distributions.
+    :rtype: float
+    """
+    res = scipy.stats.chisquare(f_obs, f_ref)
+    chisq: float = res[0]
+    return chisq
+
+
+def get_chisq_pvalue(f_obs: np.array, f_ref: np.array) -> float:
+    """
+    Returns the p-value of the Chi-Square, which is the probability of
+    obtaining test results at least as extreme as the observed results.
+    A small p-value means that the observed results are very unlikely
+    under the null hypothesis (i.e. the distributions are the same).
+    https://en.wikipedia.org/wiki/Chi-squared_test
+
+    :param f_obs: Frequencies of the observed probability distribution.
+    :type f_obs: np.array
+    :param f_ref: Frequencies of the reference probability distribution.
+    :type f_ref: np.array
+    :return: The p-value of the Chi-Square test statistic between the
+        frequencies of the two probability distributions.
+    :rtype: float
+    """
+    res = scipy.stats.chisquare(f_obs, f_ref)
+    pvalue: float = res[1]
+    return pvalue
+
+
+class DistributionBalanceMeasures(BalanceMeasures):
+    """
+    This class computes data balance measures for columns of interest
+    based on a reference distribution. Currently, only the uniform reference
+    distribution is supported.
+    """
+
+    DISTRIBUTION_METRICS: Dict[
+        Measures, Callable[[np.array, np.array], float]
+    ] = {
+        Measures.KL_DIVERGENCE: get_kl_divergence,
+        Measures.JS_DISTANCE: get_js_distance,
+        Measures.WS_DISTANCE: get_ws_distance,
+        Measures.INF_NORM_DIST: get_inf_norm_dist,
+        Measures.TOTAL_VAR_DIST: get_total_var_dist,
+        Measures.CHISQ_PVALUE: get_chisq_pvalue,
+        Measures.CHISQ_STATISTIC: get_chisq_statistic,
+        Measures.CROSS_ENTROPY: get_cross_entropy,
+    }
+
+    def __init__(self, cols_of_interest: List[str]) -> None:
+        """
+        Construct a DistributionBalanceMeasure class for calculating
+        distribution balance measures on a dataset.
+
+        :param cols_of_interest: The list of columns to compute
+            distribution balance measures on.
+        :type cols_of_interest: List[str]
+        """
+        super().__init__(cols_of_interest=cols_of_interest)
+
+    def measures(self, dataset: pd.DataFrame) -> pd.DataFrame:
+        """
+        Returns distribution balance measures for the given dataset and
+        columns of interest.
+
+        The following measures are computed:
+        * Kullback-Leibler Divergence -
+            https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+        * Jensen-Shannon Distance -
+            https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence
+        * Wasserstein Distance -
+            https://en.wikipedia.org/wiki/Wasserstein_metric
+        * Infinity Norm Distance -
+            https://en.wikipedia.org/wiki/Chebyshev_distance
+        * Total Variation Distance -
+            https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures
+        * Chi-Squared Test -
+            https://en.wikipedia.org/wiki/Chi-squared_test
+        * Cross Entropy -
+            https://en.wikipedia.org/wiki/Cross_entropy
+
+        :param dataset: The dataset to compute distribution measures on.
+        :type dataset: pd.DataFrame
+        :return: A pandas DataFrame that contains the given
+            columns of interest and for each column of interest,
+            a `dict` of <measure name, measure value> pairs.
+        :rtype: pd.DataFrame
+        """
+        all_measures = [
+            DistributionBalanceMeasures._get_distribution_measures_for_col(
+                df=dataset, col_of_interest=col
+            )
+            for col in self.cols_of_interest
+        ]
+        return pd.DataFrame.from_dict(all_measures)
+
+    @staticmethod
+    def _get_distribution_measures_for_col(
+        df: pd.DataFrame, col_of_interest: str
+    ) -> Dict[Measures, float]:
+        """
+        Returns a dictionary of distribution balance measures based on the
+        given dataset and column of interest.
+
+        :param df: The dataset to compute distribution measures on.
+        :type df: pd.DataFrame
+        :param col_of_interest: The column of interest to compute
+            distribution measures on.
+        :type col_of_interest: str
+        :return: A `dict` of <measure name, measure value> pairs.
+        :rtype: Dict[Measures, float]
+        """
+        f_obs = df.groupby(col_of_interest).size().reset_index(name="count")
+        sum_obs = f_obs["count"].sum()
+        obs = f_obs["count"] / sum_obs
+        ref = DistributionBalanceMeasures._create_reference_distribution(
+            n=f_obs.shape[0]
+        )
+        f_ref = ref * sum_obs
+
+        measures = {Constants.FEATURE_NAME.value: col_of_interest}
+        for (
+            measure,
+            func,
+        ) in DistributionBalanceMeasures.DISTRIBUTION_METRICS.items():
+            if measure in [Measures.CHISQ_PVALUE, Measures.CHISQ_STATISTIC]:
+                measures[measure.value] = func(f_obs["count"], f_ref)
+            else:
+                measures[measure.value] = func(obs, ref)
+
+        return measures
+
+    @staticmethod
+    def _create_reference_distribution(n: int) -> np.array:
+        """
+        Returns a reference distribution based on `n` outcomes.
+        For now, this is a uniform distribution.
+
+        :param n: The number of outcomes.
+        :type n: int
+        :return: The reference distribution.
+        :rtype: np.array
+        """
+        uniform_val: float = 1.0 / n
+        return np.ones(n) * uniform_val

--- a/responsibleai/responsibleai/databalanceanalysis/feature_balance_measures.py
+++ b/responsibleai/responsibleai/databalanceanalysis/feature_balance_measures.py
@@ -1,0 +1,411 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import itertools
+from typing import Callable, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+import scipy
+
+from responsibleai.databalanceanalysis.balance_measures import BalanceMeasures
+from responsibleai.databalanceanalysis.constants import Constants, Measures
+
+
+def get_statistical_parity(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Statistical Parity of a feature, a fairness measure which
+    states the probability that the feature sees the positive outcome.
+    https://en.wikipedia.org/wiki/Fairness_%28machine_learning%29
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Statistical Parity of the feature.
+    :rtype: float
+    """
+    return p_pos_feature / p_feature
+
+
+def get_point_mutual(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Point Mutual Information of a feature, an entropy measure
+    which quantifies the discrepancy between the probability of their
+    coincidence given their joint distribution and their individual
+    distributions (assuming independence).
+    https://en.wikipedia.org/wiki/Pointwise_mutual_information
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Point Mutual Information of the feature.
+    :rtype: float
+    """
+    dp = get_statistical_parity(p_pos, p_feature, p_pos_feature, total_count)
+    return -np.inf if dp == 0 else np.log(dp)
+
+
+def get_sorenson_dice(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Sørensen-Dice coefficient of a feature, an
+    intersection-over-union measure used to gauge the similarity between
+    two samples. Also known as the F1 score.
+    https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Sørensen-Dice coefficient of the feature.
+    :rtype: float
+    """
+    return p_pos_feature / (p_feature + p_pos)
+
+
+def get_jaccard_index(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Jaccard Index of a feature, an
+    intersection-over-union measure used for gauging similarity and
+    diversity of sample sets.
+    https://en.wikipedia.org/wiki/Jaccard_index
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Jaccard Index of the feature.
+    :rtype: float
+    """
+    return p_pos_feature / (p_feature + p_pos - p_pos_feature)
+
+
+def get_kr_correlation(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Kendall Rank Correlation of a feature, a correlation
+    and statistical test that measures the ordinal association between two
+    measured quantities.
+    https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Kendall Rank Correlation of the feature.
+    :rtype: float
+    """
+    a = np.power(total_count, 2) * (
+        1 -
+        2 * p_feature -
+        2 * p_pos +
+        2 * p_pos_feature +
+        2 * p_pos * p_feature
+    )
+    b = total_count * (2 * p_feature + 2 * p_pos - 4 * p_pos_feature - 1)
+    c = np.power(total_count, 2) * np.sqrt(
+        (p_feature - np.power(p_feature, 2)) * (p_pos - np.power(p_pos, 2))
+    )
+    return (a + b) / c
+
+
+def get_log_likelihood_ratio(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the Log likelihood ratio of a feature, a correlation
+    and statistical test that gives the probability of correctly predicting
+    the label in ratio to probability of incorrectly predicting the label.
+    https://en.wikipedia.org/wiki/Likelihood_function#Likelihood_ratio
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The Log likelihood ratio of the feature.
+    :rtype: float
+    """
+    return -np.inf if p_pos_feature == 0 else np.log(p_pos_feature / p_pos)
+
+
+def get_ttest_stat(
+    p_pos: float, p_feature: float, p_pos_feature: float, total_count: int
+) -> float:
+    """
+    Returns the t-test statistic of a feature, a correlation
+    and statistical test that is used to compare the means of two groups
+    (pairwise). t-test compares the means of two groups and
+    this gets a value to be looked up on t-distribution.
+    https://en.wikipedia.org/wiki/Student%27s_t-test
+
+    :param p_pos: The probability of the positive outcome in the dataset.
+    :type p_pos: float
+    :param p_feature: The probability of the feature in the dataset.
+    :type p_feature: float
+    :param p_pos_feature: The probability of the positive outcome and the
+        feature in the dataset.
+    :type p_pos_feature: float
+    :param total_count: The total number of observations in the dataset.
+    :type total_count: int
+    :return: The t-test statistic of the feature.
+    :rtype: float
+    """
+    return (p_pos - (p_feature * p_pos)) / np.sqrt(p_feature * p_pos)
+
+
+def get_ttest_pvalue(metric: float, num_unique_vals: int) -> float:
+    """
+    Returns the t-test p-value. Once the t-test statistic and degrees
+    of freedom are determined, the p-value can be found using a table
+    of values from the t-distribution.
+    https://en.wikipedia.org/wiki/Student%27s_t-test
+
+    :param metric: The t-test statistic of the feature.
+    :type metric: float
+    :param num_unique_vals: The number of unique values in the feature.
+    :type num_unique_vals: int
+    :return: The t-test p-value of the feature.
+    :rtype: float
+    """
+    t_statistic = metric
+    dof = num_unique_vals - 1
+    return scipy.stats.t.sf(abs(t_statistic), dof)
+
+
+class FeatureBalanceMeasures(BalanceMeasures):
+    """
+    This class computes a set of feature balance measures that allow us to see
+    whether each combination of a feature is receiving the positive outcome
+    (true prediction) at balanced probability.
+    """
+
+    CLASS_A = "ClassA"
+    CLASS_B = "ClassB"
+    PROB_POSITIVE = "p_pos"
+    PROB_FEATURE = "p_feature"
+    PROB_POS_FEATURE = "p_pos_feature"
+
+    FEATURE_METRICS: Dict[
+        Measures, Callable[[float, float, float, int], float]
+    ] = {
+        Measures.STATISTICAL_PARITY: get_statistical_parity,
+        Measures.POINTWISE_MUTUAL_INFO: get_point_mutual,
+        Measures.SD_COEF: get_sorenson_dice,
+        Measures.JACCARD_INDEX: get_jaccard_index,
+        Measures.KR_CORRELATION: get_kr_correlation,
+        Measures.LOG_LIKELIHOOD: get_log_likelihood_ratio,
+        Measures.TTEST: get_ttest_stat,
+    }
+
+    OVERALL_METRICS: Dict[
+        Tuple[Measures, Measures], Callable[[float, int], float]
+    ] = {
+        (
+            Measures.TTEST_PVALUE,
+            Measures.TTEST,
+        ): get_ttest_pvalue,
+    }
+
+    def __init__(self, cols_of_interest: List[str], label_col: str) -> None:
+        """
+        Construct a FeatureBalanceMeasures class for calculating
+        feature balance measures on a dataset.
+
+        :param cols_of_interest: The list of columns to compute
+            feature balance measures on.
+        :type cols_of_interest: List[str]
+        :param label_col: The name of the label column.
+        :type label_col: str
+        """
+        super().__init__(cols_of_interest=cols_of_interest)
+        self.label_col = label_col
+
+    def measures(self, dataset: pd.DataFrame) -> pd.DataFrame:
+        """
+        Returns feature balance measures for the given dataset,
+        columns of interest, and label column.
+
+        The following measures are computed:
+        * Statistical Parity -
+            https://en.wikipedia.org/wiki/Fairness_%28machine_learning%29
+        * Pointwise Mutual Information -
+            https://en.wikipedia.org/wiki/Pointwise_mutual_information
+        * Sorensen-Dice Coefficient -
+            https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+        * Jaccard Index -
+            https://en.wikipedia.org/wiki/Jaccard_index
+        * Kendall Rank Correlation -
+            https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient
+        * Log-Likelihood Ratio -
+            https://en.wikipedia.org/wiki/Likelihood_function#Likelihood_ratio
+        * t-test -
+            https://en.wikipedia.org/wiki/Student%27s_t-test
+
+        :param dataset: The dataset to compute the measures on.
+        :type df: pd.DataFrame
+        :return: A pandas DataFrame that contains four columns and has the
+            format: <Feature Name>, <Class A value>, <Class B value>, <dict of
+            measure name -> measure value key-value pairs>
+        :rtype: pd.DataFrame
+        """
+        feature_balance_measures = [
+            FeatureBalanceMeasures._get_measure_gaps_for_col(
+                df=dataset, col_of_interest=col, label_col=self.label_col
+            )
+            for col in self.cols_of_interest
+        ]
+        return pd.concat(feature_balance_measures)
+
+    @staticmethod
+    def _get_measure_gaps_for_col(
+        df: pd.DataFrame, col_of_interest: str, label_col: str
+    ) -> pd.DataFrame:
+        """
+        For the column of interest, computes "gaps" between two classes
+        (feature values) for every combination of values in the column.
+        Returns a dataframe that contains as many rows as there are unique
+        combinations in the column of interest and for each row, the
+        two feature values being compared and a dictionary of measure values.
+
+        :param df: The dataset to compute gaps between feature values on.
+        :type df: pd.DataFrame
+        :param col_of_interest: The column of interest to compute gaps between
+            feature values on.
+        :type col_of_interest: str
+        :param label_col: The name of the label column.
+        :type label_col: str
+        :return: A dataframe that contains four columns.
+        :rtype: pd.DataFrame
+        """
+        unique_vals = df[col_of_interest].unique()
+        # create list of tuples of the pairings of classes
+        pairs = list(itertools.combinations(unique_vals, 2))
+        gap_df = pd.DataFrame(
+            pairs,
+            columns=[
+                FeatureBalanceMeasures.CLASS_A,
+                FeatureBalanceMeasures.CLASS_B,
+            ],
+        )
+        gap_df[Constants.FEATURE_NAME.value] = col_of_interest
+
+        metrics_df = FeatureBalanceMeasures._get_individual_measures(
+            df=df, col_of_interest=col_of_interest, label_col=label_col
+        )
+
+        for measure in FeatureBalanceMeasures.FEATURE_METRICS.keys():
+            classA_metric = gap_df[FeatureBalanceMeasures.CLASS_A].apply(
+                lambda row: metrics_df.loc[row]
+            )[measure.value]
+            classB_metric = gap_df[FeatureBalanceMeasures.CLASS_B].apply(
+                lambda row: metrics_df.loc[row]
+            )[measure.value]
+            gap_df[measure.value] = classA_metric - classB_metric
+
+        # For overall stats
+        for (
+            measure,
+            test_stat,
+        ), func in FeatureBalanceMeasures.OVERALL_METRICS.items():
+            gap_df[measure.value] = gap_df[test_stat.value].apply(
+                lambda row: func(row, len(unique_vals))
+            )
+
+        return gap_df
+
+    @staticmethod
+    def _get_individual_measures(
+        df: pd.DataFrame,
+        col_of_interest: str,
+        label_col: str,
+        label_pos_val: any = 1,
+    ):
+        """
+        For the column of interest, computes the individual feature balance
+        measures for every unique value in the column. These measures are
+        used to compute "gaps" between two classes (feature values).
+
+        :param df: The df to compute individual feature balance
+            measures on.
+        :type df: pd.DataFrame
+        :param col_of_interest: The column of interest to compute the
+            individual feature balance measures on.
+        :type col_of_interest: str
+        :param label_col: The name of the label column.
+        :type label_col: str
+        :param label_pos_val: The value of the label column that indicates
+            a positive label.
+        :type label_pos_val: any
+        :return: A dataframe that contains individual feature balance measures.
+        :rtype: pd.DataFrame
+        """
+        num_rows = df.shape[0]
+
+        p_feature_col = (
+            df[col_of_interest]
+            .value_counts()
+            .rename(FeatureBalanceMeasures.PROB_FEATURE) / num_rows
+        )
+        p_pos_feature_col = (
+            df[df[label_col] == label_pos_val][col_of_interest]
+            .value_counts()
+            .rename(FeatureBalanceMeasures.PROB_POS_FEATURE) / num_rows
+        ).fillna(0)
+
+        new_df = pd.concat([p_feature_col, p_pos_feature_col], axis=1)
+        new_df[FeatureBalanceMeasures.PROB_POSITIVE] = (
+            df[df[label_col] == label_pos_val].shape[0] / num_rows
+        )
+
+        for measure, func in FeatureBalanceMeasures.FEATURE_METRICS.items():
+            new_df[measure.value] = new_df.apply(
+                lambda row: func(
+                    row[FeatureBalanceMeasures.PROB_POSITIVE],
+                    row[FeatureBalanceMeasures.PROB_FEATURE],
+                    row[FeatureBalanceMeasures.PROB_POS_FEATURE],
+                    num_rows,
+                ),
+                axis=1,
+            )
+
+        return new_df

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -1,8 +1,11 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import json
+
 import numpy as np
 import pandas as pd
+import pytest
 # Defines common utilities for responsibleai tests
 from dice_ml.utils import helpers
 from lightgbm import LGBMClassifier
@@ -178,3 +181,9 @@ def create_models_regression(X_train, y_train):
     rf_model = create_sklearn_random_forest_regressor(X_train, y_train)
 
     return [rf_model]
+
+
+def assert_series_and_dict_equal(left: pd.Series, right: dict):
+    left_json = left.to_json(orient="index")
+    left_dict = json.loads(left_json)
+    assert left_dict == pytest.approx(right)

--- a/responsibleai/tests/databalanceanalysis/__init__.py
+++ b/responsibleai/tests/databalanceanalysis/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Responsible AI data balance analysis tests."""

--- a/responsibleai/tests/databalanceanalysis/conftest.py
+++ b/responsibleai/tests/databalanceanalysis/conftest.py
@@ -1,0 +1,188 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import copy
+
+import pandas as pd
+import pytest
+
+from ..common_utils import create_adult_income_dataset
+
+
+@pytest.fixture(scope="session")
+def adult_data():
+    (
+        data_train,
+        data_test,
+        y_train,
+        y_test,
+        categorical_features,
+        _,
+        target_col,
+        _,
+    ) = create_adult_income_dataset()
+    train_df = copy.deepcopy(data_train)
+    test_df = copy.deepcopy(data_test)
+    train_df[target_col] = y_train
+    test_df[target_col] = y_test
+    cols_of_interest = categorical_features
+    return train_df, test_df, cols_of_interest, target_col
+
+
+@pytest.fixture(scope="session")
+def adult_data_feature_balance_measures():
+    return pd.DataFrame(
+        {
+            "ClassA": {"0": "White", "1": "Male"},
+            "ClassB": {"0": "Other", "1": "Female"},
+            "FeatureName": {"0": "race", "1": "gender"},
+            "StatisticalParity": {"0": 0.0982367846, "1": 0.1977193125},
+            "PointwiseMutualInfo": {"0": 0.4906283898, "1": 1.0465727536},
+            "SorensonDiceCoeff": {"0": 0.1394139444, "1": 0.1622153797},
+            "JaccardIndex": {"0": 0.1846417746, "1": 0.2230209651},
+            "KendallRankCorrelation": {"0": -4.6080688829, "1": -0.8738917288},
+            "LogLikelihoodRatio": {"0": 2.264674102, "1": 1.7462342396},
+            "TTest": {"0": -1.0210127581, "1": -0.3685341442},
+            "TTestPValue": {"0": 0.2466906059, "1": 0.3876079751},
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+def adult_data_distribution_balance_measures():
+    return pd.DataFrame(
+        {
+            "FeatureName": {"0": "race", "1": "gender"},
+            "KLDivergence": {"0": 0.2791392127, "1": 0.0576400449},
+            "JensenShannonDist": {"0": 0.2741838602, "1": 0.1209204479},
+            "WassersteinDist": {"0": 0.3549600737, "1": 0.168112715},
+            "InfiniteNormDist": {"0": 0.3549600737, "1": 0.168112715},
+            "TotalVarianceDist": {"0": 0.3549600737, "1": 0.168112715},
+            "ChiSquarePValue": {"0": 0.0, "1": 0.0},
+            "ChiSquareStat": {"0": 13127.8433660934, "1": 2944.6623157248},
+            "CrossEntropy": {"0": 1.5057745222, "1": 1.0865356576},
+        }
+    )
+
+
+@pytest.fixture(scope="session")
+def adult_data_aggregate_balance_measures():
+    return pd.DataFrame(
+        {
+            "TheilLIndex": {"0": 0.3912215368},
+            "TheilTIndex": {"0": 0.3420484048},
+            "AtkinsonIndex": {"0": 0.3237696704},
+        }
+    )
+
+
+# This synthetic dataset was manually created in the SynapseML data balance
+# feature so that metrics can be manually computed, thought of as the expected
+# results, and then compared to the actual results. This and the expected
+# measure fixtures below it are ports from the open source SynapseML repo.
+@pytest.fixture(scope="session")
+def synthetic_data(
+    synthetic_data_label, synthetic_data_feature_1, synthetic_data_feature_2
+):
+    rows = [
+        (0, "Male", "Asian"),
+        (0, "Male", "White"),
+        (1, "Male", "Other"),
+        (1, "Male", "Black"),
+        (0, "Female", "White"),
+        (0, "Female", "Black"),
+        (1, "Female", "Black"),
+        (0, "Other", "Asian"),
+        (0, "Other", "White"),
+    ]
+    return pd.DataFrame(
+        rows,
+        columns=[
+            synthetic_data_label,
+            synthetic_data_feature_1,
+            synthetic_data_feature_2,
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def synthetic_data_label():
+    return "Label"
+
+
+@pytest.fixture(scope="session")
+def synthetic_data_feature_1():
+    return "Gender"
+
+
+@pytest.fixture(scope="session")
+def synthetic_data_feature_2():
+    return "Ethnicity"
+
+
+@pytest.fixture(scope="session")
+def expected_aggregate_measures_feature_1():
+    return {
+        "AtkinsonIndex": 0.03850028646172776,
+        "TheilLIndex": 0.039261011885461196,
+        "TheilTIndex": 0.03775534151008828,
+    }
+
+
+@pytest.fixture(scope="session")
+def expected_aggregate_measures_both_features():
+    return {
+        "AtkinsonIndex": 0.030659793186437745,
+        "TheilLIndex": 0.03113963808639034,
+        "TheilTIndex": 0.03624967113471546,
+    }
+
+
+@pytest.fixture(scope="session")
+def expected_distribution_measures_feature_1():
+    return {
+        "FeatureName": "Gender",
+        "KLDivergence": 0.03775534151008829,
+        "JensenShannonDist": 0.09785224086736323,
+        "WassersteinDist": 0.07407407407407407,
+        "InfiniteNormDist": 0.1111111111111111,
+        "TotalVarianceDist": 0.1111111111111111,
+        "ChiSquarePValue": 0.7165313105737893,
+        "ChiSquareStat": 0.6666666666666666,
+        "CrossEntropy": 1.6416041676697,
+    }
+
+
+@pytest.fixture(scope="session")
+def expected_distribution_measures_feature_2():
+    return {
+        "FeatureName": "Ethnicity",
+        "KLDivergence": 0.07551068302017659,
+        "JensenShannonDist": 0.14172745151398888,
+        "WassersteinDist": 0.08333333333333333,
+        "InfiniteNormDist": 0.1388888888888889,
+        "TotalVarianceDist": 0.16666666666666666,
+        "ChiSquarePValue": 0.7476795872877147,
+        "ChiSquareStat": 1.222222222222222,
+        "CrossEntropy": 2.1274437525244,
+    }
+
+
+@pytest.fixture(scope="session")
+def expected_feature_balance_measures():
+    # Note: Compared to SynapseML, this module does not compute n_pmi_y,
+    # n_pmi_xy, and s_pmi. However, this module does compute TTest and
+    # TTestPValue so their actual values are used.
+    return {
+        "ClassA": "Male",
+        "ClassB": "Female",
+        "FeatureName": "Gender",
+        "StatisticalParity": 0.16666666666666669,
+        "PointwiseMutualInfo": 0.4054651081081645,
+        "SorensonDiceCoeff": 0.1190476190476191,
+        "JaccardIndex": 0.20000000000000004,
+        "KendallRankCorrelation": 0.18801108758923135,
+        "LogLikelihoodRatio": 0.6931471805599454,
+        "TTest": -0.1855414423,
+        "TTestPValue": 0.4349585786,
+    }

--- a/responsibleai/tests/databalanceanalysis/test_aggregate_balance_measures.py
+++ b/responsibleai/tests/databalanceanalysis/test_aggregate_balance_measures.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pandas as pd
+
+from responsibleai.databalanceanalysis import AggregateBalanceMeasures
+
+from ..common_utils import assert_series_and_dict_equal
+
+
+class TestAggregateBalanceMeasures:
+    def test_one_feature_synthetic_data(
+        self,
+        synthetic_data,
+        synthetic_data_feature_1,
+        expected_aggregate_measures_feature_1,
+    ):
+        agg_measures = (
+            AggregateBalanceMeasures(
+                cols_of_interest=[synthetic_data_feature_1]
+            )
+            .measures(dataset=synthetic_data)
+            .iloc[0]
+        )
+        assert_series_and_dict_equal(
+            agg_measures, expected_aggregate_measures_feature_1
+        )
+
+    def test_both_features_synthetic_data(
+        self,
+        synthetic_data,
+        synthetic_data_feature_1,
+        synthetic_data_feature_2,
+        expected_aggregate_measures_both_features,
+    ):
+        agg_measures = (
+            AggregateBalanceMeasures(
+                cols_of_interest=[
+                    synthetic_data_feature_1,
+                    synthetic_data_feature_2,
+                ]
+            )
+            .measures(dataset=synthetic_data)
+            .iloc[0]
+        )
+        assert_series_and_dict_equal(
+            agg_measures, expected_aggregate_measures_both_features
+        )
+
+    def test_adult_data(
+        self, adult_data, adult_data_aggregate_balance_measures
+    ):
+        train_df, test_df, _, _ = adult_data
+        full_df = pd.concat([train_df, test_df])
+        actual = AggregateBalanceMeasures(
+            cols_of_interest=["race", "gender"]
+        ).measures(dataset=full_df)
+        pd.testing.assert_frame_equal(
+            actual.reset_index(drop=True),
+            adult_data_aggregate_balance_measures.reset_index(drop=True),
+        )

--- a/responsibleai/tests/databalanceanalysis/test_distribution_balance_measures.py
+++ b/responsibleai/tests/databalanceanalysis/test_distribution_balance_measures.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pandas as pd
+
+from responsibleai.databalanceanalysis import DistributionBalanceMeasures
+
+from ..common_utils import assert_series_and_dict_equal
+
+
+class TestDistributionBalanceMeasures:
+    def test_feature_1_synthetic_data(
+        self,
+        synthetic_data,
+        synthetic_data_feature_1,
+        expected_distribution_measures_feature_1,
+    ):
+        dist_measures = (
+            DistributionBalanceMeasures(
+                cols_of_interest=[synthetic_data_feature_1]
+            )
+            .measures(dataset=synthetic_data)
+            .iloc[0]
+        )
+        assert_series_and_dict_equal(
+            dist_measures, expected_distribution_measures_feature_1
+        )
+
+    def test_feature_2_synthetic_data(
+        self,
+        synthetic_data,
+        synthetic_data_feature_2,
+        expected_distribution_measures_feature_2,
+    ):
+        dist_measures = (
+            DistributionBalanceMeasures(
+                cols_of_interest=[synthetic_data_feature_2]
+            )
+            .measures(dataset=synthetic_data)
+            .iloc[0]
+        )
+        assert_series_and_dict_equal(
+            dist_measures, expected_distribution_measures_feature_2
+        )
+
+    def test_adult_data(
+        self, adult_data, adult_data_distribution_balance_measures
+    ):
+        train_df, test_df, _, _ = adult_data
+        full_df = pd.concat([train_df, test_df])
+        actual = DistributionBalanceMeasures(
+            cols_of_interest=["race", "gender"]
+        ).measures(dataset=full_df)
+        pd.testing.assert_frame_equal(
+            actual.reset_index(drop=True),
+            adult_data_distribution_balance_measures.reset_index(drop=True),
+        )

--- a/responsibleai/tests/databalanceanalysis/test_feature_balance_measures.py
+++ b/responsibleai/tests/databalanceanalysis/test_feature_balance_measures.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pandas as pd
+
+from responsibleai.databalanceanalysis import FeatureBalanceMeasures
+
+from ..common_utils import assert_series_and_dict_equal
+
+
+class TestFeatureBalanceMeasures:
+    def test_synthetic_data(
+        self,
+        synthetic_data,
+        synthetic_data_feature_1,
+        synthetic_data_label,
+        expected_feature_balance_measures,
+    ):
+        feat_measures = (
+            FeatureBalanceMeasures(
+                cols_of_interest=[synthetic_data_feature_1],
+                label_col=synthetic_data_label,
+            )
+            .measures(dataset=synthetic_data)
+            .query("ClassA == 'Male' and ClassB == 'Female'")
+            .iloc[0]
+        )
+        assert_series_and_dict_equal(
+            feat_measures, expected_feature_balance_measures
+        )
+
+    def test_adult_data(self, adult_data, adult_data_feature_balance_measures):
+        train_df, test_df, cols_of_interest, target_col = adult_data
+        full_df = pd.concat([train_df, test_df])
+        actual = (
+            FeatureBalanceMeasures(
+                cols_of_interest=cols_of_interest, label_col=target_col
+            )
+            .measures(dataset=full_df)
+            .query(
+                "(ClassA == 'White' and ClassB == 'Other') or " +
+                "(ClassA == 'Male' and ClassB == 'Female')"
+            )
+        )
+        pd.testing.assert_frame_equal(
+            actual.reset_index(drop=True),
+            adult_data_feature_balance_measures.reset_index(drop=True),
+        )

--- a/responsibleai/tests/databalanceanalysis/test_feature_balance_measures.py
+++ b/responsibleai/tests/databalanceanalysis/test_feature_balance_measures.py
@@ -32,15 +32,18 @@ class TestFeatureBalanceMeasures:
     def test_adult_data(self, adult_data, adult_data_feature_balance_measures):
         train_df, test_df, cols_of_interest, target_col = adult_data
         full_df = pd.concat([train_df, test_df])
-        actual = (
-            FeatureBalanceMeasures(
-                cols_of_interest=cols_of_interest, label_col=target_col
-            )
-            .measures(dataset=full_df)
-            .query(
-                "(ClassA == 'White' and ClassB == 'Other') or " +
-                "(ClassA == 'Male' and ClassB == 'Female')"
-            )
+        feat_measures = FeatureBalanceMeasures(
+            cols_of_interest=cols_of_interest, label_col=target_col
+        ).measures(dataset=full_df)
+        actual = pd.concat(
+            [
+                feat_measures.query(
+                    "(ClassA == 'White' and ClassB == 'Other')"
+                ),
+                feat_measures.query(
+                    "(ClassA == 'Male' and ClassB == 'Female')"
+                ),
+            ]
         )
         pd.testing.assert_frame_equal(
             actual.reset_index(drop=True),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

Previously, the plan was to consume the `databalanceanalysis` module via the package `raimitigations` (open PR #1449).

However, it makes sense to move that module into the `responsibleai` package because we will be directly consuming this module for the Data Balance visualizations.

The module depends on numpy, pandas, and scipy -- all of which are already listed requirements.

This PR is:
- Lifting the `databalanceanalysis` module from this [GitHub repo](https://github.com/microsoft/responsible-ai-mitigations/tree/main/raimitigations/databalanceanalysis)
- Cleaning up the code + formatting 
- Docstrings for all methods
- More unit tests for both synthetic data (where we can calculate measures by hand) and adult census data

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
