### PR TITLE
fix error analysis predictions analyzer failing due to new filtering refactor

### DIFF
--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -34,14 +34,23 @@ def filter_from_cohort(analyzer, filters, composite_filters,
     :type include_original_columns_only: bool
     :rtype: pandas.DataFrame
     """
+    is_model_analyzer = hasattr(analyzer, MODEL)
+    model = None
+    pred_y = None
+
+    if is_model_analyzer:
+        model = analyzer.model
+    else:
+        pred_y = analyzer.pred_y
+
     filter_data_with_cohort = FilterDataWithCohortFilters(
-        model=analyzer.model,
+        model=model,
         dataset=analyzer.dataset,
         features=analyzer.feature_names,
         categorical_features=analyzer.categorical_features,
         categories=analyzer.categories,
         true_y=analyzer.true_y,
-        pred_y=analyzer.pred_y,
+        pred_y=pred_y,
         model_task=analyzer.model_task)
 
     return filter_data_with_cohort.filter_data_from_cohort(

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '7'
+_patch = '8'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Description

The simple scenario where only predictions and true labels are passed to error analysis dashboard is failing with the new released 0.3.7 version of erroranalysis package.  This is due to the new filtering refactor, where model does not exist for the simple scenario, but we are still trying to access it.  Supposedly our notebook tests should have caught this, but it seems because the dashboard python code is run on a separate thread the error doesn't actually lead to a notebook failure.  This PR fixes the logic and adds additional unit tests for the both the predictions analyzer and model analyzer cases.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
