### PR TITLE
fix e2e UI tests incorrectly running tests with flights when no notebook name specified and reduce number of test jobs

### DIFF
--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -49,13 +49,7 @@ jobs:
         operatingSystem: [ubuntu-latest, windows-latest]
         pythonVersion: [3.6, 3.7, 3.8, 3.9]
         flights: ["", "newModelOverviewExperience"]
-        notebook: # keep this list in sync with scripts/e2e-widget.js
-          - "responsibleaidashboard-census-classification-model-debugging"
-          - "responsibleaidashboard-diabetes-regression-model-debugging"
-          - "responsibleaidashboard-housing-classification-model-debugging"
-          - "responsibleaidashboard-diabetes-decision-making"
-          - "responsibleaidashboard-housing-decision-making"
-          - "responsibleaidashboard-multiclass-dnn-model-debugging"
+        notebookGroup: ["nb_group_1", "nb_group_2"]
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -116,9 +110,22 @@ jobs:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
 
-      - name: Run widget tests
+      # keep list of notebooks in sync with scripts/e2e-widget.js, create new notebook group if necessary
+      - if: ${{ matrix.notebookGroup == 'nb_group_1'}}
+        name: Run widget tests
         shell: bash -l {0}
-        run: yarn e2e-widget -n ${{ matrix.notebook }} -f ${{ matrix.flights }}
+        run: |
+          yarn e2e-widget -n "responsibleaidashboard-census-classification-model-debugging" -f ${{ matrix.flights }}
+          yarn e2e-widget -n "responsibleaidashboard-diabetes-regression-model-debugging" -f ${{ matrix.flights }}
+          yarn e2e-widget -n "responsibleaidashboard-housing-decision-making" -f ${{ matrix.flights }}
+
+      - if: ${{ matrix.notebookGroup == 'nb_group_2'}}
+        name: Run widget tests
+        shell: bash -l {0}
+        run: |
+          yarn e2e-widget -n "responsibleaidashboard-housing-classification-model-debugging" -f ${{ matrix.flights }}
+          yarn e2e-widget -n "responsibleaidashboard-diabetes-decision-making" -f ${{ matrix.flights }}
+          yarn e2e-widget -n "responsibleaidashboard-multiclass-dnn-model-debugging" -f ${{ matrix.flights }}
 
       - name: Upload e2e test screen shot
         if: always()

--- a/scripts/e2e-widget.js
+++ b/scripts/e2e-widget.js
@@ -182,7 +182,7 @@ function writeCypressSettings(hosts) {
 
 function e2e(watch, selectedNotebook, flights) {
   const nxPath = path.join(__dirname, "../node_modules/@nrwl/cli/bin/nx.js");
-  console.log("Running e2e");
+  console.log(`Running e2e for notebook ${selectedNotebook}`);
   let notebookArgs = [];
   if (selectedNotebook) {
     // remove prefix "responsibleaidashboard"
@@ -243,9 +243,11 @@ async function main() {
   const skipgen = commander.opts().skipgen;
   const notebook = commander.opts().notebook;
   let flights = commander.opts().flights;
+  console.log("Checking flights: " + flights);
   if (flights?.toString() === "true") {
     // -f passed without arguments
     flights = undefined;
+    console.log("setting flights to undefined!!!");
   }
   checkIfAllNotebooksHaveTests();
   if (skipgen === undefined || !skipgen) {
@@ -253,7 +255,15 @@ async function main() {
   }
   const hosts = await runNotebooks(notebook);
   writeCypressSettings(hosts);
-  e2e(commander.opts().watch, notebook, flights);
+  for (var fileName of fileNames) {
+    if (notebook && fileName !== notebook) {
+      console.log(
+        `Skipping e2e for ${fileName}. Looking for ${notebook} only.`
+      );
+      continue;
+    }
+    e2e(commander.opts().watch, fileName, flights);
+  }
   process.exit(0);
 }
 


### PR DESCRIPTION
## Description

Fix e2e UI tests incorrectly running tests with flights when no notebook name specified and reduce number of test jobs.
1.) When the e2e UI tests are run without a notebook flag but with a flight, such as in the release build, we don't create a path filter that excludes the tests using flights, so we end up running all UI tests with all flights instead of just the ones for the specified flight, which leads to test failures.
2.) The number of notebook jobs is very high, but it seems that most of those jobs spend more time in the setup (eg 5-10 mins) than running the notebook itself (which varies from 2-8 minutes).  I think it's more prudent to reduce the number of jobs and compute used when we seem to be wasting most of the time in the setup, which could instead be run for multiple notebooks.  Hence, I created 2 groups of notebooks - so that we still parallelize the jobs but significantly reduce the number of jobs, especially since prior to this PR we spent more time in the setup code than running the notebook itself.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
