### PR TITLE
[ModelOverview] Fix bug- On choosing a specific feature cohort and trying to choose feature cohort again - dropdown has all cohorts selected

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyout.tsx
@@ -96,18 +96,7 @@ export class ChartConfigurationFlyout extends React.Component<
           errorCohort.cohort.name !==
           this.props.featureBasedCohorts[index].cohort.name
       );
-    const selectedFeatureBasedCohortsChanged =
-      (prevProps.selectedFeatureBasedCohorts === undefined &&
-        this.props.selectedFeatureBasedCohorts !== undefined) ||
-      (prevProps.selectedFeatureBasedCohorts &&
-        this.props.selectedFeatureBasedCohorts &&
-        (this.props.selectedFeatureBasedCohorts.length !==
-          prevProps.selectedFeatureBasedCohorts.length ||
-          prevProps.selectedFeatureBasedCohorts.some(
-            (num, index) =>
-              num !== this.props.selectedFeatureBasedCohorts?.[index]
-          )));
-    if (featureBasedCohortsChanged || selectedFeatureBasedCohortsChanged) {
+    if (featureBasedCohortsChanged) {
       newlySelectedFeatureBasedCohorts = this.props.featureBasedCohorts.map(
         (_, index) => index
       );


### PR DESCRIPTION
Signed-off-by: Ruby Zhu <zhenzhu@microsoft.com>

<!--- Provide a general summary of your changes in the Title above -->
This PR fix bug [Bug 1874154](https://msdata.visualstudio.com/Vienna/_workitems/edit/1874154): Model Overview: On choosing a specific feature cohort and trying to choose feature cohort again - dropdown has all cohorts selected
## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->
**Bug repro steps:**
1. select OS, job title under feature cohorts
2. Click on choose cohorts
3. select feature cohorts
4. deselect all, select one from list and confirm
5. click on choose cohorts
6. all feature cohorts are selected again by default

**Root cause:** 
The code try to compare if the selected feature changed or if the selected feature cohorts changed, then it set the selected cohort value with the whole feature cohorts list. Per my understanding, we only need to set the selected cohort with whole feature cohort when user select a new feature. 
**Fix:**
For selected feature cohorts, only update to the original whole feature cohort list when feature changed

**gif before fix**
![dropdownBF](https://user-images.githubusercontent.com/76190371/182726388-201c5f2c-32e1-4999-bbe9-3a164f7cba6b.gif)

**gif after fix**
![dropdownAF](https://user-images.githubusercontent.com/76190371/182726530-15b4b65c-beb9-4c44-bc83-e305d8f261ad.gif)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
