### PR TITLE
Model overview: use spline instead of line chart

### DIFF
--- a/libs/core-ui/src/lib/util/calculateLineData.ts
+++ b/libs/core-ui/src/lib/util/calculateLineData.ts
@@ -8,7 +8,7 @@ export interface IProbabilityBinCount {
   binCount: number;
 }
 
-export function calculateLinePlotDataFromErrorCohort(
+export function calculateSplinePlotDataFromErrorCohort(
   errorCohort: ErrorCohort,
   key: string
 ) {

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1415,7 +1415,7 @@
       "nA": "N/A",
       "disaggregatedAnalysisBaseCohortDislaimer": "The cohorts in the following feature-based analysis are based on the global cohort, {0}.",
       "disaggregatedAnalysisBaseCohortWarning": "Unlike the {0} cohort, {1} includes filters. As a consequence, it only captures a subset of the whole dataset and insights may not generalize to the full dataset.",
-      "probabilityLineChartToggleLabel": "Use line chart",
+      "probabilitySplineChartToggleLabel": "Use spline chart",
       "countAxisLabel": "Count",
       "helpMeChooseFeaturesButton": "Help me choose features",
       "helpMeChooseMetricsButton": "Help me choose metrics",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionChart.tsx
@@ -22,7 +22,7 @@ import React from "react";
 
 import { modelOverviewChartStyles } from "./ModelOverviewChart.styles";
 import { ProbabilityDistributionBoxChart } from "./ProbabilityDistributionBoxChart";
-import { ProbabilityDistributionLineChart } from "./ProbabilityDistributionLineChart";
+import { ProbabilityDistributionSplineChart } from "./ProbabilityDistributionSplineChart";
 
 interface IProbabilityDistributionChartProps {
   cohorts: ErrorCohort[];
@@ -34,7 +34,7 @@ interface IProbabilityDistributionChartState {
   probabilityOption?: IChoiceGroupOption;
   newlySelectedProbabilityOption?: IChoiceGroupOption;
   probabilityFlyoutIsVisible: boolean;
-  showLineChart: boolean;
+  showSplineChart: boolean;
 }
 
 export class ProbabilityDistributionChart extends React.Component<
@@ -47,7 +47,7 @@ export class ProbabilityDistributionChart extends React.Component<
 
   constructor(props: IProbabilityDistributionChartProps) {
     super(props);
-    this.state = { probabilityFlyoutIsVisible: false, showLineChart: false };
+    this.state = { probabilityFlyoutIsVisible: false, showSplineChart: false };
   }
 
   public componentDidMount(): void {
@@ -96,13 +96,13 @@ export class ProbabilityDistributionChart extends React.Component<
             <Toggle
               label={
                 localization.ModelAssessment.ModelOverview
-                  .probabilityLineChartToggleLabel
+                  .probabilitySplineChartToggleLabel
               }
               inlineLabel
-              onChange={this.onLineChartToggleChange}
+              onChange={this.onSplineChartToggleChange}
             />
           </Stack.Item>
-          {this.state.showLineChart && (
+          {this.state.showSplineChart && (
             <DefaultButton
               text={
                 localization.ModelAssessment.ModelOverview.cohortSelectionButton
@@ -112,7 +112,7 @@ export class ProbabilityDistributionChart extends React.Component<
           )}
         </Stack>
         <Stack horizontal>
-          {!noCohortSelected && !this.state.showLineChart && (
+          {!noCohortSelected && !this.state.showSplineChart && (
             <Stack.Item className={classNames.verticalAxis}>
               <DefaultButton
                 className={classNames.rotatedVerticalBox}
@@ -137,8 +137,8 @@ export class ProbabilityDistributionChart extends React.Component<
             )}
             {!noCohortSelected && (
               <Stack>
-                {this.state.showLineChart ? (
-                  <ProbabilityDistributionLineChart
+                {this.state.showSplineChart ? (
+                  <ProbabilityDistributionSplineChart
                     selectedCohorts={selectedCohorts}
                     probabilityOption={this.state.probabilityOption}
                   />
@@ -150,7 +150,7 @@ export class ProbabilityDistributionChart extends React.Component<
                 )}
                 <Stack.Item
                   className={
-                    this.state.showLineChart
+                    this.state.showSplineChart
                       ? classNames.horizontalAxisNoExtraLeftPadding
                       : classNames.horizontalAxis
                   }
@@ -241,12 +241,12 @@ export class ProbabilityDistributionChart extends React.Component<
       });
   }
 
-  private onLineChartToggleChange = (
+  private onSplineChartToggleChange = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     checked?: boolean | undefined
   ) => {
     if (checked !== undefined) {
-      this.setState({ showLineChart: checked });
+      this.setState({ showSplineChart: checked });
     }
   };
 }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionSplineChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionSplineChart.tsx
@@ -4,7 +4,7 @@
 import { getTheme, IChoiceGroupOption } from "@fluentui/react";
 import {
   BasicHighChart,
-  calculateLinePlotDataFromErrorCohort,
+  calculateSplinePlotDataFromErrorCohort,
   defaultModelAssessmentContext,
   ErrorCohort,
   ModelAssessmentContext
@@ -12,16 +12,16 @@ import {
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
-interface IProbabilityDistributionLineChartProps {
+interface IProbabilityDistributionSplineChartProps {
   selectedCohorts: ErrorCohort[];
   probabilityOption?: IChoiceGroupOption;
 }
 
-class IProbabilityDistributionLineChartState {}
+class IProbabilityDistributionSplineChartState {}
 
-export class ProbabilityDistributionLineChart extends React.Component<
-  IProbabilityDistributionLineChartProps,
-  IProbabilityDistributionLineChartState
+export class ProbabilityDistributionSplineChart extends React.Component<
+  IProbabilityDistributionSplineChartProps,
+  IProbabilityDistributionSplineChartState
 > {
   public static contextType = ModelAssessmentContext;
   public context: React.ContextType<typeof ModelAssessmentContext> =
@@ -30,8 +30,8 @@ export class ProbabilityDistributionLineChart extends React.Component<
   public render(): React.ReactNode {
     const theme = getTheme();
 
-    const linePlotData = this.props.selectedCohorts.map((cohort) => {
-      return calculateLinePlotDataFromErrorCohort(
+    const splinePlotData = this.props.selectedCohorts.map((cohort) => {
+      return calculateSplinePlotDataFromErrorCohort(
         cohort,
         this.props.probabilityOption!.key.toString()
       )!; // TODO: handle undefined case
@@ -39,11 +39,11 @@ export class ProbabilityDistributionLineChart extends React.Component<
 
     return (
       <BasicHighChart
-        id={"ProbabilityDistributionLineChart"}
+        id={"ProbabilityDistributionSplineChart"}
         theme={theme}
         configOverride={{
           chart: {
-            type: "line"
+            type: "spline"
           },
           legend: {
             align: "right",
@@ -58,16 +58,20 @@ export class ProbabilityDistributionLineChart extends React.Component<
               }
             }
           },
-          series: linePlotData.map((lineData, index) => {
+          series: splinePlotData.map((splineData, index) => {
             return {
-              data: lineData.map((probBinCount) => probBinCount.binCount),
+              data: splineData.map(
+                (probBinCount: { binCount: any }) => probBinCount.binCount
+              ),
               name: this.props.selectedCohorts[index].cohort.name,
-              type: "line"
+              type: "spline"
             };
           }),
           xAxis: {
-            categories: linePlotData.map((lineData) =>
-              lineData.map((probBinCount) => probBinCount.binName)
+            categories: splinePlotData.map((splineData) =>
+              splineData.map(
+                (probBinCount: { binName: any }) => probBinCount.binName
+              )
             )[0],
             title: { text: this.props.probabilityOption!.text }
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR replaces the line chart with a spline chart to make it more pleasant to look at. The only real change is that the chart option is changed from `"line"` to `"spline"`, the rest are renaming changes.

Old experience:

![image](https://user-images.githubusercontent.com/10245648/174624198-3e3a24cb-ef27-40a6-8380-47b48b90a360.png)


New experience:

![image](https://user-images.githubusercontent.com/10245648/174623968-2ed141e3-48b9-44fc-9919-7dad3c2e06cb.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
