### PR TITLE
refactor text highlighting component to use Text and Label from FluentUI instead of styles on spans

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHighlighting.styles.ts
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHighlighting.styles.ts
@@ -5,7 +5,8 @@ import {
   IStyle,
   mergeStyles,
   mergeStyleSets,
-  IProcessedStyleSet
+  IProcessedStyleSet,
+  getTheme
 } from "@fluentui/react";
 import { NeutralColors, SharedColors } from "@fluentui/theme";
 
@@ -17,16 +18,17 @@ export interface ITextHighlightingStyles {
 
 export const textHighlightingStyles: () => IProcessedStyleSet<ITextHighlightingStyles> =
   () => {
+    const theme = getTheme();
     const normal = {
-      fontFamily: "Segoe UI",
-      fontSize: "1.5em"
+      color: theme.semanticColors.bodyText
     };
     return mergeStyleSets<ITextHighlightingStyles>({
       boldunderline: mergeStyles([
         normal,
         {
           color: SharedColors.blue10,
-          fontWeight: "bold",
+          fontSize: theme.fonts.large.fontSize,
+          padding: 0,
           textDecorationLine: "underline"
         }
       ]),
@@ -34,8 +36,7 @@ export const textHighlightingStyles: () => IProcessedStyleSet<ITextHighlightingS
         normal,
         {
           backgroundColor: SharedColors.blue10,
-          color: NeutralColors.white,
-          fontweight: "400px"
+          color: NeutralColors.white
         }
       ]),
       normal

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHightlighting.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHightlighting.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { Label, Text, Stack, IStackTokens } from "@fluentui/react";
 import React from "react";
 
 import { Utils } from "../../CommonUtils";
@@ -8,36 +9,61 @@ import { IChartProps } from "../../Interfaces/IChartProps";
 
 import { textHighlightingStyles } from "./TextHighlighting.styles";
 
+const textStackTokens: IStackTokens = {
+  childrenGap: "s2",
+  padding: "s2"
+};
+
 export class TextHighlighting extends React.PureComponent<IChartProps> {
   /*
-   * presents the document in an accessible manner with text highlighting
+   * Presents the document in an accessible manner with text highlighting
    */
-  public render(): React.ReactNode[] {
+  public render(): React.ReactNode {
     const classNames = textHighlightingStyles();
     const text = this.props.text;
     const importances = this.props.localExplanations;
     const k = this.props.topK;
     const sortedList = Utils.sortedTopK(importances, k!, this.props.radio!);
-    const val = text.map((word, wordIndex) => {
-      let styleType = classNames.normal;
-      const score = importances[wordIndex];
-      if (sortedList.includes(wordIndex)) {
-        if (score > 0) {
-          styleType = classNames.highlighted;
-        } else if (score < 0) {
-          styleType = classNames.boldunderline;
-        } else {
-          styleType = classNames.normal;
-        }
-      }
-      return (
-        <span key={wordIndex} className={styleType} title={score.toString()}>
-          {word}
-        </span>
-      );
-    });
-    return val.map((word, wordIndex) => {
-      return <span key={wordIndex}>{word} </span>;
-    });
+    return (
+      <Stack horizontal horizontalAlign="start" tokens={textStackTokens}>
+        {text.map((word, wordIndex) => {
+          let styleType = classNames.normal;
+          const score = importances[wordIndex];
+          let isBold = false;
+          if (sortedList.includes(wordIndex)) {
+            if (score > 0) {
+              styleType = classNames.highlighted;
+            } else if (score < 0) {
+              styleType = classNames.boldunderline;
+              isBold = true;
+            } else {
+              styleType = classNames.normal;
+            }
+          }
+          if (isBold) {
+            return (
+              <Label
+                key={wordIndex}
+                className={styleType}
+                title={score.toString()}
+              >
+                {word}
+              </Label>
+            );
+          }
+
+          return (
+            <Text
+              variant={"large"}
+              key={wordIndex}
+              className={styleType}
+              title={score.toString()}
+            >
+              {word}
+            </Text>
+          );
+        })}
+      </Stack>
+    );
   }
 }

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/TextExplanationDashboard.styles.ts
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/TextExplanationDashboard.styles.ts
@@ -34,7 +34,6 @@ export const textExplanationDashboardStyles: () => IProcessedStyleSet<ITextExpla
         borderColor: NeutralColors.gray80,
         borderRadius: "1px",
         borderStyle: "groove",
-        fontWeight: "lighter",
         lineHeight: "32px",
         maxHeight: "200px",
         minWidth: "400px",

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/TextExplanationDashboard.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/TextExplanationDashboard.tsx
@@ -85,9 +85,11 @@ export class TextExplanationDashboard extends React.PureComponent<
             />
           </Stack.Item>
           <Stack.Item align="center">
-            {`${this.state.topK.toString()} ${
-              localization.InterpretText.Dashboard.importantWords
-            }`}
+            <Text variant={"large"}>
+              {`${this.state.topK.toString()} ${
+                localization.InterpretText.Dashboard.importantWords
+              }`}
+            </Text>
           </Stack.Item>
         </Stack>
         <Stack tokens={componentStackTokens} horizontal>


### PR DESCRIPTION
## Description

This PR refactors the text highlighting component in interpret-text.  Currently, it uses spans with special styling.  Instead, this PR refactors it to use Text and Label components from FluentUI instead.

Note the UI looks mostly the same:
![image](https://user-images.githubusercontent.com/24683184/179012802-b72b6a6f-f8fa-4f1b-b491-d012fbe912ab.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
