### PR TITLE
initial vision dashboard

### DIFF
--- a/apps/dashboard/src/app/applications.ts
+++ b/apps/dashboard/src/app/applications.ts
@@ -272,7 +272,16 @@ export const applications: IApplications = <const>{
         dataset: wineDataMAD,
         errorAnalysisData: [wineErrorAnalysisData],
         modelExplanationData: [wineWithFairnessModelExplanationData]
-      } as IModelAssessmentDataSet
+      } as IModelAssessmentDataSet,
+      visionData: {
+        causalAnalysisData: undefined,
+        classDimension: 2,
+        cohortData: undefined,
+        counterfactualData: undefined,
+        dataset: adultCensusWithFairnessDataset,
+        errorAnalysisData: undefined,
+        modelExplanationData: [adultCensusWithFairnessModelExplanationData]
+      } as IModelAssessmentDataSet,
     },
     versions: { "1": 1, "2:Static-View": 2 }
   }

--- a/apps/dashboard/src/model-assessment/App.tsx
+++ b/apps/dashboard/src/model-assessment/App.tsx
@@ -6,12 +6,12 @@ import { ICausalWhatIfData, Metrics } from "@responsible-ai/core-ui";
 import { HelpMessageDict } from "@responsible-ai/error-analysis";
 import { Language } from "@responsible-ai/localization";
 import {
-  ModelAssessmentDashboard,
   IModelAssessmentDashboardProps,
   IModelAssessmentData
 } from "@responsible-ai/model-assessment";
 import React from "react";
 
+import { VisionModelAssessmentDashboard } from "../../../../libs/model-assessment/src/lib/ModelAssessmentDashboard/VisionModelAssessmentDashboard"
 import {
   generateJsonMatrix,
   createJsonImportancesGenerator,
@@ -125,7 +125,9 @@ export class App extends React.Component<IAppProps> {
       };
     }
 
-    return <ModelAssessmentDashboard {...modelAssessmentDashboardProps} />;
+    //return <ModelAssessmentDashboard {...modelAssessmentDashboardProps} />;
+    return <VisionModelAssessmentDashboard {...modelAssessmentDashboardProps} />;
+
   }
 
   private readonly requestCausalWhatIf = async (

--- a/libs/dataset-explorer/src/index.ts
+++ b/libs/dataset-explorer/src/index.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export * from "./lib/DatasetExplorerTab";
+export * from "./lib/VisionDatasetExplorerTab";

--- a/libs/dataset-explorer/src/lib/DataCharacteristics.styles.ts
+++ b/libs/dataset-explorer/src/lib/DataCharacteristics.styles.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  //getTheme,
+  FontSizes
+} from "@fluentui/react";
+//import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
+
+export interface IDataCharacteristicsStyles {
+  list: IStyle;
+  tile: IStyle;
+  label: IStyle;
+  image: IStyle;
+}
+
+export const dataCharacteristicsStyles: () => IProcessedStyleSet<IDataCharacteristicsStyles> =
+  () => {
+    //const theme = getTheme();
+    return mergeStyleSets<IDataCharacteristicsStyles>({
+      image: {
+        left: 0,
+        position: "absolute",
+        top: 0,
+        width: "100%"
+      },
+      label: {
+        color: "black",
+        fontSize: FontSizes.small,
+        justifySelf: "center",
+        paddingBottom: "100%",
+        width: "100%"
+      },
+      list: {
+        fontSize: 0,
+        position: "relative"
+      },
+      tile: {
+        float: "left",
+        marginTop: "0.5%",
+        paddingLeft: "1%",
+        paddingRight: "1%",
+        position: "relative",
+        textAlign: "center"
+      }
+    });
+  };

--- a/libs/dataset-explorer/src/lib/DataCharacteristics.tsx
+++ b/libs/dataset-explorer/src/lib/DataCharacteristics.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  Text,
+  FocusZone,
+  List,
+  Image,
+  ImageFit,
+  IRectangle
+} from "@fluentui/react";
+import React from "react";
+
+import { dataCharacteristicsStyles } from "./DataCharacteristics.styles";
+
+export interface IDataCharacteristicsProps {
+  imageDim: number;
+  openPanel(): void | undefined;
+}
+
+export interface IDataCharacteristicsState {
+  columnCount: number;
+}
+
+export interface IListItem {
+  title: string;
+  image: string;
+}
+
+const RowsPerPage = 3;
+
+export class DataCharacteristics extends React.Component<
+  IDataCharacteristicsProps,
+  IDataCharacteristicsState
+> {
+  public constructor(props: IDataCharacteristicsProps) {
+    super(props);
+
+    this.state = {
+      columnCount: 1
+    };
+  }
+
+  public render(): React.ReactNode {
+    const classNames = dataCharacteristicsStyles();
+
+    const items: IListItem[] = [];
+
+    for (let i = 0; i < 20; i++) {
+      items.push({
+        image:
+          "https://1.bp.blogspot.com/-uhSQ0kz07ZI/UjCVa4_ru9I/AAAAAAAAYZI/g7RsfGH81LA/s1600/Duckling+Wallpapers+%25286%2529.jpg",
+        title: `label ${(i + 1).toString()}`
+      });
+    }
+
+    return (
+      <FocusZone>
+        <List
+          items={items}
+          onRenderCell={this.onRenderCell}
+          className={classNames.list}
+          getPageHeight={this.getPageHeight}
+          getItemCountForPage={this.getItemCountForPage}
+        />
+      </FocusZone>
+    );
+  }
+
+  private onRenderCell = (item?: IListItem | undefined) => {
+    const classNames = dataCharacteristicsStyles();
+    return (
+      <div
+        data-is-focusable
+        className={classNames.tile}
+        onClick={this.props.openPanel}
+        onKeyPress={this.props.openPanel}
+        role="button"
+        tabIndex={0}
+      >
+        <Text className={classNames.label}>{item?.title}</Text>
+        <Image
+          alt={item?.title}
+          width={this.props.imageDim}
+          height={this.props.imageDim}
+          imageFit={ImageFit.contain}
+          src={item?.image}
+        />
+      </div>
+    );
+  };
+
+  private getPageHeight = () => {
+    return this.props.imageDim * RowsPerPage;
+  };
+
+  private getItemCountForPage = (
+    itemIndex?: number | undefined,
+    surfaceRect?: IRectangle | undefined
+  ) => {
+    if (!surfaceRect || !itemIndex) {
+      return 0;
+    }
+
+    if (itemIndex === 0) {
+      this.setState({
+        columnCount: Math.ceil(surfaceRect.width / this.props.imageDim)
+      });
+    }
+
+    return this.state.columnCount * RowsPerPage;
+  };
+}

--- a/libs/dataset-explorer/src/lib/Flyout.styles.ts
+++ b/libs/dataset-explorer/src/lib/Flyout.styles.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme,
+  FontSizes
+} from "@fluentui/react";
+//import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
+
+export interface IDatasetExplorerTabStyles {
+  list: IStyle;
+  tile: IStyle;
+  sizer: IStyle;
+  padder: IStyle;
+  label: IStyle;
+  image: IStyle;
+}
+
+export const flyoutStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<IDatasetExplorerTabStyles>({
+      list: {
+        overflow: 'scroll', 
+        fontSize: 0, 
+        position: 'relative',
+      },
+      tile: {
+        textAlign: 'center',
+        position: 'relative',
+        float: 'left',
+        paddingLeft: '1%',
+        paddingRight: '1%',
+        marginTop: '0.5%',
+        selectors: {
+          'focus:after': {
+            content: '',
+            position: 'absolute',
+            left: 2,
+            right: 2,
+            top: 2,
+            bottom: 2,
+            boxSizing: 'border-box',
+            border: `1px solid ${theme.palette.themePrimary}`
+          }
+        }
+      },
+      sizer: {
+        paddingBottom: '100%'
+      },
+      padder: {
+        position: 'absolute',
+        left: 2,
+        top: 2,
+        right: 2,
+        bottom: 2
+      },
+      label: {
+        justifySelf: 'center',
+        paddingBottom: "100%",
+        color: "black",
+        width: "100%",
+        fontSize: FontSizes.small,
+      },
+      image: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+      }
+    });
+  };

--- a/libs/dataset-explorer/src/lib/Flyout.tsx
+++ b/libs/dataset-explorer/src/lib/Flyout.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Text, Panel, FocusZone, Stack } from "@fluentui/react";
+import React from "react";
+
+import { flyoutStyles } from "./Flyout.styles";
+import { IListItem } from "./ImageList";
+
+export interface IFlyoutProps {
+  isOpen: boolean;
+  item: IListItem | undefined;
+  callback(): void | undefined;
+}
+
+export class IFlyoutState {}
+
+export class Flyout extends React.Component<IFlyoutProps, IFlyoutState> {
+  public constructor(props: IFlyoutProps) {
+    super(props);
+    this.state = {};
+  }
+
+  public render(): React.ReactNode {
+    const classNames = flyoutStyles();
+
+    return (
+      <FocusZone>
+        <Panel
+          headerText="Selected instance"
+          isOpen={this.props.isOpen}
+          closeButtonAriaLabel="Close"
+          onDismiss={this.props.callback}
+        >
+          <Stack tokens={{ childrenGap: "l1" }}>
+            <Stack.Item>
+              <div className={classNames.line} />
+            </Stack.Item>
+            <Stack.Item>
+              <Text>hi</Text>
+            </Stack.Item>
+          </Stack>
+        </Panel>
+      </FocusZone>
+    );
+  }
+}

--- a/libs/dataset-explorer/src/lib/ImageList.styles.ts
+++ b/libs/dataset-explorer/src/lib/ImageList.styles.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  //getTheme,
+  FontSizes
+} from "@fluentui/react";
+//import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
+
+export interface IDatasetExplorerTabStyles {
+  list: IStyle;
+  tile: IStyle;
+  label: IStyle;
+  image: IStyle;
+}
+
+export const imageListStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
+  () => {
+    //const theme = getTheme();
+    return mergeStyleSets<IDatasetExplorerTabStyles>({
+      image: {
+        left: 0,
+        position: "absolute",
+        top: 0,
+        width: "100%",
+      },
+      label: {
+        color: "black",
+        fontSize: FontSizes.small,
+        justifySelf: 'center',
+        paddingBottom: "100%",
+        width: "100%",
+      },
+      list: {
+        fontSize: 0, 
+        position: 'relative',
+      },
+      tile: {
+        float: 'left',
+        marginTop: '0.5%',
+        paddingLeft: '1%',
+        paddingRight: '1%',
+        position: 'relative',
+        textAlign: 'center',
+      }
+    });
+  };

--- a/libs/dataset-explorer/src/lib/ImageList.tsx
+++ b/libs/dataset-explorer/src/lib/ImageList.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  Text,
+  FocusZone,
+  List,
+  Image,
+  ImageFit,
+  IRectangle,
+} from "@fluentui/react";
+import React from "react";
+
+import { imageListStyles } from "./ImageList.styles";
+
+export interface IImageListProps {
+  imageDim: number;
+  openPanel(): void | undefined;
+}
+
+export interface IImageListState {
+  columnCount: number;
+}
+
+export interface IListItem {
+  title: string;
+  image: string;
+}
+
+const RowsPerPage = 3;
+
+
+export class ImageList extends React.Component< IImageListProps, IImageListState > {  
+ 
+  public constructor(props: IImageListProps) {
+    super(props);
+    
+    this.state = {
+      columnCount: 1,
+    }
+  }
+
+
+  public render(): React.ReactNode {
+    const classNames = imageListStyles();
+
+    const items: IListItem[] = []
+
+    for (let i = 0; i < 20; i++) {
+      items.push({ image: 'https://1.bp.blogspot.com/-uhSQ0kz07ZI/UjCVa4_ru9I/AAAAAAAAYZI/g7RsfGH81LA/s1600/Duckling+Wallpapers+%25286%2529.jpg', title: `label ${(i + 1).toString()}`})
+    }
+
+    return (
+      <FocusZone>
+        <List 
+          items={items} 
+          onRenderCell={this.onRenderCell}
+          className={classNames.list}
+          getPageHeight={this.getPageHeight}
+          getItemCountForPage={this.getItemCountForPage}
+        />
+      </FocusZone>
+
+    );
+  }
+
+  private onRenderCell = (item?: IListItem | undefined ) => {
+
+    const classNames = imageListStyles();
+    return (
+      <div data-is-focusable className={classNames.tile} onClick={this.props.openPanel} onKeyPress={this.props.openPanel} role="button" tabIndex={0}>
+          <Text className={classNames.label}>{item?.title}</Text>
+          <Image alt={item?.title} width={this.props.imageDim} height={this.props.imageDim} imageFit={ImageFit.contain} src={item?.image} />
+      </div>
+    )
+  }
+
+  private getPageHeight = () => {
+    return this.props.imageDim * RowsPerPage;
+  }
+
+  private getItemCountForPage = (itemIndex?: number | undefined, surfaceRect?: IRectangle | undefined) => {
+    if (!surfaceRect || !itemIndex) {
+      return 0
+    }
+
+    if (itemIndex === 0) {
+      this.setState({ columnCount: Math.ceil(surfaceRect.width / this.props.imageDim )})
+    }
+
+    return this.state.columnCount * RowsPerPage
+  }
+}

--- a/libs/dataset-explorer/src/lib/TableList.styles.ts
+++ b/libs/dataset-explorer/src/lib/TableList.styles.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme,
+  FontSizes
+} from "@fluentui/react";
+//import { descriptionMaxWidth, FabricStyles } from "@responsible-ai/core-ui";
+
+export interface IDatasetExplorerTabStyles {
+  list: IStyle;
+  tile: IStyle;
+  sizer: IStyle;
+  padder: IStyle;
+  label: IStyle;
+  image: IStyle;
+}
+
+export const tableListStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<IDatasetExplorerTabStyles>({
+      list: {
+        overflow: 'scroll', 
+        fontSize: 0, 
+        position: 'relative',
+      },
+      tile: {
+        textAlign: 'center',
+        position: 'relative',
+        float: 'left',
+        paddingLeft: '1%',
+        paddingRight: '1%',
+        marginTop: '0.5%',
+        selectors: {
+          'focus:after': {
+            content: '',
+            position: 'absolute',
+            left: 2,
+            right: 2,
+            top: 2,
+            bottom: 2,
+            boxSizing: 'border-box',
+            border: `1px solid ${theme.palette.themePrimary}`
+          }
+        }
+      },
+      sizer: {
+        paddingBottom: '100%'
+      },
+      padder: {
+        position: 'absolute',
+        left: 2,
+        top: 2,
+        right: 2,
+        bottom: 2
+      },
+      label: {
+        justifySelf: 'center',
+        paddingBottom: "100%",
+        color: "black",
+        width: "100%",
+        fontSize: FontSizes.small,
+      },
+      image: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+      }
+    });
+  };

--- a/libs/dataset-explorer/src/lib/TableList.tsx
+++ b/libs/dataset-explorer/src/lib/TableList.tsx
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  FocusZone,
+  DetailsList,
+  DetailsHeader,
+  IDetailsHeaderProps,
+  IRenderFunction,
+  IGroup,
+  IColumn,
+  Image,
+  Text,
+  Stack,
+} from "@fluentui/react";
+import { localization } from "@responsible-ai/localization";
+import React from "react";
+
+
+export interface ITableListProps {
+  imageDim: number;
+  pageSize: number;
+  openPanel(): void | undefined;
+}
+
+export interface ITableListState {
+  items: IListItem[],
+  groups: IGroup[],
+  columns: IColumn[],
+}
+
+export interface IListItem {
+  title: string;
+  subtitle: string;
+  image: string;
+  trueY: number;
+  predictedY: number;
+  index: number;
+  other: number;
+}
+
+export class TableList extends React.Component< ITableListProps, ITableListState > {  
+ 
+  public constructor(props: ITableListProps) {
+    super(props);
+    
+    this.state = {
+      columns: [],
+      groups: [],
+      items: [],
+    }
+  }
+
+  public componentDidMount(): void {
+    const items: IListItem[] = []
+
+    for (let i = 0; i < 50; i++) {
+      items.push({  
+                   image: 'https://1.bp.blogspot.com/-uhSQ0kz07ZI/UjCVa4_ru9I/AAAAAAAAYZI/g7RsfGH81LA/s1600/Duckling+Wallpapers+%25286%2529.jpg',
+                   index: i + 1,
+                   other: 0,
+                   predictedY: 1,
+                   subtitle: 'subtitle',
+                   title: `label ${  (i + 1).toString()}`,
+                   trueY: 0,
+                 })
+    }
+
+    const groups: IGroup[] = [
+      {count: this.props.pageSize, key: 'success', level: 0, name: localization.Interpret.VisionDatasetExplorer.titleBarSuccess, startIndex: 0},
+      {count: this.props.pageSize, key: 'error', level: 0, name: localization.Interpret.VisionDatasetExplorer.titleBarError, startIndex: this.props.pageSize}
+    ]
+
+    const columns: IColumn[] = [
+      {fieldName: "title", isResizable: true, key: "title", maxWidth: 400, minWidth: 200, name: localization.Interpret.VisionDatasetExplorer.columnOne},
+      {fieldName: "index", isResizable: true, key: "index", maxWidth: 400, minWidth: 200, name: localization.Interpret.VisionDatasetExplorer.columnTwo},
+      {fieldName: "trueY", isResizable: true, key: "truey", maxWidth: 400, minWidth: 200, name: localization.Interpret.VisionDatasetExplorer.columnThree},
+      {fieldName: "predictedY", isResizable: true, key: "predictedy", maxWidth: 400, minWidth: 200, name: localization.Interpret.VisionDatasetExplorer.columnFour},
+      {fieldName: "other", isResizable: true, key: "other", maxWidth: 400, minWidth: 200, name: localization.Interpret.VisionDatasetExplorer.columnFive},
+    ]
+    
+
+    this.setState({ columns, groups, items })
+
+  }
+
+  public render(): React.ReactNode {
+    //const classNames = tableListStyles();
+
+    return (
+      <FocusZone style={{width: '100%'}}>
+        <DetailsList 
+          items={this.state.items}
+          groups={this.state.groups}
+          columns={this.state.columns}
+          groupProps={{showEmptyGroups: true}}
+          onRenderDetailsHeader={this.onRenderDetailsHeader}
+          onRenderItemColumn={this.onRenderColumn}
+        />
+      </FocusZone>
+
+    );
+  }
+
+  private onRenderDetailsHeader = (props: IDetailsHeaderProps | undefined, _defaultRender?: IRenderFunction<IDetailsHeaderProps> | undefined) => {
+    if (!props) {
+      return <div />
+    }
+    return <DetailsHeader {...props} ariaLabelForToggleAllGroupsButton={'Expand collapse groups'} />;
+  }
+
+
+  private onRenderColumn = (item: IListItem | undefined, index: number | undefined, column?: IColumn | undefined) => {
+
+    const value = item && column && column.fieldName ? item[column.fieldName as keyof IListItem] : '';
+
+    const image = item && column && column.fieldName === "title" ? item["image" as keyof IListItem] : '';
+
+    if (typeof (image) === "number") {
+      return <div />;
+    }
+
+    if (index) {
+      index = index + 1;
+    }
+
+    const subtitle = item && column && column.fieldName === "title" ? item["subtitle" as keyof IListItem] : '';
+
+    return <div data-is-focusable>
+      <Stack horizontal tokens={{ childrenGap: "s1" }}>
+        {image && <Stack.Item>
+          <Image src={image} style={{ borderRadius: 4, height: 'auto', width: this.props.imageDim }} />
+        </Stack.Item>}
+        <Stack.Item>
+          <Stack>
+            <Stack.Item><Text>{value}</Text></Stack.Item>
+            {subtitle && <Stack.Item><Text>{subtitle}</Text></Stack.Item>}
+          </Stack>
+        </Stack.Item>
+      </Stack>
+    </div>;
+  };
+
+}

--- a/libs/dataset-explorer/src/lib/TitleBar.styles.ts
+++ b/libs/dataset-explorer/src/lib/TitleBar.styles.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+} from "@fluentui/react";
+
+export interface IDatasetExplorerTabStyles {
+  errorIcon: IStyle;
+  iconContainer: IStyle;
+  successIcon: IStyle;
+  titleBarLabel: IStyle;
+  titleBarNumber: IStyle;
+}
+
+export const titleBarStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
+  () => {
+    return mergeStyleSets<IDatasetExplorerTabStyles>({
+      errorIcon: {
+        color: "#C50F1F",
+        fontSize: "large",
+        fontWeight: "600",
+      },
+      iconContainer: {
+        position: "relative",
+        top: "2px"
+      },
+      successIcon: {
+        color: "#6BB700",
+        fontSize: "large",
+        fontWeight: "600",
+      },
+      titleBarLabel: {
+        fontWeight: "600",
+      },
+      titleBarNumber: {
+        color: "#0078D4"
+      },
+    });
+  };

--- a/libs/dataset-explorer/src/lib/TitleBar.tsx
+++ b/libs/dataset-explorer/src/lib/TitleBar.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Stack, Text, Icon } from "@fluentui/react";
+import { localization } from "@responsible-ai/localization";
+import React from "react";
+
+import { titleBarStyles } from "./TitleBar.styles";
+export interface ITitleBarProps {
+  type: TitleBarOptions;
+}
+
+export class ITitleBarState {}
+
+enum TitleBarOptions {
+  Error,
+  Success
+}
+
+export class TitleBar extends React.Component<ITitleBarProps, ITitleBarState> {
+  public constructor(props: ITitleBarProps) {
+    super(props);
+    this.state = {};
+  }
+
+  public render(): React.ReactNode {
+    const classNames = titleBarStyles();
+
+    return (
+      <Stack
+        horizontal
+        tokens={{ childrenGap: "s1" }}
+        horizontalAlign="center"
+        verticalAlign="end"
+      >
+        <Stack.Item className={classNames.iconContainer}>
+          <Icon
+            iconName={
+              this.props.type === TitleBarOptions.Error ? "Cancel" : "Checkmark"
+            }
+            className={
+              this.props.type === TitleBarOptions.Error
+                ? classNames.errorIcon
+                : classNames.successIcon
+            }
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <Text variant="large" className={classNames.titleBarLabel}>
+            {this.props.type === TitleBarOptions.Error
+              ? localization.Interpret.VisionDatasetExplorer.titleBarError
+              : localization.Interpret.VisionDatasetExplorer.titleBarSuccess}
+          </Text>
+        </Stack.Item>
+        <Stack.Item>
+          <Text variant="large" className={classNames.titleBarNumber}>
+            {this.props.type === TitleBarOptions.Error ? "6170" : "3825"}
+          </Text>
+        </Stack.Item>
+      </Stack>
+    );
+  }
+}

--- a/libs/dataset-explorer/src/lib/VisionDatasetExplorerTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/VisionDatasetExplorerTab.styles.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme
+} from "@fluentui/react";
+export interface IDatasetExplorerTabStyles {
+  cohortDropdown: IStyle;
+  cohortPickerLabel: IStyle;
+  cohortPickerLabelWrapper: IStyle;
+  line: IStyle;
+  page: IStyle;
+  searchBox: IStyle;
+  filterButton: IStyle;
+  toolBarContainer: IStyle;
+  mainContainer: IStyle;
+  halfContainer: IStyle;
+  imageListContainer: IStyle;
+  slider: IStyle;
+  tabs: IStyle;
+}
+
+export const visionDatasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<IDatasetExplorerTabStyles>({
+      cohortDropdown: {
+        width: "300px"
+      },
+      cohortPickerLabel: {
+        fontWeight: "600",
+      },
+      cohortPickerLabelWrapper: {
+        paddingBottom: "5px",
+      },
+      filterButton: {
+        height: "32px"
+      },
+      halfContainer: {
+        height: "100%",
+        width: "50%"
+      },
+      imageListContainer: {
+        border: "1px solid #D2D4D6",
+        height: "100%",
+        overflow: "scroll"
+      },
+      line: {
+        borderTop: "1px solid #EDEBE9"
+      },
+      mainContainer: {
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        width: '100%'
+      },
+      page: {
+        color: theme.semanticColors.bodyText,
+        height: "100%",
+        padding: "0 40px 10px 40px",
+        width: "100%"
+      },
+      searchBox: {
+        width: '300px'
+      },
+      slider: {
+        width: '320px',
+      },
+      tabs: {
+        display: "flex",
+        flexDirection: "row",
+        left: "-10px",
+        position: "relative"
+      },
+      toolBarContainer: {
+        width: '100%',
+      },
+    });
+  };

--- a/libs/dataset-explorer/src/lib/VisionDatasetExplorerTab.tsx
+++ b/libs/dataset-explorer/src/lib/VisionDatasetExplorerTab.tsx
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IDropdownOption,
+  Dropdown,
+  Text,
+  Stack,
+  Pivot,
+  PivotItem,
+  SearchBox,
+  Slider,
+  CommandBarButton
+} from "@fluentui/react";
+import { localization } from "@responsible-ai/localization";
+import React from "react";
+
+import { DataCharacteristics } from "./DataCharacteristics";
+import { Flyout } from "./Flyout";
+import { ImageList } from "./ImageList";
+import { TableList } from "./TableList";
+import { TitleBar } from "./TitleBar";
+import { visionDatasetExplorerTabStyles } from "./VisionDatasetExplorerTab.styles";
+
+export class IVisionDatasetExplorerTabProps {}
+
+export interface IVisionDatasetExplorerTabState {
+  imageDim: number;
+  pageSize: number;
+  panelOpen: boolean;
+  selectedKey: string;
+}
+
+enum VisionDatasetExplorerTabOptions {
+  First = "Image explorer view",
+  Second = "Table view",
+  Third = "Data characteristics"
+}
+
+export enum TitleBarOptions {
+  Error,
+  Success
+}
+
+const PageSizeOptions: IDropdownOption[] = [
+  { key: "s", text: "10" },
+  { key: "m", text: "25" },
+  { key: "l", text: "50" },
+  { key: "xl", text: "100" }
+];
+const EnableHelperText = false;
+export class VisionDatasetExplorerTab extends React.Component<
+  IVisionDatasetExplorerTabProps,
+  IVisionDatasetExplorerTabState
+> {
+  public constructor(props: IVisionDatasetExplorerTabProps) {
+    super(props);
+
+    this.state = {
+      imageDim: 200,
+      pageSize: 10,
+      panelOpen: false,
+      selectedKey: VisionDatasetExplorerTabOptions.First
+    };
+  }
+
+  public render(): React.ReactNode {
+    const classNames = visionDatasetExplorerTabStyles();
+    const DropdownOptions: Array<IDropdownOption<any>> = [
+      { key: 0, text: "All Data" }
+    ];
+
+    return (
+      <Stack
+        horizontal={false}
+        grow
+        tokens={{ childrenGap: "l1" }}
+        className={classNames.page}
+      >
+        <Stack.Item>
+          <Stack horizontal horizontalAlign="space-between" verticalAlign="end">
+            <Stack.Item>
+              <Pivot
+                selectedKey={this.state.selectedKey}
+                onLinkClick={this.handleLinkClick}
+                linkSize={"normal"}
+                headersOnly
+                className={classNames.tabs}
+              >
+                <PivotItem
+                  headerText={
+                    localization.Interpret.VisionDatasetExplorer.tabOptionFirst
+                  }
+                  itemKey={VisionDatasetExplorerTabOptions.First}
+                />
+                <PivotItem
+                  headerText={
+                    localization.Interpret.VisionDatasetExplorer.tabOptionSecond
+                  }
+                  itemKey={VisionDatasetExplorerTabOptions.Second}
+                />
+                <PivotItem
+                  headerText={
+                    localization.Interpret.VisionDatasetExplorer.tabOptionThird
+                  }
+                  itemKey={VisionDatasetExplorerTabOptions.Third}
+                />
+              </Pivot>
+            </Stack.Item>
+            <Stack.Item>
+              <CommandBarButton
+                className={classNames.filterButton}
+                iconProps={{ iconName: "Settings" }}
+                text={localization.Interpret.VisionDatasetExplorer.settings}
+              />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <div className={classNames.line} />
+        </Stack.Item>
+        {EnableHelperText && (
+          <Stack.Item>
+            <Text variant="medium">
+              {localization.Interpret.VisionDatasetExplorer.helperText}
+            </Text>
+          </Stack.Item>
+        )}
+        <Stack.Item>
+          <Stack>
+            <Stack.Item className={classNames.cohortPickerLabelWrapper}>
+              <Text
+                variant="mediumPlus"
+                className={classNames.cohortPickerLabel}
+              >
+                {localization.Interpret.ModelPerformance.cohortPickerLabel}
+              </Text>
+            </Stack.Item>
+            <Stack.Item>
+              <Stack
+                horizontal
+                className={classNames.toolBarContainer}
+                tokens={{ childrenGap: "l1" }}
+                verticalAlign="center"
+              >
+                <Stack.Item>
+                  <Dropdown
+                    className={classNames.cohortDropdown}
+                    id="dataExplorerCohortDropdown"
+                    options={DropdownOptions}
+                    selectedKey={0}
+                  />
+                </Stack.Item>
+                <Stack.Item>
+                  <SearchBox
+                    className={classNames.searchBox}
+                    placeholder="Search"
+                  />
+                </Stack.Item>
+                <Stack.Item>
+                  <CommandBarButton
+                    className={classNames.filterButton}
+                    iconProps={{ iconName: "Filter" }}
+                    text={localization.Interpret.VisionDatasetExplorer.filter}
+                  />
+                </Stack.Item>
+              </Stack>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <Stack
+            horizontal
+            horizontalAlign="space-between"
+            verticalAlign="start"
+          >
+            <Stack.Item>
+              <Slider
+                max={80}
+                min={20}
+                className={classNames.slider}
+                label={
+                  localization.Interpret.VisionDatasetExplorer.thumbnailSize
+                }
+                defaultValue={40}
+                showValue={false}
+                onChange={this.onSliderChange}
+              />
+            </Stack.Item>
+            {this.state.selectedKey ===
+              VisionDatasetExplorerTabOptions.Second && (
+              <Stack.Item>
+                <Stack
+                  horizontal
+                  tokens={{ childrenGap: "s1" }}
+                  verticalAlign="center"
+                >
+                  <Stack.Item>
+                    <Text>
+                      {localization.Interpret.VisionDatasetExplorer.pageSize}
+                    </Text>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Dropdown
+                      defaultSelectedKey="s"
+                      options={PageSizeOptions}
+                      onChange={this.onPageSizeSelect}
+                    />
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+            )}
+          </Stack>
+        </Stack.Item>
+        {this.state.selectedKey === VisionDatasetExplorerTabOptions.First && (
+          <Stack horizontal={false} grow tokens={{ childrenGap: "l1" }}>
+            <Stack
+              horizontal
+              tokens={{ childrenGap: "l1" }}
+              style={{
+                height:
+                  this.state.imageDim * 3 + Math.floor(this.state.imageDim / 2)
+              }}
+            >
+              <Stack
+                className={classNames.halfContainer}
+                tokens={{ childrenGap: "l1" }}
+              >
+                <Stack.Item>
+                  <TitleBar type={TitleBarOptions.Error} />
+                </Stack.Item>
+                <Stack.Item className={classNames.imageListContainer}>
+                  <ImageList
+                    imageDim={this.state.imageDim}
+                    openPanel={this.onButtonClick}
+                  />
+                </Stack.Item>
+              </Stack>
+              <Stack
+                className={classNames.halfContainer}
+                tokens={{ childrenGap: "l1" }}
+              >
+                <Stack.Item>
+                  <TitleBar type={TitleBarOptions.Success} />
+                </Stack.Item>
+                <Stack.Item className={classNames.imageListContainer}>
+                  <ImageList
+                    imageDim={this.state.imageDim}
+                    openPanel={this.onButtonClick}
+                  />
+                </Stack.Item>
+              </Stack>
+            </Stack>
+          </Stack>
+        )}
+        {this.state.selectedKey === VisionDatasetExplorerTabOptions.Second && (
+          <Stack className={classNames.mainContainer}>
+            <TableList
+              imageDim={this.state.imageDim}
+              openPanel={this.onButtonClick}
+              pageSize={this.state.pageSize}
+            />
+          </Stack>
+        )}
+        {this.state.selectedKey === VisionDatasetExplorerTabOptions.Third && (
+          <Stack
+            className={classNames.mainContainer}
+            tokens={{ childrenGap: "l1" }}
+          >
+            <Stack.Item>
+              <DataCharacteristics
+                imageDim={this.state.imageDim}
+                openPanel={this.onButtonClick}
+              />
+            </Stack.Item>
+          </Stack>
+        )}
+        <Stack.Item>
+          <Flyout
+            isOpen={this.state.panelOpen}
+            item={{ image: "hi", title: "hi" }}
+            callback={this.onButtonClick}
+          />
+        </Stack.Item>
+      </Stack>
+    );
+  }
+
+  private onButtonClick = () => {
+    this.setState({ panelOpen: !this.state.panelOpen });
+  };
+
+  private onPageSizeSelect = (
+    event: React.FormEvent<HTMLDivElement>,
+    item: IDropdownOption | undefined
+  ): void => {
+    this.setState({ pageSize: Number(item?.text) });
+    if (event) {
+      return;
+    }
+  };
+
+  private onSliderChange = (value: number) => {
+    if (this.state.selectedKey === VisionDatasetExplorerTabOptions.First) {
+      this.setState({ imageDim: Math.floor((value / 100) * 400) });
+    } else {
+      this.setState({ imageDim: Math.floor((value / 100) * 100) });
+    }
+  };
+
+  private handleLinkClick = (item?: PivotItem) => {
+    if (item) {
+      this.setState({ selectedKey: item.props.itemKey! });
+      if (item.props.itemKey === VisionDatasetExplorerTabOptions.First) {
+        this.setState({ imageDim: 200 });
+      } else {
+        this.setState({ imageDim: 50 });
+      }
+    }
+  };
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1119,6 +1119,23 @@
       "groupPredicted": "Predicted Y",
       "groupTrue": "True Y"
     },
+    "VisionDatasetExplorer": {
+      "columnOne": "Title",
+      "columnTwo": "Index",
+      "columnThree": "True Y",
+      "columnFour": "Predicted Y",
+      "columnFive": "Other metadata",
+      "filter": "Filter",
+      "helperText": "Create dataset cohorts to analyze dataset statistics along filters such as predicted outcome, dataset features and error groups. Learn about the over/under presentation in your dataset.",
+      "pageSize": "Page size: ",
+      "settings": "Settings",
+      "tabOptionFirst": "Image explorer view",
+      "tabOptionSecond": "Table view",
+      "tabOptionThird": "Data characteristics",
+      "thumbnailSize": "Thumbnail size",
+      "titleBarError": "Error instances",
+      "titleBarSuccess": "Success instances"
+    },
     "WhatIf": {
       "_defaultCustomRootName.comment": "default prefix for a hypothetical point made by copying another point",
       "_filterFeaturePlaceholder.comment": "placeholder in search box for searching for features by name",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/VisionTabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/VisionTabsView.tsx
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DefaultEffects, PivotItem, Stack, Text } from "@fluentui/react";
+import { CausalInsightsTab } from "@responsible-ai/causality";
+import {
+  WeightVectorOption,
+  ModelTypes,
+  WeightVectors,
+  ModelAssessmentContext,
+  defaultModelAssessmentContext,
+  IModelAssessmentContext
+} from "@responsible-ai/core-ui";
+import { CounterfactualsTab } from "@responsible-ai/counterfactuals";
+import { VisionDatasetExplorerTab } from "@responsible-ai/dataset-explorer";
+import {
+  ErrorAnalysisOptions,
+  ErrorAnalysisViewTab,
+  MapShift,
+  MatrixArea,
+  MatrixFilter,
+  TreeViewRenderer
+} from "@responsible-ai/error-analysis";
+import { localization } from "@responsible-ai/localization";
+import _, { Dictionary } from "lodash";
+import * as React from "react";
+
+import { AddTabButton } from "../../AddTabButton";
+import {
+  isFlightActive,
+  newModelOverviewExperienceFlight
+} from "../../FeatureFlights";
+import { GlobalTabKeys } from "../../ModelAssessmentEnums";
+import { FeatureImportancesTab } from "../FeatureImportances";
+import { ModelOverview } from "../ModelOverview/ModelOverview";
+
+import { tabsViewStyles } from "./TabsView.styles";
+import { ITabsViewProps } from "./TabsViewProps";
+
+export interface ITabsViewState {
+  errorAnalysisOption: ErrorAnalysisOptions;
+  importances: number[];
+  mapShiftErrorAnalysisOption: ErrorAnalysisOptions;
+  mapShiftVisible: boolean;
+  selectedFeatures: string[];
+  selectedWeightVector: WeightVectorOption;
+  weightVectorLabels: Dictionary<string>;
+  weightVectorOptions: WeightVectorOption[];
+}
+
+export class VisionTabsView extends React.PureComponent<
+  ITabsViewProps,
+  ITabsViewState
+> {
+  public static contextType = ModelAssessmentContext;
+  public context: IModelAssessmentContext = defaultModelAssessmentContext;
+
+  public constructor(props: ITabsViewProps) {
+    super(props);
+    const weightVectorLabels = {
+      [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
+    };
+    const weightVectorOptions = [];
+    if (props.modelMetadata.modelType === ModelTypes.Multiclass) {
+      weightVectorOptions.push(WeightVectors.AbsAvg);
+    }
+    props.modelMetadata.classNames.forEach((name, index) => {
+      weightVectorLabels[index] = localization.formatString(
+        localization.Interpret.WhatIfTab.classLabel,
+        name
+      );
+      weightVectorOptions.push(index);
+    });
+    const importances = props.errorAnalysisData?.[0]?.importances ?? [];
+    this.state = {
+      errorAnalysisOption: ErrorAnalysisOptions.TreeMap,
+      importances,
+      mapShiftErrorAnalysisOption: ErrorAnalysisOptions.TreeMap,
+      mapShiftVisible: false,
+      selectedFeatures: props.dataset.feature_names,
+      selectedWeightVector:
+        props.modelMetadata.modelType === ModelTypes.Multiclass
+          ? WeightVectors.AbsAvg
+          : 0,
+      weightVectorLabels,
+      weightVectorOptions
+    };
+    if (this.props.requestImportances) {
+      this.props
+        .requestImportances([], new AbortController().signal)
+        .then((result) => {
+          this.setState({ importances: result });
+        });
+    }
+  }
+
+  public render(): React.ReactNode {
+    const disabledView =
+      this.props.requestDebugML === undefined &&
+      this.props.requestMatrix === undefined &&
+      this.props.baseCohort.cohort.name !==
+        localization.ErrorAnalysis.Cohort.defaultLabel;
+    const classNames = tabsViewStyles();
+    return (
+      <Stack tokens={{ padding: "l1" }}>
+        {this.props.activeGlobalTabs[0]?.key !==
+          GlobalTabKeys.ErrorAnalysisTab && (
+          <Stack.Item className={classNames.buttonSection}>
+            <AddTabButton
+              tabIndex={0}
+              onAdd={this.props.addTab}
+              availableTabs={this.props.addTabDropdownOptions}
+            />
+          </Stack.Item>
+        )}
+        {this.props.activeGlobalTabs.map((t, i) => (
+          <>
+            <Stack.Item
+              key={i}
+              className={classNames.section}
+              styles={{ root: { boxShadow: DefaultEffects.elevation4 } }}
+            >
+              {t.key === GlobalTabKeys.ErrorAnalysisTab &&
+                this.props.errorAnalysisData?.[0] && (
+                  <>
+                    <div
+                      className={classNames.sectionHeader}
+                      id="errorAnalysisHeader"
+                    >
+                      <Text variant={"xxLarge"}>
+                        {
+                          localization.ModelAssessment.ComponentNames
+                            .ErrorAnalysis
+                        }
+                      </Text>
+                    </div>
+                    <ErrorAnalysisViewTab
+                      disabledView={disabledView}
+                      tree={this.props.errorAnalysisData[0].tree}
+                      matrix={this.props.errorAnalysisData[0].matrix}
+                      matrixFeatures={
+                        this.props.errorAnalysisData[0].matrix_features
+                      }
+                      messages={this.props.stringParams?.contextualHelp}
+                      getTreeNodes={this.props.requestDebugML}
+                      getMatrix={this.props.requestMatrix}
+                      updateSelectedCohort={this.props.updateSelectedCohort}
+                      features={
+                        this.props.errorAnalysisData[0].tree_features ||
+                        this.props.dataset.feature_names
+                      }
+                      selectedFeatures={this.state.selectedFeatures}
+                      errorAnalysisOption={this.state.errorAnalysisOption}
+                      selectedCohort={this.props.selectedCohort}
+                      baseCohort={this.props.baseCohort}
+                      selectFeatures={(features: string[]): void =>
+                        this.setState({ selectedFeatures: features })
+                      }
+                      importances={this.state.importances}
+                      onClearCohortSelectionClick={(): void => {
+                        this.props.onClearCohortSelectionClick();
+                      }}
+                      onSaveCohortClick={(): void => {
+                        this.props.setSaveCohortVisible();
+                      }}
+                      showCohortName={false}
+                      handleErrorDetectorChanged={
+                        this.handleErrorDetectorChanged
+                      }
+                      selectedKey={this.state.errorAnalysisOption}
+                    />
+                  </>
+                )}
+              {t.key === GlobalTabKeys.ModelOverviewTab && (
+                <>
+                  <div className={classNames.sectionHeader}>
+                    <Text variant={"xxLarge"} id="modelStatisticsHeader">
+                      {
+                        localization.ModelAssessment.ComponentNames
+                          .ModelOverview
+                      }
+                    </Text>
+                  </div>
+                  <ModelOverview
+                    showNewModelOverviewExperience={isFlightActive(
+                      newModelOverviewExperienceFlight,
+                      this.context.featureFlights
+                    )}
+                  />
+                </>
+              )}
+              {t.key === GlobalTabKeys.DataExplorerTab && (
+                <>
+                  <div className={classNames.sectionHeader}>
+                    <Text variant={"xxLarge"} id="dataExplorerHeader">
+                      {localization.ModelAssessment.ComponentNames.DataExplorer}
+                    </Text>
+                  </div>
+                  <VisionDatasetExplorerTab />
+                </>
+              )}
+              {t.key === GlobalTabKeys.FeatureImportancesTab &&
+                this.props.modelExplanationData?.[0] && (
+                  <>
+                    <div className={classNames.sectionHeader}>
+                      <Text variant={"xxLarge"} id="featureImportanceHeader">
+                        {
+                          localization.ModelAssessment.ComponentNames
+                            .FeatureImportances
+                        }
+                      </Text>
+                    </div>
+                    <FeatureImportancesTab
+                      modelMetadata={this.props.modelMetadata}
+                      modelExplanationData={this.props.modelExplanationData}
+                      selectedWeightVector={this.state.selectedWeightVector}
+                      weightVectorOptions={this.state.weightVectorOptions}
+                      weightVectorLabels={this.state.weightVectorLabels}
+                      requestPredictions={this.props.requestPredictions}
+                      onWeightVectorChange={this.onWeightVectorChange}
+                    />
+                  </>
+                )}
+              {t.key === GlobalTabKeys.CausalAnalysisTab &&
+                this.props.causalAnalysisData?.[0] && (
+                  <>
+                    <div
+                      className={classNames.sectionHeader}
+                      id="causalAnalysisHeader"
+                    >
+                      <Text variant={"xxLarge"} id="causalInsightsTab">
+                        {
+                          localization.ModelAssessment.ComponentNames
+                            .CausalAnalysis
+                        }
+                      </Text>
+                    </div>
+                    <CausalInsightsTab
+                      data={this.props.causalAnalysisData?.[0]}
+                    />
+                  </>
+                )}
+
+              {t.key === GlobalTabKeys.CounterfactualsTab &&
+                this.props.counterfactualData?.[0] && (
+                  <>
+                    <div className={classNames.sectionHeader}>
+                      <Text variant={"xxLarge"}>
+                        {
+                          localization.ModelAssessment.ComponentNames
+                            .Counterfactuals
+                        }
+                      </Text>
+                    </div>
+                    <CounterfactualsTab
+                      data={this.props.counterfactualData?.[0]}
+                    />
+                  </>
+                )}
+            </Stack.Item>
+            <Stack.Item className={classNames.buttonSection}>
+              <AddTabButton
+                tabIndex={i + 1}
+                onAdd={this.props.addTab}
+                availableTabs={this.props.addTabDropdownOptions}
+              />
+            </Stack.Item>
+          </>
+        ))}
+        {this.state.mapShiftVisible && (
+          <MapShift
+            currentOption={this.state.mapShiftErrorAnalysisOption}
+            isOpen={this.state.mapShiftVisible}
+            onDismiss={(): void =>
+              this.setState({
+                errorAnalysisOption: this.state.errorAnalysisOption,
+                mapShiftVisible: false
+              })
+            }
+            onSave={(): void => {
+              this.setState({
+                mapShiftVisible: false
+              });
+              this.props.setSaveCohortVisible();
+            }}
+            onShift={(): void => {
+              // reset all states on shift
+              MatrixFilter.resetState();
+              MatrixArea.resetState();
+              TreeViewRenderer.resetState();
+              this.setState({
+                errorAnalysisOption: this.state.mapShiftErrorAnalysisOption,
+                mapShiftVisible: false
+              });
+              this.props.setSelectedCohort(this.props.baseCohort);
+            }}
+          />
+        )}
+      </Stack>
+    );
+  }
+
+  private onWeightVectorChange = (weightOption: WeightVectorOption): void => {
+    this.props.jointDataset.buildLocalFlattenMatrix(weightOption);
+    this.props.cohorts.forEach((errorCohort) =>
+      errorCohort.cohort.clearCachedImportances()
+    );
+    this.setState({ selectedWeightVector: weightOption });
+  };
+
+  private handleErrorDetectorChanged = (item?: PivotItem): void => {
+    if (item && item.props.itemKey) {
+      // Note comparison below is actually string comparison (key is string), we have to set the enum
+      if (item.props.itemKey === ErrorAnalysisOptions.HeatMap) {
+        const selectedOptionHeatMap = ErrorAnalysisOptions.HeatMap;
+        this.setErrorDetector(selectedOptionHeatMap);
+      } else {
+        const selectedOptionTreeMap = ErrorAnalysisOptions.TreeMap;
+        this.setErrorDetector(selectedOptionTreeMap);
+      }
+    }
+  };
+
+  private setErrorDetector = (key: ErrorAnalysisOptions): void => {
+    if (this.props.selectedCohort.isTemporary) {
+      this.setState({
+        mapShiftErrorAnalysisOption: key,
+        mapShiftVisible: true
+      });
+    } else {
+      this.setState({
+        errorAnalysisOption: key
+      });
+    }
+  };
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/VisionModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/VisionModelAssessmentDashboard.tsx
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getTheme, IDropdownOption, loadTheme, Stack } from "@fluentui/react";
+import {
+  CohortBasedComponent,
+  ModelAssessmentContext,
+  ErrorCohort,
+  CohortSource,
+  Cohort,
+  SaveCohort,
+  defaultTheme
+} from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+import _ from "lodash";
+import * as React from "react";
+
+import { getAvailableTabs } from "./AvailableTabs";
+import { buildInitialModelAssessmentContext } from "./Context/buildModelAssessmentContext";
+import { MainMenu } from "./Controls/MainMenu";
+import { VisionTabsView } from "./Controls/TabsView/VisionTabsView";
+import { modelAssessmentDashboardStyles } from "./ModelAssessmentDashboard.styles";
+import { IModelAssessmentDashboardProps } from "./ModelAssessmentDashboardProps";
+import { IModelAssessmentDashboardState } from "./ModelAssessmentDashboardState";
+import { GlobalTabKeys } from "./ModelAssessmentEnums";
+
+export class VisionModelAssessmentDashboard extends CohortBasedComponent<
+  IModelAssessmentDashboardProps,
+  IModelAssessmentDashboardState
+> {
+  private addTabDropdownOptions: IDropdownOption[];
+
+  public constructor(props: IModelAssessmentDashboardProps) {
+    super(props);
+    if (this.props.locale) {
+      localization.setLanguage(this.props.locale);
+    }
+    this.state = buildInitialModelAssessmentContext(_.cloneDeep(props));
+    loadTheme(props.theme || defaultTheme);
+    this.addTabDropdownOptions = getAvailableTabs(this.props, true);
+  }
+  public componentDidUpdate(prev: IModelAssessmentDashboardProps): void {
+    if (prev.theme !== this.props.theme) {
+      loadTheme(this.props.theme || defaultTheme);
+    }
+    if (this.props.locale && prev.locale !== this.props.locale) {
+      localization.setLanguage(this.props.locale);
+    }
+  }
+
+  public render(): React.ReactNode {
+    const classNames = modelAssessmentDashboardStyles();
+    return (
+      <ModelAssessmentContext.Provider
+        value={{
+          addCohort: this.addCohort,
+          baseErrorCohort: this.state.baseCohort,
+          causalAnalysisData: this.props.causalAnalysisData?.[0],
+          counterfactualData: this.props.counterfactualData?.[0],
+          dataset: this.props.dataset,
+          deleteCohort: this.deleteCohort,
+          editCohort: this.editCohort,
+          errorAnalysisData: this.props.errorAnalysisData?.[0],
+          errorCohorts: this.state.cohorts,
+          featureFlights: this.props.featureFlights,
+          jointDataset: this.state.jointDataset,
+          modelExplanationData: this.props.modelExplanationData?.[0]
+            ? {
+                ...this.props.modelExplanationData?.[0],
+                predictedY: this.props.dataset.predicted_y,
+                probabilityY: this.props.dataset.probability_y
+              }
+            : undefined,
+          modelMetadata: this.state.modelMetadata,
+          requestCausalWhatIf: this.props.requestCausalWhatIf,
+          requestLocalFeatureExplanations:
+            this.props.requestLocalFeatureExplanations,
+          requestPredictions: this.props.requestPredictions,
+          selectedErrorCohort: this.state.selectedCohort,
+          shiftErrorCohort: this.shiftErrorCohort,
+          telemetryHook:
+            this.props.telemetryHook ||
+            ((): void => {
+              return;
+            }),
+          theme: getTheme()
+        }}
+      >
+        <Stack id="ModelAssessmentDashboard" className={classNames.page}>
+          <MainMenu
+            activeGlobalTabs={this.state.activeGlobalTabs}
+            removeTab={this.removeTab}
+          />
+          <Stack.Item className={classNames.mainContent}>
+            <VisionTabsView
+              modelExplanationData={this.props.modelExplanationData}
+              causalAnalysisData={this.props.causalAnalysisData}
+              counterfactualData={this.props.counterfactualData}
+              errorAnalysisData={this.props.errorAnalysisData}
+              cohortData={this.props.cohortData}
+              cohorts={this.state.cohorts}
+              jointDataset={this.state.jointDataset}
+              activeGlobalTabs={this.state.activeGlobalTabs}
+              baseCohort={this.state.baseCohort}
+              selectedCohort={this.state.selectedCohort}
+              dataset={this.props.dataset}
+              onClearCohortSelectionClick={this.clearCohortSelection}
+              requestPredictions={this.props.requestPredictions}
+              requestDebugML={this.props.requestDebugML}
+              requestImportances={this.props.requestImportances}
+              requestMatrix={this.props.requestMatrix}
+              stringParams={this.props.stringParams}
+              updateSelectedCohort={this.updateSelectedCohort}
+              setSaveCohortVisible={this.setSaveCohortVisible}
+              setSelectedCohort={this.setSelectedCohort}
+              modelMetadata={this.state.modelMetadata}
+              addTabDropdownOptions={this.addTabDropdownOptions}
+              addTab={this.addTab}
+            />
+          </Stack.Item>
+          {this.state.saveCohortVisible && (
+            <SaveCohort
+              isOpen={this.state.saveCohortVisible}
+              onDismiss={(): void =>
+                this.setState({ saveCohortVisible: false })
+              }
+              onSave={this.onSaveCohort}
+              temporaryCohort={this.state.selectedCohort}
+              baseCohort={this.state.baseCohort}
+            />
+          )}
+        </Stack>
+      </ModelAssessmentContext.Provider>
+    );
+  }
+
+  private setSaveCohortVisible = (): void => {
+    this.setState({ saveCohortVisible: true });
+  };
+
+  private addTab = (index: number, tab: GlobalTabKeys): void => {
+    const tabs = [...this.state.activeGlobalTabs];
+    let dataCount: number;
+    if (index > 0) {
+      dataCount = tabs[index - 1].dataCount;
+    } else {
+      dataCount = this.state.baseCohort.cohortStats.totalCohort;
+    }
+    tabs.splice(index, 0, {
+      dataCount,
+      key: tab,
+      name:
+        this.addTabDropdownOptions.find(({ key }) => key === tab)?.text || ""
+    });
+    this.setState({ activeGlobalTabs: tabs });
+  };
+
+  private removeTab = (index: number): void => {
+    const tabs = [...this.state.activeGlobalTabs];
+    tabs.splice(index, 1);
+    this.setState({ activeGlobalTabs: tabs });
+  };
+
+  private shiftErrorCohort = (cohort: ErrorCohort) => {
+    this.setState({
+      baseCohort: cohort,
+      selectedCohort: cohort
+    });
+  };
+
+  private setSelectedCohort = (cohort: ErrorCohort): void => {
+    this.setState({
+      selectedCohort: cohort
+    });
+  };
+
+  private clearCohortSelection = (): void => {
+    const cohorts = this.state.cohorts.filter(
+      (errorCohort) => !errorCohort.isTemporary
+    );
+    this.setState({
+      cohorts,
+      selectedCohort: this.state.baseCohort
+    });
+  };
+
+  private onSaveCohort = (
+    savedCohort: ErrorCohort,
+    switchNew?: boolean
+  ): void => {
+    if (
+      this.state.cohorts.some((c) => c.cohort.name === savedCohort.cohort.name)
+    ) {
+      return;
+    }
+    let newCohorts = [...this.state.cohorts, savedCohort];
+    newCohorts = newCohorts.filter((cohort) => !cohort.isTemporary);
+    this.setState((preState) => ({
+      baseCohort: switchNew ? savedCohort : preState.baseCohort,
+      cohorts: newCohorts,
+      selectedCohort: switchNew ? savedCohort : preState.selectedCohort
+    }));
+  };
+
+  private addCohort = (
+    manuallyCreatedCohort: Cohort,
+    switchNew?: boolean
+  ): void => {
+    if (
+      this.state.cohorts.some(
+        (c) => c.cohort.name === manuallyCreatedCohort.name
+      )
+    ) {
+      return;
+    }
+    const newErrorCohort = new ErrorCohort(
+      manuallyCreatedCohort,
+      this.state.jointDataset,
+      0,
+      CohortSource.ManuallyCreated
+    );
+    let newCohorts = [...this.state.cohorts, newErrorCohort];
+    newCohorts = newCohorts.filter((cohort) => !cohort.isTemporary);
+    this.setState((prevState) => ({
+      baseCohort: switchNew ? newErrorCohort : prevState.baseCohort,
+      cohorts: newCohorts,
+      selectedCohort: switchNew ? newErrorCohort : prevState.selectedCohort
+    }));
+  };
+
+  private editCohort = (editCohort: Cohort, switchNew?: boolean): void => {
+    const editIndex = this.state.cohorts.findIndex(
+      (c) => c.cohort.name === editCohort.name
+    );
+    if (editIndex === -1) {
+      return;
+    }
+    const newErrorCohort = new ErrorCohort(
+      editCohort,
+      this.state.jointDataset,
+      0,
+      CohortSource.ManuallyCreated
+    );
+    let newCohorts = [...this.state.cohorts];
+    newCohorts[editIndex] = newErrorCohort;
+    newCohorts = newCohorts.filter((cohort) => !cohort.isTemporary);
+
+    if (switchNew) {
+      this.setState({
+        cohorts: newCohorts,
+        selectedCohort: newCohorts[editIndex]
+      });
+    } else {
+      this.setState({ cohorts: newCohorts });
+    }
+  };
+
+  private deleteCohort = (cohort: ErrorCohort) => {
+    if (
+      this.state.baseCohort.cohort.name === cohort.cohort.name ||
+      this.state.selectedCohort.cohort.name === cohort.cohort.name
+    ) {
+      return;
+    }
+    const newCohorts = [...this.state.cohorts].filter(
+      (t) => t.cohort.name !== cohort.cohort.name
+    );
+    this.setState({
+      cohorts: newCohorts
+    });
+  };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

I started the implementation of the image classification dashboard by creating a draft of the image explorer tab. All the UI elements present in the Figma are present here, but the filter, search, and create cohort functionalities are not implemented yet due to ongoing design discussions. The images are able to be resized via the corresponding slider and are currently hardcoded to start at 200px wide and be scaled anywhere between 80px and 320px. When clicked, the explanation panel opens, but no features of the explanation panel are implemented.

Next steps:
- When the window is sized in certain ways, there is an extra scrollbar that appears on each image list. This will have to be removed.
- All of the text is hardcoded in English. I will work on adding localization.
- Working on the table view

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->
- [ check] I have added screenshots above for all UI changes.

![Screenshot (13)](https://user-images.githubusercontent.com/69280655/178603383-538bb2ee-c886-49aa-acf4-2e9b914c927b.png)


![Screenshot (14)](https://user-images.githubusercontent.com/69280655/178603440-07ceb40c-dcb3-4d63-b526-dd9a98dadfca.png)

- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
