### PR TITLE
Make the local point selection drop down consistent in causal and counterfactual

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/CausalIndividualChart.tsx
@@ -195,7 +195,7 @@ export class CausalIndividualChart extends React.PureComponent<
         </Stack.Item>
         <Stack className={classNames.legendAndText}>
           <ComboBox
-            label={localization.CausalAnalysis.IndividualView.datapointIndex}
+            label={localization.CausalAnalysis.IndividualView.selectedDatapoint}
             onChange={this.selectPointFromDropdown}
             options={this.getDataOptions()}
             selectedKey={this.state.selectedIndex}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -21,7 +21,7 @@
       "currentOutcome": "Current outcome",
       "currentTreatment": "Current treatment value",
       "dataRequired": "This tab requires a datapoint be selected.",
-      "datapointIndex": "Datapoint index",
+      "selectedDatapoint": "Selected datapoint",
       "description": "Individual causal effects can inform personalized interventions, such as a targeted promotion to customers or an individualized treatment plan. How would an individual with a particular set of features respond to a change in a causal feature, or treatment?  The causal what-if tool calculates marginal changes in real-world outcomes for a particular individual if you change their level of a treatment. This analysis enables you to understand how real-world outcomes would have changed under different policy choices, such as a different pricing strategy for a product or an alternative treatment for a patient. Specify the treatment of interest and observe how the real-world outcome would change.",
       "directIndividual": "Direct individual causal effect of each treatment with 95% confidence interval",
       "index": "Datapoint index",


### PR DESCRIPTION
## Description

Before
Causal
![image](https://user-images.githubusercontent.com/47334368/177861092-0df42602-045d-4777-a638-404af52c8ae2.png)

Counterfactual
![image](https://user-images.githubusercontent.com/47334368/177860956-ea420377-7d7a-4799-bc12-22dfd943d40e.png)

After
Causal
![image](https://user-images.githubusercontent.com/47334368/177860857-d1a71c02-fdc1-46d3-8fb7-1768623f0a5f.png)

Counterfactual
![image](https://user-images.githubusercontent.com/47334368/177860942-35c85130-4d27-404d-9f9f-a841adc22913.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
