### PR TITLE
fix release pipeline failing on UI widget tests

### DIFF
--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -60,17 +60,10 @@ jobs:
         run: |
           yarn buildall
 
-      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
-        name: Install pytorch on non-MacOS
+      - name: Install pytorch
         shell: bash -l {0}
         run: |
           conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
-
-      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
-        name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
-        shell: bash -l {0}
-        run: |
-          conda install --yes --quiet pytorch torchvision captum -c pytorch
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}
@@ -137,9 +130,9 @@ jobs:
         run: pytest ./tests/
         working-directory: ${{ env.raiDirectory }}
 
-      - name: Run widget tests
+      - name: Run widget tests without flights
         shell: bash -l {0}
-        run: yarn e2e-widget -f ${{ matrix.flights }}
+        run: yarn e2e-widget -f ""
 
       - name: Upload e2e test screen shot
         if: always()
@@ -172,7 +165,6 @@ jobs:
     strategy:
       matrix:
         package: [responsibleai, raiwidgets]
-        flights: ["", "newModelOverviewExperience"]
 
     steps:
       - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
## Description

Fix release pipeline failing on UI widget tests.  The fix here is to run the tests without flights prior to release.
Alternatively, we could run all UI tests as an extra step, but this seems unnecessary for release pipeline.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
