### PR TITLE
add new interpret-vision library skeleton

### DIFF
--- a/libs/interpret-vision/.babelrc
+++ b/libs/interpret-vision/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@nrwl/react/babel"],
+  "plugins": []
+}

--- a/libs/interpret-vision/.eslintrc.json
+++ b/libs/interpret-vision/.eslintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "Please don't use bind. Prefer use arrow function.",
+            "selector": "MemberExpression > Identifier[name='bind']"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/interpret-vision/README.md
+++ b/libs/interpret-vision/README.md
@@ -1,0 +1,7 @@
+# interpret-vision
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test interpret-vision` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/interpret-vision/jest.config.js
+++ b/libs/interpret-vision/jest.config.js
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+module.exports = {
+  coverageDirectory: "../../coverage/libs/interpret-vision",
+  displayName: "interpret-vision",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "html"],
+  preset: "../../jest.preset.js",
+  transform: {
+    "^.+\\.[tj]sx?$": [
+      "babel-jest",
+      { configFile: "./babel-jest.config.json", cwd: __dirname }
+    ]
+  }
+};

--- a/libs/interpret-vision/package.json
+++ b/libs/interpret-vision/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@responsible-ai/interpret-vision",
+  "version": "0.0.0",
+  "license": "MIT"
+}

--- a/libs/interpret-vision/src/index.ts
+++ b/libs/interpret-vision/src/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export * from "./lib/InterpretVision";

--- a/libs/interpret-vision/src/lib/InterpretVision.tsx
+++ b/libs/interpret-vision/src/lib/InterpretVision.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from "react";
+
+export class IInterpretVisionProps {}
+
+export class InterpretVision extends React.Component<IInterpretVisionProps> {
+  public constructor(props: IInterpretVisionProps) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <h1>Welcome</h1>
+      </div>
+    );
+  }
+}

--- a/libs/interpret-vision/tsconfig.json
+++ b/libs/interpret-vision/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {},
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/interpret-vision/tsconfig.lib.json
+++ b/libs/interpret-vision/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.test.ts", "**/*.test.tsx"],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/interpret-vision/tsconfig.spec.json
+++ b/libs/interpret-vision/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -55,6 +55,9 @@
     "interpret-text": {
       "tags": []
     },
+    "interpret-vision": {
+      "tags": []
+    },
     "localization": {
       "tags": []
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -46,6 +46,9 @@
       "@responsible-ai/fairness": ["libs/fairness/src/index.ts"],
       "@responsible-ai/interpret": ["libs/interpret/src/index.ts"],
       "@responsible-ai/interpret-text": ["libs/interpret-text/src/index.ts"],
+      "@responsible-ai/interpret-vision": [
+        "libs/interpret-vision/src/index.ts"
+      ],
       "@responsible-ai/localization": ["libs/localization/src/index.ts"],
       "@responsible-ai/mlchartlib": ["libs/mlchartlib/src/index.ts"],
       "@responsible-ai/model-assessment": ["libs/model-assessment/src/index.ts"]

--- a/workspace.json
+++ b/workspace.json
@@ -703,6 +703,46 @@
         }
       }
     },
+    "interpret-vision": {
+      "root": "libs/interpret-vision",
+      "sourceRoot": "libs/interpret-vision/src",
+      "projectType": "library",
+      "architect": {
+        "build": {
+          "builder": "@nrwl/web:package",
+          "outputs": ["{options.outputPath}"],
+          "options": {
+            "outputPath": "dist/libs/interpret-vision",
+            "tsConfig": "libs/interpret-vision/tsconfig.lib.json",
+            "project": "libs/interpret-vision/package.json",
+            "entryFile": "libs/interpret-vision/src/index.ts",
+            "external": ["react/jsx-runtime"],
+            "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+            "assets": [
+              {
+                "glob": "libs/interpret-vision/README.md",
+                "input": ".",
+                "output": "."
+              }
+            ]
+          }
+        },
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/interpret-vision/**/*.{ts,tsx,js,jsx}"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/interpret-vision"],
+          "options": {
+            "jestConfig": "libs/interpret-vision/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
+    },
     "localization": {
       "root": "libs/localization",
       "sourceRoot": "libs/localization/src",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add skeleton library for interpret-vision component.
It will be part of the RAI vision dashboard.

This PR just sets up the skeleton framework. Most of the code was generated via:

nx generate @nrwl/react:library interpret-vision --publishable --importPath @responsible-ai/interpret-vision
and then files were overwritten based on other projects to be as similar as possible, after which yarn lintfix was applied.

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
