### PR TITLE
use new getNativeModel method in get_surrogate_booster_pyspark to simplify erroranalysis code

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -25,8 +25,6 @@ from erroranalysis._internal.utils import is_spark
 
 # imports required for pyspark support
 try:
-    import glob
-
     import pyspark.sql.functions as F
     from synapse.ml.lightgbm import LightGBMClassifier, LightGBMRegressor
 except ImportError:
@@ -332,15 +330,9 @@ def get_surrogate_booster_pyspark(filtered_df, analyzer, max_depth,
         diff_data = diff_data.drop(PREDICTION)
     model = create_surrogate_model_pyspark(analyzer, diff_data, max_depth,
                                            num_leaves, min_child_samples)
-    # TODO: update lightgbm in pyspark to get around file requirement
-    model_path = "./models/lgbmclassifier.model"
-    model.saveNativeModel(model_path)
-    model_file = glob.glob(model_path + '/*.txt')[0]
-    with open(model_file) as f:
-        contents = f.read()
+    model_str = model.getNativeModel()
     booster_args = {'objective': analyzer.model_task}
-
-    lgbm_booster = Booster(params=booster_args, model_str=contents)
+    lgbm_booster = Booster(params=booster_args, model_str=model_str)
     return lgbm_booster, diff_data.to_koalas()
 
 

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '2'
+_patch = '3'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Description

Use new getNativeModel method in get_surrogate_booster_pyspark to simplify erroranalysis code.
The getNativeModel has just recently been added to synapseml in PR https://github.com/microsoft/SynapseML/pull/1515.  Now we can update the get_surrogate_booster_pyspark to use that instead of the custom logic to save/read from file when using error analysis in spark scenario.

Error Analysis on 4GB Higgs dataset in databricks cluster:

![image](https://user-images.githubusercontent.com/24683184/172720531-55bd6200-eb98-4a65-baf0-5570d97597fa.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
