### PR TITLE
Collapse correct prediction by default for individual feature importance

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
@@ -302,6 +302,7 @@ export class IndividualFeatureImportanceView extends React.Component<
           count: noIncorrectItem
             ? this.props.selectedCohort.cohort.filteredData.length
             : firstIncorrectItemIndex,
+          isCollapsed: true,
           key: "groupCorrect",
           level: 0,
           name: localization.ModelAssessment.FeatureImportances


### PR DESCRIPTION
Since people are focused on the error analysis, it will be more appropriate to by default to show the table with Correct predictions collapsed and only Incorrect predictions expanded.
This PR is to collapse "Correct prediction" by default and show "Incorrect prediction" by default for individual feature importance.

## Description
Before:
"Correct prediction" is expanded by default:
![image](https://user-images.githubusercontent.com/91754176/172687178-7f6a3bfc-a714-4ee2-a966-c607bf4b82b8.png)


After:
Collapse "Correct prediction" by default.
![image](https://user-images.githubusercontent.com/91754176/172687071-25f87a6e-222b-486c-9b03-e17a5df071c8.png)

## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
