### PR TITLE
update raiwidgets and responsibleai to latest erroranalysis 0.3.3 release

### DIFF
--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -5,6 +5,6 @@ rai-core-flask==0.3.0
 itsdangerous==2.0.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.3.2
+erroranalysis>=0.3.3
 fairlearn>=0.7.0
 raiutils>=0.1.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,7 +1,7 @@
 dice-ml>=0.8,<0.9
 econml~=0.13.0
 jsonschema
-erroranalysis>=0.3.2
+erroranalysis>=0.3.3
 interpret-community>=0.26.0
 lightgbm>=2.0.11
 numpy>=1.17.2


### PR DESCRIPTION
## Description

Update raiwidgets and responsibleai to latest erroranalysis version 0.3.3, which was released yesterday.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
