### PR TITLE
Add extra space between Identity feature and the actual feature name

### DIFF
--- a/libs/counterfactuals/src/util/generatePlotlyProps.ts
+++ b/libs/counterfactuals/src/util/generatePlotlyProps.ts
@@ -182,7 +182,7 @@ function generateDataTrace(
           dictionary,
           jointDatasetFeatureName
         );
-        hovertemplate += `${localization.Common.identityFeature}(${metaIdentityFeature.label}): {point.customdata.ID}<br>`;
+        hovertemplate += `${localization.Common.identityFeature} (${metaIdentityFeature.label}): {point.customdata.ID}<br>`;
         rawIdentityFeature.forEach((val, index) => {
           if (metaIdentityFeature?.treatAsCategorical) {
             customdata[index].ID =


### PR DESCRIPTION
## Description

This is based on @imatiach-msft's comment https://github.com/microsoft/responsible-ai-toolbox/pull/1637/files/6dfdf14a889a4264b28d60529ff7a7151ea77cce#r945832160. So adding the extra space in counterfactual scatter plot.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
