### PR TITLE
Inject FeatureMetadata into RAIInsights

### DIFF
--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class TaskType(str, Enum):
@@ -20,6 +20,7 @@ class Dataset:
     class_names: List[str]
     categorical_features: List[str]
     target_column: str
+    feature_metadata: Optional[Dict[str, Any]]
     data_balance_measures: Dict[str, Any]
 
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -95,6 +95,10 @@ class RAIInsights(RAIBaseInsights):
         :param maximum_rows_for_test: Limit on size of test data
             (for performance reasons)
         :type maximum_rows_for_test: int
+        :param feature_metadata: Feature metadata for the train/test
+                                 dataset to identify different kinds
+                                 of features in the dataset.
+        :type feature_metadata: FeatureMetadata
         """
         categorical_features = categorical_features or []
         self._validate_rai_insights_input_parameters(

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -17,6 +17,7 @@ from raiutils.models import SKLearn, is_classifier
 from responsibleai._interfaces import Dataset, RAIInsightsData
 from responsibleai._internal.constants import ManagerNames, Metadata
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.feature_metadata import FeatureMetadata
 from responsibleai.managers.causal_manager import CausalManager
 from responsibleai.managers.counterfactual_manager import CounterfactualManager
 from responsibleai.managers.data_balance_manager import DataBalanceManager
@@ -31,6 +32,7 @@ _TARGET_COLUMN = 'target_column'
 _TASK_TYPE = 'task_type'
 _CLASSES = 'classes'
 _FEATURE_COLUMNS = 'feature_columns'
+_FEATURE_METADATA = 'feature_metadata'
 _FEATURE_RANGES = 'feature_ranges'
 _CATEGORICAL_FEATURES = 'categorical_features'
 _META_JSON = Metadata.META_JSON
@@ -57,7 +59,8 @@ class RAIInsights(RAIBaseInsights):
                  categorical_features: Optional[List[str]] = None,
                  classes: Optional[np.ndarray] = None,
                  serializer: Optional[Any] = None,
-                 maximum_rows_for_test: int = 5000):
+                 maximum_rows_for_test: int = 5000,
+                 feature_metadata: Optional[FeatureMetadata] = None):
         """Creates an RAIInsights object.
         :param model: The model to compute RAI insights for.
             A model that implements sklearn.predict or sklearn.predict_proba
@@ -105,6 +108,8 @@ class RAIInsights(RAIBaseInsights):
         self._feature_ranges = RAIInsights._get_feature_ranges(
             test=test, categorical_features=categorical_features,
             feature_columns=self._feature_columns)
+        self._feature_metadata = feature_metadata
+
         self.categorical_features = categorical_features
 
         super(RAIInsights, self).__init__(
@@ -178,7 +183,8 @@ class RAIInsights(RAIBaseInsights):
             target_column: str, task_type: str,
             categorical_features: List[str], classes: np.ndarray,
             serializer,
-            maximum_rows_for_test: int):
+            maximum_rows_for_test: int,
+            feature_metadata: Optional[FeatureMetadata] = None):
         """Validate the inputs for the RAIInsights constructor.
 
         :param model: The model to compute RAI insights for.
@@ -364,6 +370,15 @@ class RAIInsights(RAIBaseInsights):
                 "Expecting pandas DataFrame for train and test."
             )
 
+        if feature_metadata is not None:
+            if not isinstance(feature_metadata, FeatureMetadata):
+                raise UserConfigValidationException(
+                    "Expecting type FeatureMetadata but got {0}".format(
+                        type(feature_metadata)))
+
+            feature_metadata.validate_feature_metadata_with_user_features(
+                list(train.columns))
+
     def _validate_features_same(self, small_train_features_before,
                                 small_train_data, function):
         """
@@ -437,6 +452,13 @@ class RAIInsights(RAIBaseInsights):
         dashboard_dataset.categorical_features = self.categorical_features
         dashboard_dataset.class_names = convert_to_list(
             self._classes)
+
+        if self._feature_metadata is not None:
+            dashboard_dataset.feature_metadata = \
+                self._feature_metadata.to_dict()
+        else:
+            dashboard_dataset.feature_metadata = None
+
         dashboard_dataset.data_balance_measures = \
             self._data_balance_manager.get_data()
 
@@ -557,14 +579,17 @@ class RAIInsights(RAIBaseInsights):
         """
         top_dir = Path(path)
         classes = convert_to_list(self._classes)
+        feature_metadata_dict = None
+        if self._feature_metadata is not None:
+            feature_metadata_dict = self._feature_metadata.to_dict()
         meta = {
             _TARGET_COLUMN: self.target_column,
             _TASK_TYPE: self.task_type,
             _CATEGORICAL_FEATURES: self.categorical_features,
             _CLASSES: classes,
             _FEATURE_COLUMNS: self._feature_columns,
-            _FEATURE_RANGES: self._feature_ranges
-
+            _FEATURE_RANGES: self._feature_ranges,
+            _FEATURE_METADATA: feature_metadata_dict
         }
         with open(top_dir / _META_JSON, 'w') as file:
             json.dump(meta, file)
@@ -622,6 +647,18 @@ class RAIInsights(RAIBaseInsights):
 
         inst.__dict__['_' + _FEATURE_COLUMNS] = meta[_FEATURE_COLUMNS]
         inst.__dict__['_' + _FEATURE_RANGES] = meta[_FEATURE_RANGES]
+        if meta[_FEATURE_METADATA] is None:
+            inst.__dict__['_' + _FEATURE_METADATA] = None
+        else:
+            inst.__dict__['_' + _FEATURE_METADATA] = FeatureMetadata(
+                identity_feature_name=meta[_FEATURE_METADATA][
+                    'identity_feature_name'],
+                datetime_features=meta[_FEATURE_METADATA][
+                    'datetime_features'],
+                categorical_features=meta[_FEATURE_METADATA][
+                    'categorical_features'],
+                dropped_features=meta[_FEATURE_METADATA][
+                    'dropped_features'],)
 
     @staticmethod
     def load(path):


### PR DESCRIPTION
## Description

This change adds passing of `FeatureMetadata` into `RAIInsights` class. The `FeatureMetadata` is also saved on the disk via the `save()` and loaded back into the memory via `RAIInsights.load()`. The `FeatureMetadata` is also added to the `Datasets` interface in `_interfaces.py` so that the UI can make use of this data structure.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
