### PR TITLE
design updates for the RAI text dashboard local importances view

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.styles.ts
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.styles.ts
@@ -7,17 +7,10 @@ import {
   IProcessedStyleSet,
   getTheme
 } from "@fluentui/react";
-import {
-  getPrimaryBackgroundChartColor,
-  getPrimaryChartColor
-} from "@responsible-ai/core-ui";
 
 export interface ITextExplanationDashboardStyles {
   chartRight: IStyle;
   textHighlighting: IStyle;
-  legend: IStyle;
-  posFeatureImportance: IStyle;
-  negFeatureImportance: IStyle;
 }
 
 export const textExplanationDashboardStyles: () => IProcessedStyleSet<ITextExplanationDashboardStyles> =
@@ -27,17 +20,6 @@ export const textExplanationDashboardStyles: () => IProcessedStyleSet<ITextExpla
       chartRight: {
         maxWidth: "230px",
         minWidth: "230px"
-      },
-      legend: {
-        color: theme.semanticColors.disabledText
-      },
-      negFeatureImportance: {
-        color: getPrimaryChartColor(theme),
-        textDecorationLine: "underline"
-      },
-      posFeatureImportance: {
-        backgroundColor: getPrimaryChartColor(theme),
-        color: getPrimaryBackgroundChartColor(theme)
       },
       textHighlighting: {
         borderColor: theme.semanticColors.variantBorder,

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
@@ -5,7 +5,6 @@ import {
   ChoiceGroup,
   IChoiceGroupOption,
   IStackTokens,
-  Label,
   Slider,
   Stack,
   Text
@@ -18,6 +17,7 @@ import React from "react";
 import { RadioKeys, Utils } from "../../CommonUtils";
 import { ITextExplanationViewProps } from "../../Interfaces/IExplanationViewProps";
 import { BarChart } from "../BarChart/BarChart";
+import { TextFeatureLegend } from "../TextFeatureLegend/TextFeatureLegend";
 import { TextHighlighting } from "../TextHighlighting/TextHightlighting";
 
 import { textExplanationDashboardStyles } from "./TextExplanationView.styles";
@@ -37,19 +37,14 @@ const options: IChoiceGroupOption[] = [
   /*
    * Creates the choices for the radio button
    */
-  { key: RadioKeys.All, text: localization.InterpretText.Dashboard.allButton },
-  { key: RadioKeys.Pos, text: localization.InterpretText.Dashboard.posButton },
-  { key: RadioKeys.Neg, text: localization.InterpretText.Dashboard.negButton }
+  { key: RadioKeys.All, text: localization.InterpretText.View.allButton },
+  { key: RadioKeys.Pos, text: localization.InterpretText.View.posButton },
+  { key: RadioKeys.Neg, text: localization.InterpretText.View.negButton }
 ];
 
 const componentStackTokens: IStackTokens = {
   childrenGap: "m",
   padding: "m"
-};
-
-const legendStackTokens: IStackTokens = {
-  childrenGap: "m",
-  padding: "s"
 };
 
 export class TextExplanationView extends React.PureComponent<
@@ -89,23 +84,22 @@ export class TextExplanationView extends React.PureComponent<
     const classNames = textExplanationDashboardStyles();
     return (
       <Stack>
-        <Stack tokens={componentStackTokens}>
-          <Stack.Item>
-            <Slider
-              min={1}
-              max={this.state.maxK}
-              step={1}
-              defaultValue={this.state.topK}
-              showValue={false}
-              onChange={this.setTopK}
+        <Stack tokens={componentStackTokens} horizontal>
+          <Stack.Item
+            align="stretch"
+            grow
+            disableShrink
+            className={classNames.textHighlighting}
+          >
+            <TextHighlighting
+              text={this.state.text}
+              localExplanations={this.state.importances}
+              topK={this.state.topK}
+              radio={this.state.radio}
             />
           </Stack.Item>
-          <Stack.Item align="center">
-            <Text variant={"large"}>
-              {`${this.state.topK.toString()} ${
-                localization.InterpretText.Dashboard.importantWords
-              }`}
-            </Text>
+          <Stack.Item align="end">
+            <TextFeatureLegend />
           </Stack.Item>
         </Stack>
         <Stack tokens={componentStackTokens} horizontal>
@@ -121,12 +115,29 @@ export class TextExplanationView extends React.PureComponent<
             <Stack tokens={componentStackTokens}>
               <Stack.Item>
                 <Text variant={"xLarge"}>
-                  {localization.InterpretText.Dashboard.label +
-                    localization.InterpretText.Dashboard.colon +
+                  {localization.InterpretText.View.label +
+                    localization.InterpretText.View.colon +
                     Utils.predictClass(
                       this.props.dataSummary.classNames!,
                       this.props.dataSummary.prediction!
                     )}
+                </Text>
+              </Stack.Item>
+              <Stack.Item>
+                <Slider
+                  min={1}
+                  max={this.state.maxK}
+                  step={1}
+                  defaultValue={this.state.topK}
+                  showValue={false}
+                  onChange={this.setTopK}
+                />
+              </Stack.Item>
+              <Stack.Item align="center">
+                <Text variant={"large"}>
+                  {`${this.state.topK.toString()} ${
+                    localization.InterpretText.View.importantWords
+                  }`}
                 </Text>
               </Stack.Item>
               <Stack.Item>
@@ -147,61 +158,8 @@ export class TextExplanationView extends React.PureComponent<
               </Stack.Item>
               <Stack.Item>
                 <Text variant={"small"}>
-                  {localization.InterpretText.Dashboard.legendText}
+                  {localization.InterpretText.View.legendText}
                 </Text>
-              </Stack.Item>
-            </Stack>
-          </Stack.Item>
-        </Stack>
-        <Stack tokens={componentStackTokens} horizontal>
-          <Stack.Item
-            grow
-            disableShrink
-            className={classNames.textHighlighting}
-          >
-            <TextHighlighting
-              text={this.state.text}
-              localExplanations={this.state.importances}
-              topK={this.state.topK}
-              radio={this.state.radio}
-            />
-          </Stack.Item>
-          <Stack.Item grow>
-            <Stack tokens={componentStackTokens}>
-              <Stack.Item>
-                <Text variant={"large"} className={classNames.legend}>
-                  {localization.InterpretText.Dashboard.featureLegend}
-                </Text>
-              </Stack.Item>
-              <Stack.Item>
-                <Stack horizontal tokens={legendStackTokens}>
-                  <Stack.Item align="center">
-                    <Label className={classNames.posFeatureImportance}>A</Label>
-                  </Stack.Item>
-                  <Stack.Item align="center">
-                    <Text>
-                      {
-                        localization.InterpretText.Dashboard
-                          .posFeatureImportance
-                      }
-                    </Text>
-                  </Stack.Item>
-                </Stack>
-              </Stack.Item>
-              <Stack.Item>
-                <Stack horizontal tokens={legendStackTokens}>
-                  <Stack.Item align="center">
-                    <Label className={classNames.negFeatureImportance}>A</Label>
-                  </Stack.Item>
-                  <Stack.Item align="center">
-                    <Text>
-                      {
-                        localization.InterpretText.Dashboard
-                          .negFeatureImportance
-                      }
-                    </Text>
-                  </Stack.Item>
-                </Stack>
               </Stack.Item>
             </Stack>
           </Stack.Item>

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextFeatureLegend/TextFeatureLegend.styles.ts
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextFeatureLegend/TextFeatureLegend.styles.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme
+} from "@fluentui/react";
+import {
+  getPrimaryBackgroundChartColor,
+  getPrimaryChartColor
+} from "@responsible-ai/core-ui";
+
+export interface ITextFeatureLegendStyles {
+  legend: IStyle;
+  negFeatureImportance: IStyle;
+  posFeatureImportance: IStyle;
+}
+
+export const textFeatureLegendStyles: () => IProcessedStyleSet<ITextFeatureLegendStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<ITextFeatureLegendStyles>({
+      legend: {
+        color: theme.semanticColors.disabledText
+      },
+      negFeatureImportance: {
+        color: getPrimaryChartColor(theme),
+        textDecorationLine: "underline"
+      },
+      posFeatureImportance: {
+        backgroundColor: getPrimaryChartColor(theme),
+        color: getPrimaryBackgroundChartColor(theme)
+      }
+    });
+  };

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextFeatureLegend/TextFeatureLegend.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextFeatureLegend/TextFeatureLegend.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Label, Text, Stack, IStackTokens } from "@fluentui/react";
+import { localization } from "@responsible-ai/localization";
+import React from "react";
+
+import { textFeatureLegendStyles } from "./TextFeatureLegend.styles";
+
+const componentStackTokens: IStackTokens = {
+  childrenGap: "m",
+  padding: "m"
+};
+
+const legendStackTokens: IStackTokens = {
+  childrenGap: "m",
+  padding: "s"
+};
+
+export class TextFeatureLegend extends React.Component {
+  public render(): React.ReactNode {
+    const classNames = textFeatureLegendStyles();
+    return (
+      <Stack tokens={componentStackTokens}>
+        <Stack.Item>
+          <Text variant={"large"} className={classNames.legend}>
+            {localization.InterpretText.Legend.featureLegend}
+          </Text>
+        </Stack.Item>
+        <Stack.Item>
+          <Stack horizontal tokens={legendStackTokens}>
+            <Stack.Item align="center">
+              <Label className={classNames.posFeatureImportance}>A</Label>
+            </Stack.Item>
+            <Stack.Item align="center">
+              <Text>
+                {localization.InterpretText.Legend.posFeatureImportance}
+              </Text>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <Stack horizontal tokens={legendStackTokens}>
+            <Stack.Item align="center">
+              <Label className={classNames.negFeatureImportance}>A</Label>
+            </Stack.Item>
+            <Stack.Item align="center">
+              <Text>
+                {localization.InterpretText.Legend.negFeatureImportance}
+              </Text>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+      </Stack>
+    );
+  }
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1261,19 +1261,21 @@
     "summaryImportance": "Summary importance"
   },
   "InterpretText": {
-    "Dashboard": {
+    "View": {
       "interpretibilityDashboard": "Interpretability Dashboard",
       "importantWords": "Most Important Words",
       "topFeatureList": "Top feature list analysis",
       "allButton": "ALL FEATURES",
       "negButton": "NEGATIVE FEATURES",
       "posButton": "POSITIVE FEATURES",
-      "featureLegend": "TEXT FEATURE LEGEND",
-      "posFeatureImportance": "POSITIVE FEATURE IMPORTANCE",
-      "negFeatureImportance": "NEGATIVE FEATURE IMPORTANCE",
       "legendText": "Positive scalar feature importances represents the extent that the word was important towards the classification of your selected label, and negative scalar feature importances represents words that encouraged your model away from your selected label.",
       "label": "Label",
       "colon": ": "
+    },
+    "Legend": {
+      "featureLegend": "TEXT FEATURE LEGEND",
+      "posFeatureImportance": "POSITIVE FEATURE IMPORTANCE",
+      "negFeatureImportance": "NEGATIVE FEATURE IMPORTANCE"
     },
     "BarChart": {
       "featureImportance": "FEATURE IMPORTANCE"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Design updates for the local importances view based on new figma:
- Move text section to top
- Move slidebar for top most important words to the side
- Some refactoring of legend to separate file and localization updates

Before:
![image](https://user-images.githubusercontent.com/24683184/182937252-0f08148b-dc4d-4723-940c-9937b626ca1f.png)

After:
![image](https://user-images.githubusercontent.com/24683184/182874805-d60a24c8-b363-454f-940a-3b473b1b60c0.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
