### PR TITLE
Move CalculateBoxPlot.test.tsx to core-ui

### DIFF
--- a/libs/core-ui/src/lib/util/CalculateBoxPlot.test.tsx
+++ b/libs/core-ui/src/lib/util/CalculateBoxPlot.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { calculateBoxPlotData, getPercentile } from "@responsible-ai/core-ui";
+import { calculateBoxPlotData, getPercentile } from "./calculateBoxData";
 
 describe("calculateBoxPlot", () => {
   it.each`


### PR DESCRIPTION
## Description

Seems like current location of the test file is misplaced. Running the tests in CalculateBoxPlot.test.tsx doesn't contribute to code in calculateBoxData.ts. Hence, moving this file to core-ui.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
