### PR TITLE
[ModelOverview]Fix bug- Model Overview: Clarification - Should state of 'use line chart' be persisted when switched from Probability -> Metrics -> Prob tab

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -69,6 +69,7 @@ interface IModelOverviewState {
   // and deliberately ignored cohorts for the chart section.
   maxCohortId: number;
   selectedMetric: string;
+  showSplineChart: boolean;
 }
 
 const datasetCohortViewPivotKey = "datasetCohortView";
@@ -96,7 +97,8 @@ export class ModelOverview extends React.Component<
       selectedFeaturesContinuousFeatureBins: {},
       selectedMetric: "",
       selectedMetrics: [],
-      showHeatmapColors: true
+      showHeatmapColors: true,
+      showSplineChart: false
     };
   }
 
@@ -481,6 +483,8 @@ export class ModelOverview extends React.Component<
                       onChooseCohorts={this.onChooseCohorts}
                       cohorts={chartCohorts}
                       telemetryHook={this.props.telemetryHook}
+                      onToggleChange={this.onSplineToggleChange}
+                      showSplineChart={this.state.showSplineChart}
                     />
                   </PivotItem>
                 )}
@@ -506,6 +510,10 @@ export class ModelOverview extends React.Component<
       </Stack>
     );
   }
+
+  private onSplineToggleChange = (checked: boolean) => {
+    this.setState({ showSplineChart: checked });
+  };
 
   private onClickMetricsConfiguration = () => {
     this.setState({ metricConfigurationIsVisible: true });

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionChart.tsx
@@ -29,7 +29,9 @@ import { ProbabilityDistributionSplineChart } from "./ProbabilityDistributionSpl
 
 interface IProbabilityDistributionChartProps {
   cohorts: ErrorCohort[];
+  showSplineChart: boolean;
   onChooseCohorts: () => void;
+  onToggleChange: (checked: boolean) => void;
   telemetryHook?: (message: ITelemetryEvent) => void;
 }
 
@@ -37,7 +39,6 @@ interface IProbabilityDistributionChartState {
   probabilityOption?: IChoiceGroupOption;
   newlySelectedProbabilityOption?: IChoiceGroupOption;
   probabilityFlyoutIsVisible: boolean;
-  showSplineChart: boolean;
 }
 
 export class ProbabilityDistributionChart extends React.Component<
@@ -50,7 +51,7 @@ export class ProbabilityDistributionChart extends React.Component<
 
   constructor(props: IProbabilityDistributionChartProps) {
     super(props);
-    this.state = { probabilityFlyoutIsVisible: false, showSplineChart: false };
+    this.state = { probabilityFlyoutIsVisible: false };
   }
 
   public componentDidMount(): void {
@@ -103,9 +104,10 @@ export class ProbabilityDistributionChart extends React.Component<
               }
               inlineLabel
               onChange={this.onSplineChartToggleChange}
+              checked={this.props.showSplineChart}
             />
           </Stack.Item>
-          {this.state.showSplineChart && (
+          {this.props.showSplineChart && (
             <DefaultButton
               id="modelOverviewProbabilityDistributionLineChartCohortSelectionButton"
               text={
@@ -116,7 +118,7 @@ export class ProbabilityDistributionChart extends React.Component<
           )}
         </Stack>
         <Stack horizontal>
-          {!noCohortSelected && !this.state.showSplineChart && (
+          {!noCohortSelected && !this.props.showSplineChart && (
             <Stack.Item className={classNames.verticalAxis}>
               <DefaultButton
                 id="modelOverviewProbabilityDistributionBoxChartCohortSelectionButton"
@@ -142,7 +144,7 @@ export class ProbabilityDistributionChart extends React.Component<
             )}
             {!noCohortSelected && (
               <Stack>
-                {this.state.showSplineChart ? (
+                {this.props.showSplineChart ? (
                   <ProbabilityDistributionSplineChart
                     selectedCohorts={this.props.cohorts}
                     probabilityOption={this.state.probabilityOption}
@@ -155,7 +157,7 @@ export class ProbabilityDistributionChart extends React.Component<
                 )}
                 <Stack.Item
                   className={
-                    this.state.showSplineChart
+                    this.props.showSplineChart
                       ? classNames.horizontalAxisNoExtraLeftPadding
                       : classNames.horizontalAxis
                   }
@@ -253,7 +255,7 @@ export class ProbabilityDistributionChart extends React.Component<
     checked?: boolean | undefined
   ) => {
     if (checked !== undefined) {
-      this.setState({ showSplineChart: checked });
+      this.props.onToggleChange(checked);
       this.props.telemetryHook?.({
         level: TelemetryLevels.ButtonClick,
         type: TelemetryEventName.ModelOverviewSplineChartToggleUpdated


### PR DESCRIPTION
Signed-off-by: Ruby Zhu <zhenzhu@microsoft.com>

<!--- Provide a general summary of your changes in the Title above -->
This PR fix bug  [Bug 1777738](https://msdata.visualstudio.com/Vienna/_workitems/edit/1777738): Model Overview: Clarification - Should state of 'use line chart' be persisted when switched from Probability -> Metrics -> Prob tab
## Description
Problem:
Should state of 'use line chart' be persisted when switched from Probability -> Metrics -> Prob tab
<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->
gif before fix
![toggleB](https://user-images.githubusercontent.com/76190371/182738039-9b903fdf-60e2-485f-b9cc-f28739fb5592.gif)

gif after fix
![toggleA](https://user-images.githubusercontent.com/76190371/182738046-31455ffb-1ed1-4c84-8fb3-b342ef3f197d.gif)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
