### PR TITLE
Improve error message when categorical string column is treated as numeric and error analysis is run

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -691,7 +691,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} <= {:.2f}".format(p_node_name,
                                                   parent_threshold)
-                df = df[df[p_node_name_val] <= parent_threshold]
+                filter_by_threshold(df, p_node_name_val,
+                                    parent_threshold, side)
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_INCLUDES
                 arg = create_categorical_arg(parent_threshold)
@@ -708,7 +709,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} > {:.2f}".format(p_node_name,
                                                  parent_threshold)
-                df = df[df[p_node_name_val] > parent_threshold]
+                filter_by_threshold(df, p_node_name_val,
+                                    parent_threshold, side)
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_EXCLUDES
                 arg = create_categorical_arg(parent_threshold)
@@ -737,6 +739,38 @@ def node_to_dict(df, tree, nodeid, categories, json,
                               total, success, metric_name,
                               metric_value, is_error_metric))
     return json, df
+
+
+def filter_by_threshold(df, p_node_name_val, parent_threshold, side):
+    """Filters the DataFrame by the threshold of the parent node.
+
+    :param df: The DataFrame to filter.
+    :type df: pandas.DataFrame
+    :param p_node_name_val: The name of the parent node.
+    :type p_node_name_val: str
+    :param parent_threshold: The threshold of the parent node.
+    :type parent_threshold: float
+    :param side: The side of the parent node.
+    :type side: TreeSide
+    :return: The filtered DataFrame.
+    :rtype: pandas.DataFrame
+    """
+    try:
+        if side == TreeSide.LEFT_CHILD:
+            df = df[df[p_node_name_val] <= parent_threshold]
+        else:
+            df = df[df[p_node_name_val] > parent_threshold]
+        return df
+    except TypeError as e:
+        has_vals = df[p_node_name_val].shape[0] > 0
+        if has_vals and isinstance(df[p_node_name_val][0], str):
+            err = ("Column {0} of type string is incorrectly treated "
+                   "as numeric with threshold value {1}. "
+                   "Please make sure it is marked as categorical instead.")
+            err = err.format(p_node_name_val, parent_threshold)
+            raise TypeError(err, e)
+        else:
+            raise e
 
 
 def compute_metrics_pyspark(df, metric, total):

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '4'
+_patch = '5'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Description

When a column is not specified as categorical, although it has string values, and then error analysis is run on the column, a cryptic crash can appear:

```
TypeError: '<=' not supported between instances of 'str' and 'float'
```

This PR improves the error message to be more useful to the user when using error analysis:

```
Column MY_COL_NAME of type string is incorrectly treated as numeric with threshold value 7.77. Please make sure it is marked as categorical instead.
```


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
