### PR TITLE
Model overview: turn on heatmap colors by default

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
@@ -47,7 +47,8 @@ export class DatasetCohortStatsTable extends React.Component<
       this.props.showHeatmapColors
     ).items;
 
-    const showColors = this.props.showHeatmapColors && this.context.errorCohorts.length > 1;
+    const showColors =
+      this.props.showHeatmapColors && this.context.errorCohorts.length > 1;
 
     return (
       <CohortStatsHeatmap

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
@@ -47,13 +47,15 @@ export class DatasetCohortStatsTable extends React.Component<
       this.props.showHeatmapColors
     ).items;
 
+    const showColors = this.props.showHeatmapColors && this.context.errorCohorts.length > 1;
+
     return (
       <CohortStatsHeatmap
         items={items}
         cohorts={this.context.errorCohorts}
         selectableMetrics={this.props.selectableMetrics}
         selectedMetrics={this.props.selectedMetrics}
-        showColors={this.props.showHeatmapColors}
+        showColors={showColors}
       />
     );
   }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -85,7 +85,7 @@ export class ModelOverview extends React.Component<
       selectedFeatures: [],
       selectedFeaturesContinuousFeatureBins: {},
       selectedMetrics: [],
-      showHeatmapColors: false
+      showHeatmapColors: true
     };
   }
 
@@ -323,6 +323,7 @@ export class ModelOverview extends React.Component<
             {(showHeatmapToggleInDatasetCohortView ||
               showHeatmapToggleInFeatureCohortView) && (
               <Toggle
+                checked={this.state.showHeatmapColors}
                 label={
                   localization.ModelAssessment.ModelOverview
                     .visualDisplayToggleLabel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Per popular request, this PR turns on the heatmap colors by default. This only shows up with the second cohort, of course, since there's no gradient with a single cohort:

![image](https://user-images.githubusercontent.com/10245648/174826145-3b45d8c0-7eb8-483c-bfc7-ebdb7bcc42ca.png)


![image](https://user-images.githubusercontent.com/10245648/174826194-c0df0f84-1177-4445-94d1-24b4962ad04c.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
