### PR TITLE
Remove redundant lines of code in StatisticsUtils.ts

### DIFF
--- a/libs/core-ui/src/lib/util/StatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtils.ts
@@ -77,12 +77,6 @@ const generateBinaryStats: (outcomes: number[]) => ILabeledStatistic[] = (
         truePosCount / (truePosCount + 0.5 * (falsePosCount + falseNegCount))
     },
     {
-      key: BinaryClassificationMetrics.F1Score,
-      label: localization.Interpret.Statistics.f1Score,
-      stat:
-        truePosCount / (truePosCount + 0.5 * (falsePosCount + falseNegCount))
-    },
-    {
       key: BinaryClassificationMetrics.FalsePositiveRate,
       label: localization.Interpret.Statistics.fpr,
       stat: falsePosCount / (trueNegCount + falsePosCount)


### PR DESCRIPTION
## Description

It seems like the following lines are duplicated:-

```
    {
      key: BinaryClassificationMetrics.F1Score,
      label: localization.Interpret.Statistics.f1Score,
      stat:
        truePosCount / (truePosCount + 0.5 * (falsePosCount + falseNegCount))
    },
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
