### PR TITLE
fix bug in treeview filtering logic in error analysis package

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -691,8 +691,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} <= {:.2f}".format(p_node_name,
                                                   parent_threshold)
-                filter_by_threshold(df, p_node_name_val,
-                                    parent_threshold, side)
+                df = filter_by_threshold(df, p_node_name_val,
+                                         parent_threshold, side)
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_INCLUDES
                 arg = create_categorical_arg(parent_threshold)
@@ -709,8 +709,8 @@ def node_to_dict(df, tree, nodeid, categories, json,
                 arg = float(parent_threshold)
                 condition = "{} > {:.2f}".format(p_node_name,
                                                  parent_threshold)
-                filter_by_threshold(df, p_node_name_val,
-                                    parent_threshold, side)
+                df = filter_by_threshold(df, p_node_name_val,
+                                         parent_threshold, side)
             elif parent_decision_type == '==':
                 method = CohortFilterMethods.METHOD_EXCLUDES
                 arg = create_categorical_arg(parent_threshold)

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '5'
+_patch = '6'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix bug introduced in recent PR:
https://github.com/microsoft/responsible-ai-toolbox/pull/1562
During refactoring of a method the filtering logic broke.  This PR fixes the filtering logic again and adds a test to validate the nodes from error analysis constructed json are the same size as the original lightgbm tree exported model file.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
