### PR TITLE
Update tree operator from symbols to strings

### DIFF
--- a/apps/dashboard/src/error-analysis/__mock_data__/dummyTreeAdultCensusIncome.ts
+++ b/apps/dashboard/src/error-analysis/__mock_data__/dummyTreeAdultCensusIncome.ts
@@ -26,7 +26,7 @@ export const dummyTreeAdultCensusIncomeData: IErrorAnalysisTreeNode[] = [
   {
     arg: [1],
     badFeaturesRowCount: 0,
-    condition: "marital-status !=  Married-civ-spouse",
+    condition: "marital-status not equal to Married-civ-spouse",
     error: 1,
     id: 1,
     isErrorMetric: true,
@@ -45,7 +45,7 @@ export const dummyTreeAdultCensusIncomeData: IErrorAnalysisTreeNode[] = [
   {
     arg: [1],
     badFeaturesRowCount: 0,
-    condition: "marital-status ==  Married-civ-spouse",
+    condition: "marital-status equal to  Married-civ-spouse",
     error: 17,
     id: 2,
     isErrorMetric: true,

--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -246,9 +246,9 @@ def build_bounds_query(filter, colname, method,
     """
     bounds = []
     if method == CohortFilterMethods.METHOD_EXCLUDES:
-        operator = " != "
+        operator = " not equal to "
     else:
-        operator = " == "
+        operator = " equal to "
     is_categorical = False
     if categorical_features:
         is_categorical = colname in categorical_features

--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -178,17 +178,20 @@ def build_query(filters, categorical_features, categories):
             arg0 = str(filter[ARG][0])
             colname = filter[COLUMN]
             if method == CohortFilterMethods.METHOD_GREATER:
-                queries.append("`" + colname + "` > " + arg0)
+                queries.append("`" + colname + "` greater than " + arg0)
             elif method == CohortFilterMethods.METHOD_LESS:
-                queries.append("`" + colname + "` < " + arg0)
+                queries.append("`" + colname + "` less than " + arg0)
             elif method == CohortFilterMethods.METHOD_LESS_AND_EQUAL:
-                queries.append("`" + colname + "` <= " + arg0)
+                queries.append("`" + colname + "` less than or equal to " +
+                               arg0)
             elif method == CohortFilterMethods.METHOD_GREATER_AND_EQUAL:
-                queries.append("`" + colname + "` >= " + arg0)
+                queries.append("`" + colname + "` greater than or equal to " +
+                               arg0)
             elif method == CohortFilterMethods.METHOD_RANGE:
                 arg1 = str(filter[ARG][1])
-                queries.append("`" + colname + "` >= " + arg0 +
-                               ' & `' + colname + "` <= " + arg1)
+                queries.append("`" + colname + "` greater than or equal to " +
+                               arg0 + ' & `' + colname +
+                               "` less than or equal to " + arg1)
             elif method == CohortFilterMethods.METHOD_INCLUDES or \
                     method == CohortFilterMethods.METHOD_EXCLUDES:
                 query = build_bounds_query(filter, colname, method,
@@ -204,11 +207,13 @@ def build_query(filters, categorical_features, categories):
                     arg0i = filter[ARG][0]
                     arg_cat = categories[cat_idx][arg0i]
                     if isinstance(arg_cat, str):
-                        queries.append("`{}` == '{}'".format(colname, arg_cat))
+                        queries.append("`{}` equal to '{}'".format(colname,
+                                       arg_cat))
                     else:
-                        queries.append("`{}` == {}".format(colname, arg_cat))
+                        queries.append("`{}` equal to {}".format(colname,
+                                       arg_cat))
                 else:
-                    queries.append("`" + colname + "` == " + arg0)
+                    queries.append("`" + colname + "` equal to " + arg0)
             else:
                 raise ValueError(
                     "Unsupported method type: {}".format(method))

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -697,8 +697,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
             if parent_decision_type == '<=':
                 method = "less and equal"
                 arg = float(parent_threshold)
-                condition = "{} <= {:.2f}".format(p_node_name,
-                                                  parent_threshold)
+                condition = "{} less than or equal to {:.2f}".format(
+                    p_node_name, parent_threshold)
                 df = df[df[p_node_name_val] <= parent_threshold]
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_INCLUDES
@@ -714,8 +714,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
             if parent_decision_type == '<=':
                 method = "greater"
                 arg = float(parent_threshold)
-                condition = "{} > {:.2f}".format(p_node_name,
-                                                 parent_threshold)
+                condition = "{} greater than {:.2f}".format(
+                    p_node_name, parent_threshold)
                 df = df[df[p_node_name_val] > parent_threshold]
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_EXCLUDES

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -618,9 +618,9 @@ def create_categorical_query(method, arg, p_node_name, p_node_query,
     :rtype: tuple(str, str)
     """
     if method == CohortFilterMethods.METHOD_INCLUDES:
-        operation = "=="
+        operation = "equal to"
     else:
-        operation = "!="
+        operation = "not equal to"
     categorical_values = categories[0]
     categorical_indexes = categories[1]
     thresholds = []


### PR DESCRIPTION
This PR updates tree operators from symbols to strings.

## Description
This is a follow up PR for https://github.com/microsoft/responsible-ai-toolbox/pull/1525 `Use of "==" and "!=" confusing to non-programmers, update operators to strings`.

Feedback from a customer meeting: When the dashboard was using '!=' they didn't appreciate that this meant "Not Equal" - similarly "==" didn't mean anything to them. We should probably use more widely understood operators.

Acceptance criteria:
Age == 41: Age equal to 41
Age != 41: Age not equal to 41
Age < 41: Age less than 41
Age > 41: Age greater than 41

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
