### PR TITLE
fix erroranalysis erroring on serialization with numpy int64 feature names

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -729,7 +729,7 @@ def node_to_dict(df, tree, nodeid, categories, json,
     metric_name = metric_to_display_name[metric]
     is_error_metric = metric in error_metrics
     if SPLIT_FEATURE in tree:
-        node_name = feature_names[tree[SPLIT_FEATURE]]
+        node_name = str(feature_names[tree[SPLIT_FEATURE]])
     else:
         node_name = None
     json.append(get_json_node(arg, condition, error, nodeid, method,

--- a/erroranalysis/erroranalysis/report/error_report.py
+++ b/erroranalysis/erroranalysis/report/error_report.py
@@ -4,6 +4,8 @@
 import json
 import uuid
 
+from raiutils.data_processing import serialize_json_safe
+
 _ErrorReportVersion1 = '1.0'
 _ErrorReportVersion2 = '2.0'
 _ErrorReportVersion3 = '3.0'
@@ -35,10 +37,7 @@ def json_converter(obj):
     if isinstance(obj, ErrorReport):
         rdict = obj.__dict__
         return rdict
-    try:
-        return obj.to_json()
-    except AttributeError:
-        return obj.__dict__
+    return serialize_json_safe(obj)
 
 
 def as_error_report(error_dict):

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '3'
+_patch = '4'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/requirements.txt
+++ b/erroranalysis/requirements.txt
@@ -3,3 +3,4 @@ pandas>=0.25.1
 scipy>=1.4.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
+raiutils>=0.1.0

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -30,6 +30,18 @@ class TestErrorReport(object):
                                categorical_features,
                                expect_user_warnings=alter_feature_names)
 
+    def test_error_report_iris_numpy_int64_features(self):
+        X_train, X_test, y_train, y_test, _, _ = create_iris_data()
+        # Test with numpy feature indexes instead of string feature names
+        feature_names = range(0, X_train.shape[1])
+        feature_names = [np.int64(i) for i in feature_names]
+        models = create_models_classification(X_train, y_train)
+
+        for model in models:
+            categorical_features = []
+            run_error_analyzer(model, X_test, y_test, feature_names,
+                               categorical_features)
+
     def test_error_report_cancer(self):
         X_train, X_test, y_train, y_test, feature_names, _ = \
             create_cancer_data()


### PR DESCRIPTION
## Description

During benchmarking, we discovered that datasets which had indexes for feature names - specifically numpy int64 values - would cause erroranalysis ErrorReports to fail to serialize.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
