### PR TITLE
Sort individual feature importance by residual for regression

### DIFF
--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -81,6 +81,7 @@ export class JointDataset {
   public static readonly PredictedYLabel = "PredictedY";
   public static readonly ProbabilityYRoot = "ProbabilityClass";
   public static readonly TrueYLabel = "TrueY";
+  public static readonly Residual = "Residual";
   public static readonly DitherLabel = "Dither";
   public static readonly DitherLabel2 = "Dither2";
   public static readonly ClassificationError = "ClassificationError";

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
@@ -282,7 +282,11 @@ export class IndividualFeatureImportanceView extends React.Component<
       this.props.modelType === ModelTypes.Regression
     ) {
       // don't use groups since there are no correct/incorrect buckets
-      this.props.selectedCohort.cohort.sort();
+      // sort individual feature importance by residual for regression prediction
+      this.props.selectedCohort.cohort.filteredData.forEach(
+        (item) => (item.Residual = Math.abs(item.PredictedY - item.TrueY))
+      );
+      this.props.selectedCohort.cohort.sort(JointDataset.Residual);
     } else {
       this.props.selectedCohort.cohort.sortByGroup(
         JointDataset.IndexLabel,


### PR DESCRIPTION
This PR orders the samples in individual feature importance by abs(true_y - predicted_y) for regression. It will show the predictions which are better first than the prediction which are way off in the model.

## Description
Before: sort by index
![image](https://user-images.githubusercontent.com/91754176/173163980-1bbf7ceb-b370-45c7-9ee8-b41844e1fda4.png)

After: sort by abs(true_y - predicted_y)
![image](https://user-images.githubusercontent.com/91754176/173163994-a79fc3e7-a5fd-4301-9b17-6a8377d9acc0.png)

## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
