### PR TITLE
Model overview: disable confirm button when no changes were made

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
@@ -194,7 +194,7 @@ export class FeatureConfigurationFlyout extends React.Component<
         this.state.newlySelectedFeatures.length &&
       this.props.selectedFeatures.every(
         (feature, featureIndex) =>
-          this.state.newlySelectedFeatures[featureIndex] == feature
+          this.state.newlySelectedFeatures[featureIndex] === feature
       ) &&
       // check that number of continuous feature bins for the selected features has not changed
       this.state.newlySelectedFeatures.every((_, featureIndex) => {

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
@@ -188,23 +188,24 @@ export class FeatureConfigurationFlyout extends React.Component<
 
   private onRenderFooterContent = () => {
     const tooManyFeaturesSelected = this._selection.getSelectedCount() > 2;
-    const noChangesInSelectedFeatures =
       // check that feature selection has not changed
-      this.props.selectedFeatures.length ===
-        this.state.newlySelectedFeatures.length &&
-      this.props.selectedFeatures.every(
+      const featureSelectionChanged =
+      this.props.selectedFeatures.length !==
+        this.state.newlySelectedFeatures.length ||
+      this.props.selectedFeatures.some(
         (feature, featureIndex) =>
-          this.state.newlySelectedFeatures[featureIndex] === feature
-      ) &&
+          this.state.newlySelectedFeatures[featureIndex] !== feature
+      );
       // check that number of continuous feature bins for the selected features has not changed
-      this.state.newlySelectedFeatures.every((_, featureIndex) => {
+      const continuousFeatureBinningChanged =
+      this.state.newlySelectedFeatures.some((_, featureIndex) => {
         const newNumberOfBins =
           this.state.newNumberOfContinuousFeatureBins[featureIndex] ??
           defaultNumberOfContinuousFeatureBins;
         const prevNumberOfBins =
           this.props.numberOfContinuousFeatureBins[featureIndex] ??
           defaultNumberOfContinuousFeatureBins;
-        return newNumberOfBins === prevNumberOfBins;
+        return newNumberOfBins !== prevNumberOfBins;
       });
     return (
       <Stack tokens={{ childrenGap: "10px" }}>
@@ -220,7 +221,7 @@ export class FeatureConfigurationFlyout extends React.Component<
           <PrimaryButton
             onClick={this.onConfirm}
             text={localization.ModelAssessment.ModelOverview.chartConfigConfirm}
-            disabled={tooManyFeaturesSelected || noChangesInSelectedFeatures}
+            disabled={tooManyFeaturesSelected || (!featureSelectionChanged && !continuousFeatureBinningChanged)}
           />
           <DefaultButton
             onClick={this.props.onDismissFlyout}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
@@ -188,16 +188,16 @@ export class FeatureConfigurationFlyout extends React.Component<
 
   private onRenderFooterContent = () => {
     const tooManyFeaturesSelected = this._selection.getSelectedCount() > 2;
-      // check that feature selection has not changed
-      const featureSelectionChanged =
+    // check that feature selection has not changed
+    const featureSelectionChanged =
       this.props.selectedFeatures.length !==
         this.state.newlySelectedFeatures.length ||
       this.props.selectedFeatures.some(
         (feature, featureIndex) =>
           this.state.newlySelectedFeatures[featureIndex] !== feature
       );
-      // check that number of continuous feature bins for the selected features has not changed
-      const continuousFeatureBinningChanged =
+    // check that number of continuous feature bins for the selected features has not changed
+    const continuousFeatureBinningChanged =
       this.state.newlySelectedFeatures.some((_, featureIndex) => {
         const newNumberOfBins =
           this.state.newNumberOfContinuousFeatureBins[featureIndex] ??
@@ -221,7 +221,10 @@ export class FeatureConfigurationFlyout extends React.Component<
           <PrimaryButton
             onClick={this.onConfirm}
             text={localization.ModelAssessment.ModelOverview.chartConfigConfirm}
-            disabled={tooManyFeaturesSelected || (!featureSelectionChanged && !continuousFeatureBinningChanged)}
+            disabled={
+              tooManyFeaturesSelected ||
+              (!featureSelectionChanged && !continuousFeatureBinningChanged)
+            }
           />
           <DefaultButton
             onClick={this.props.onDismissFlyout}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR disables the confirm button in the feature configuration flyout until actual changes were made to the previous selection:


https://user-images.githubusercontent.com/10245648/174701853-7c4acb89-25ba-4b76-9b1b-f214d04e72a9.mp4


Previously, the button wouldn't get disabled unless we select more than 2 features.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
