### PR TITLE
Remove strict pinnings from rai-core-flask requirements.txt.

### DIFF
--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -1,9 +1,9 @@
 Flask
 Flask-Cors
-ipython==7.16.3; python_version <= '3.6'
-ipython==7.31.1; python_version > '3.6'
-itsdangerous==2.0.1
-greenlet==1.1.2
-gevent==21.12.0
+ipython<=7.16.3; python_version <= '3.6'
+ipython>=7.31.1; python_version > '3.6'
+itsdangerous>=2.0.1
+greenlet>=1.1.2
+gevent>=21.12.0
 markupsafe<2.1.0
 Werkzeug<2.1.0


### PR DESCRIPTION
Hi!

We're working on making the `responsible-ai-toolbox` available on conda-forge. [We've noticed that the `rai-core-flask` package has very strict pinnings in its `install_requires`](https://github.com/conda-forge/staged-recipes/pull/19445#discussion_r924282764), making it difficult to install it with other packages in the same environment. [This is because the contents of the `requirements.txt` file are used to set the `install_requires` section in the `setup.py`.](https://github.com/microsoft/responsible-ai-toolbox/blob/e3d0f24166247e601a129cd437889600a500893b/rai_core_flask/setup.py#L41)

In this PR, we propose removing the strict pinnings (replacing `==` with `<=` or `>=`). We adjusted the pinnings to the best of our knowledge. Still, some changes might be incorrect, so please review this carefully.

If you agree with the proposed changes, it would be much appreciated if you could release of new version of `rai-core-flask`, so we can also loosen the strict pinnings in the conda-forge feedstock.

Thanks a lot for your help! 🙏 