### PR TITLE
Reorder controls in data explorer legend

### DIFF
--- a/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/DatasetExplorerTab.styles.ts
@@ -12,7 +12,6 @@ import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
 export interface IDatasetExplorerTabStyles {
   boldText: IStyle;
   callout: IStyle;
-  colorBox: IStyle;
   chartContainer: IStyle;
   chartEditorButton: IStyle;
   chartWithAxes: IStyle;
@@ -20,6 +19,8 @@ export interface IDatasetExplorerTabStyles {
   cohortDropdown: IStyle;
   cohortPickerWrapper: IStyle;
   cohortPickerLabel: IStyle;
+  colorBox: IStyle;
+  colorValue: IStyle;
   verticalAxis: IStyle;
   rotatedVerticalBox: IStyle;
   legendAndText: IStyle;
@@ -89,6 +90,9 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorer
         height: "12px",
         margin: "11px 4px 11px 8px",
         width: "12px"
+      },
+      colorValue: {
+        padding: "12px 0px"
       },
       helperText: {
         paddingLeft: "15px",

--- a/libs/dataset-explorer/src/lib/SidePanel.tsx
+++ b/libs/dataset-explorer/src/lib/SidePanel.tsx
@@ -51,9 +51,18 @@ export class SidePanel extends React.Component<ISidePanelProps> {
     const colorSeries = this.buildColorLegend();
     return (
       <Stack>
+        <ChoiceGroup
+          id="ChartTypeSelection"
+          label={localization.Interpret.DatasetExplorer.chartType}
+          selectedKey={this.props.chartProps.chartType}
+          options={this.chartOptions}
+          onChange={this.props.onChartTypeChange}
+        />
         {this.props.chartProps.chartType === ChartTypes.Scatter && (
           <Stack.Item>
-            <Label>{localization.Interpret.DatasetExplorer.colorValue}</Label>
+            <Label className={classNames.colorValue}>
+              {localization.Interpret.DatasetExplorer.colorValue}
+            </Label>
             <DefaultButton
               id="SetColorButton"
               onClick={this.props.setColorOpen}
@@ -85,14 +94,6 @@ export class SidePanel extends React.Component<ISidePanelProps> {
             </div>
           </Stack.Item>
         )}
-
-        <ChoiceGroup
-          id="ChartTypeSelection"
-          label={localization.Interpret.DatasetExplorer.chartType}
-          selectedKey={this.props.chartProps.chartType}
-          options={this.chartOptions}
-          onChange={this.props.onChartTypeChange}
-        />
       </Stack>
     );
   }


### PR DESCRIPTION
This PR reorders controls in data explorer legend. Keep Chart type controls at the top instead of moving it below "Color value" legend once user switches to "Individual Datapoints". So that order of control won't change between aggregate and individual views.

## Description
Before:
![image](https://user-images.githubusercontent.com/91754176/173423751-2ff54c76-49ca-4481-914b-5642db7e4188.png)

After (the order of "Color value" and "Chart type" is changed):
![image](https://user-images.githubusercontent.com/91754176/173423701-56d3325e-7dbb-4d84-bafe-0b2bb4ad551c.png)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
