### PR TITLE
Model overview: use unique key to avoid heatmap color mismatch

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/CohortStatsHeatmap.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/CohortStatsHeatmap.tsx
@@ -55,8 +55,14 @@ export class CohortStatsHeatmap extends React.Component<
       ? {}
       : { color: theme.semanticColors.bodyText };
 
+    // Choose a unique key because the heatmap colors need to refresh when
+    // the underlying data changes.
+    const key = `$${this.props.cohorts.map((errorCohort) =>
+      errorCohort.cohort.name.charAt(0)
+    )}${this.props.selectedMetrics.map((metricName) => metricName.charAt(0))}`;
     return (
       <HeatmapHighChart
+        key={key}
         configOverride={{
           chart: {
             height: this.props.cohorts.length * 40 + 120,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There's (what I suspect to be) a bug in highcharts that makes certain colors (like the one we use for N/A cells) stay even when the underlying data of the heatmap changes. This was discovered by @tongyu-microsoft.

The solution is to make sure the `key` we pass is not reused so that we force highcharts to regenerate the entire heatmap. For that purpose, this PR uses a key consisting of the first letters of all cohorts and first letters of all selected metrics. If either of those dimensions of the heatmap change it should regenerate the heatmap. Theoretically, a collision of this primitive "hash function" is possible. It is rather unlikely, though, and seems to only matter if one of the cells has N/A content.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
