### PR TITLE
Fix e2e-widget.js for the case without flight argument

### DIFF
--- a/scripts/e2e-widget.js
+++ b/scripts/e2e-widget.js
@@ -243,7 +243,7 @@ async function main() {
   const skipgen = commander.opts().skipgen;
   const notebook = commander.opts().notebook;
   let flights = commander.opts().flights;
-  if (flights.toString() === "true") {
+  if (flights?.toString() === "true") {
     // -f passed without arguments
     flights = undefined;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Recently, e2e-widget.js was updated to allow for passing flights via `-f`. This works either with or without args for `-f` as it's used by the GitHub workflow. However, users can just as well call the script without `-f` at all. Currently, this leads to an error as we're calling `.toString()` on the argument which would be undefined. This change ensures that we don't do that while still mapping both cases of not specifying flights (either with `-f` and no extra args, or without `-f`) to `flights` as `undefined`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
