### PR TITLE
Add ID to counterfactual config and serialized counterfactual data

### DIFF
--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -140,6 +140,7 @@ class CausalData:
 
 
 class CounterfactualData:
+    id: str
     cfs_list: List[List[List[Union[float, str]]]]
     feature_names: List[str]
     feature_names_including_target: List[str]

--- a/responsibleai/responsibleai/managers/counterfactual_manager.py
+++ b/responsibleai/responsibleai/managers/counterfactual_manager.py
@@ -3,10 +3,10 @@
 
 """Defines the Counterfactual Manager class."""
 import json
+import uuid
 import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Union
-import uuid
 
 import dice_ml
 import jsonschema

--- a/responsibleai/responsibleai/managers/counterfactual_manager.py
+++ b/responsibleai/responsibleai/managers/counterfactual_manager.py
@@ -6,6 +6,7 @@ import json
 import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Union
+import uuid
 
 import dice_ml
 import jsonschema
@@ -115,6 +116,7 @@ class CounterfactualConfig(BaseConfig):
     METHOD = 'method'
     CONTINUOUS_FEATURES = 'continuous_features'
     TOTAL_CFS = 'total_CFs'
+    ID = 'id'
     DESIRED_RANGE = 'desired_range'
     DESIRED_CLASS = 'desired_class'
     PERMITTED_RANGE = 'permitted_range'
@@ -133,11 +135,16 @@ class CounterfactualConfig(BaseConfig):
     def __init__(self, method, continuous_features, total_CFs,
                  desired_class=CounterfactualConstants.OPPOSITE,
                  desired_range=None, permitted_range=None,
-                 features_to_vary=None, feature_importance=False):
+                 features_to_vary=None, feature_importance=False,
+                 id=None):
         super(CounterfactualConfig, self).__init__()
         self.method = method
         self.continuous_features = continuous_features
         self.total_CFs = total_CFs
+        if id is None:
+            self.id = str(uuid.uuid4())
+        else:
+            self.id = id
         self.desired_range = desired_range
         self.desired_class = desired_class
         self.permitted_range = permitted_range
@@ -176,6 +183,7 @@ class CounterfactualConfig(BaseConfig):
             CounterfactualConfig.METHOD: self.method,
             CounterfactualConfig.CONTINUOUS_FEATURES: self.continuous_features,
             CounterfactualConfig.TOTAL_CFS: self.total_CFs,
+            CounterfactualConfig.ID: self.id,
             CounterfactualConfig.DESIRED_RANGE: self.desired_range,
             CounterfactualConfig.DESIRED_CLASS: self.desired_class,
             CounterfactualConfig.PERMITTED_RANGE: self.permitted_range,
@@ -209,7 +217,8 @@ class CounterfactualConfig(BaseConfig):
             features_to_vary=cf_config[
                 CounterfactualConfig.FEATURES_TO_VARY],
             feature_importance=cf_config[
-                CounterfactualConfig.FEATURE_IMPORTANCE])
+                CounterfactualConfig.FEATURE_IMPORTANCE],
+            id=cf_config[CounterfactualConfig.ID])
 
         return counterfactual_config
 
@@ -626,12 +635,18 @@ class CounterfactualManager(BaseManager):
         :return: A array of CounterfactualData.
         :rtype: List[CounterfactualData]
         """
-        return [
-            self._get_counterfactual(i) for i in self.get()]
+        serialized_counterfactual_data_list = []
+        for counterfactual_config in self._counterfactual_config_list:
+            serialized_counterfactual_data_list.append(
+                self._get_counterfactual(counterfactual_config))
 
-    def _get_counterfactual(self, counterfactual):
+        return serialized_counterfactual_data_list
+
+    def _get_counterfactual(self, counterfactual_config):
         cfdata = CounterfactualData()
-        json_data = json.loads(counterfactual.to_json())
+
+        json_data = json.loads(
+            counterfactual_config.counterfactual_obj.to_json())
         cfdata.cfs_list = json_data["cfs_list"]
         cfdata.feature_names = json_data["feature_names"]
         cfdata.feature_names_including_target = json_data[
@@ -641,6 +656,7 @@ class CounterfactualManager(BaseManager):
         cfdata.model_type = json_data["model_type"]
         cfdata.desired_class = json_data["desired_class"]
         cfdata.desired_range = json_data["desired_range"]
+        cfdata.id = counterfactual_config.id
         return cfdata
 
     @property

--- a/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
+++ b/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
@@ -119,10 +119,12 @@ class TestCounterfactualAdvancedFeatures(object):
         cf_obj_2 = rai_insights_copy.counterfactual.get()[1]
         assert cf_obj_2 is not None
 
-        assert counterfactual_config_list_before_save[0].id == \
-            counterfactual_config_list_after_save[0].id
-        assert counterfactual_config_list_before_save[1].id == \
-            counterfactual_config_list_after_save[1].id
+        assert counterfactual_config_list_before_save[0].id in \
+            [counterfactual_config_list_after_save[0].id,
+             counterfactual_config_list_after_save[1].id]
+        assert counterfactual_config_list_before_save[1].id in \
+            [counterfactual_config_list_after_save[0].id,
+             counterfactual_config_list_after_save[1].id]
 
         # Delete the dice-ml explainer directory so that the dice-ml
         # explainer can be re-trained rather being loaded from the

--- a/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
+++ b/responsibleai/tests/counterfactual/test_counterfactual_advanced_features.py
@@ -98,17 +98,31 @@ class TestCounterfactualAdvancedFeatures(object):
             permitted_range={feature_names[0]: [2.0, 5.0]})
         rai_insights.counterfactual.compute()
 
+        counterfactual_config_list_before_save = \
+            rai_insights.counterfactual._counterfactual_config_list
+        assert len(counterfactual_config_list_before_save) == 2
         assert len(rai_insights.counterfactual.get()) == 2
-        cf_obj = rai_insights.counterfactual.get()[0]
-        assert cf_obj is not None
+        cf_obj_1 = rai_insights.counterfactual.get()[0]
+        assert cf_obj_1 is not None
+        cf_obj_2 = rai_insights.counterfactual.get()[1]
+        assert cf_obj_2 is not None
 
         save_dir = tmpdir.mkdir('save-dir')
         rai_insights.save(save_dir)
         rai_insights_copy = RAIInsights.load(save_dir)
 
+        counterfactual_config_list_after_save = \
+            rai_insights_copy.counterfactual._counterfactual_config_list
         assert len(rai_insights_copy.counterfactual.get()) == 2
-        cf_obj = rai_insights_copy.counterfactual.get()[0]
-        assert cf_obj is not None
+        cf_obj_1 = rai_insights_copy.counterfactual.get()[0]
+        assert cf_obj_1 is not None
+        cf_obj_2 = rai_insights_copy.counterfactual.get()[1]
+        assert cf_obj_2 is not None
+
+        assert counterfactual_config_list_before_save[0].id == \
+            counterfactual_config_list_after_save[0].id
+        assert counterfactual_config_list_before_save[1].id == \
+            counterfactual_config_list_after_save[1].id
 
         # Delete the dice-ml explainer directory so that the dice-ml
         # explainer can be re-trained rather being loaded from the
@@ -136,3 +150,37 @@ class TestCounterfactualAdvancedFeatures(object):
         assert len(counterfactual_config_list) == 2
         assert counterfactual_config_list[0].explainer is not None
         assert counterfactual_config_list[1].explainer is not None
+
+    def test_counterfactual_manager_get_data(self):
+        X_train, X_test, y_train, y_test, feature_names, _ = \
+            create_iris_data()
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        X_train['target'] = y_train
+        X_test['target'] = y_test
+
+        rai_insights = RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test.iloc[0:10],
+            target_column='target',
+            task_type='classification')
+
+        rai_insights.counterfactual.add(
+            total_CFs=10, desired_class=2,
+            features_to_vary=[feature_names[0]],
+            permitted_range={feature_names[0]: [2.0, 5.0]})
+        rai_insights.counterfactual.compute()
+
+        serialized_data = rai_insights.counterfactual.get_data()
+        assert serialized_data is not None
+        assert len(serialized_data) == 1
+        assert hasattr(serialized_data[0], 'id')
+        assert hasattr(serialized_data[0], 'cfs_list')
+        assert hasattr(serialized_data[0], 'desired_class')
+        assert hasattr(serialized_data[0], 'desired_range')
+        assert hasattr(serialized_data[0], 'feature_names')
+        assert hasattr(serialized_data[0], 'feature_names_including_target')
+        assert hasattr(serialized_data[0], 'local_importance')
+        assert hasattr(serialized_data[0], 'summary_importance')
+        assert hasattr(serialized_data[0], 'model_type')


### PR DESCRIPTION
## Description

This will enable querying for counterfactuals from UI. UI can pass the id using which we will be able to look up the counterfactual config / explainer using which we can generate the counterfactuals.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
