### PR TITLE
update release workflows to include interpret-text npm package

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -197,6 +197,7 @@ jobs:
             counterfactuals,
             fairness,
             interpret,
+            interpret-text,
             localization,
             error-analysis,
             model-assessment,

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -227,6 +227,7 @@ jobs:
             counterfactuals,
             fairness,
             interpret,
+            interpret-text,
             localization,
             error-analysis,
             model-assessment


### PR DESCRIPTION
## Description

When updating to latest npm package, one of our developers hit an issue where interpret-text was not found.  This package is currently not in our release workflows.  It is possible this may cause UI issues in the 0.20.0 pypi release as well when the dashboard is visualized, so please keep an eye out for any issues that appear with that release.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
