### PR TITLE
Upgrade highcharts from v9.3.0 to v10.1.0, remove highcharts bundle by setting it to external module

### DIFF
--- a/libs/core-ui/src/lib/Highchart/getDefaultHighchartOptions.ts
+++ b/libs/core-ui/src/lib/Highchart/getDefaultHighchartOptions.ts
@@ -34,20 +34,6 @@ export function getDefaultHighchartOptions(theme: ITheme): Highcharts.Options {
       zoomType: "xy"
     },
     credits: undefined,
-    exporting: {
-      buttons: {
-        contextButton: {
-          menuItems: [
-            "viewFullscreen",
-            "printChart",
-            "separator",
-            "downloadPNG",
-            "downloadJPEG",
-            "downloadPDF"
-          ]
-        }
-      }
-    },
     legend: {
       enabled: false
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "d3-zoom": "^2.0.0",
     "document-register-element": "1.13.1",
     "eslint-plugin-sort-keys-fix": "^1.1.1",
-    "highcharts": "^9.3.0",
+    "highcharts": "^10.1.0",
     "jmespath": "^0.15.0",
     "json5": "^2.1.0",
     "localized-strings": "^0.2.4",

--- a/workspace.json
+++ b/workspace.json
@@ -36,6 +36,7 @@
             "entryFile": "libs/causality/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -104,6 +105,7 @@
             "entryFile": "libs/core-ui/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -172,6 +174,7 @@
             "entryFile": "libs/counterfactuals/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -367,6 +370,7 @@
             "entryFile": "libs/dataset-explorer/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -487,6 +491,7 @@
             "entryFile": "libs/error-analysis/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -555,6 +560,7 @@
             "entryFile": "libs/fairness/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -623,6 +629,7 @@
             "entryFile": "libs/interpret/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -727,6 +734,7 @@
             "entryFile": "libs/localization/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -795,6 +803,7 @@
             "entryFile": "libs/mlchartlib/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",
@@ -863,6 +872,7 @@
             "entryFile": "libs/model-assessment/src/index.ts",
             "external": [
               "@fluentui/react",
+              "highcharts",
               "jmespath",
               "localized-strings",
               "lodash",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10230,10 +10230,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^9.3.0:
-  version "9.3.3"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.3.3.tgz#ae62178de788fd7934431aa26b8e250b8073c541"
-  integrity sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg==
+highcharts@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.1.0.tgz#561872ae8ea819131d78949136d05bcaaa99108b"
+  integrity sha512-gW/pzy/Qy/hiYeCflYHpwgsP2nqQavwuRUswRf+papmbutZ3I7K7AIZJ/yZ9NL5yzpF7X7r2dX7/nzZGN4A1rg==
 
 history@^4.9.0:
   version "4.10.1"


### PR DESCRIPTION
This PR upgrades highcharts from v9.3.0 to v10.1.0, removes highcharts bundle by setting it to external module.

## Description
The reason we want to upgrade highcharts version is, there is a bug on v9.3.0 where exporting svg file is broken. This bug is fixed after v10.0.0. So here we upgrade highcharts to 10.1.0. 

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
