### PR TITLE
 Add identity feature value to dataset explorer scatter plot

### DIFF
--- a/libs/dataset-explorer/src/lib/buildCustomData.ts
+++ b/libs/dataset-explorer/src/lib/buildCustomData.ts
@@ -71,6 +71,30 @@ export function buildCustomData(
         }
       });
     }
+    if (jointData.datasetMetaData?.featureMetaData?.identity_feature_name) {
+      const identityFeatureName =
+        jointData.datasetMetaData.featureMetaData?.identity_feature_name;
+
+      const jointDatasetFeatureName =
+        jointData.getJointDatasetFeatureName(identityFeatureName);
+
+      if (jointDatasetFeatureName) {
+        const rawIdentityFeatureData = cohort.unwrap(jointDatasetFeatureName);
+        rawIdentityFeatureData.forEach((val, index) => {
+          // If categorical, show string value in tooltip
+          if (jointData.metaDict[jointDatasetFeatureName]?.treatAsCategorical) {
+            customdata[index].ID =
+              jointData.metaDict[
+                jointDatasetFeatureName
+              ].sortedCategoricalValues?.[val];
+          } else {
+            customdata[index].ID = (val as number).toLocaleString(undefined, {
+              maximumFractionDigits: 3
+            });
+          }
+        });
+      }
+    }
     const indices = cohort.unwrap(JointDataset.IndexLabel, false);
     indices.forEach((absoluteIndex, i) => {
       customdata[i].AbsoluteIndex = absoluteIndex;

--- a/libs/dataset-explorer/src/lib/buildHoverTemplate.ts
+++ b/libs/dataset-explorer/src/lib/buildHoverTemplate.ts
@@ -13,6 +13,7 @@ export function buildHoverTemplate(
   jointData: JointDataset,
   chartProps: IGenericChartProps
 ): string {
+  console.log(jointData);
   let hovertemplate = "";
   const xName = jointData.metaDict[chartProps.xAxis.property].label;
   const yName = jointData.metaDict[chartProps.yAxis.property].label;
@@ -30,6 +31,19 @@ export function buildHoverTemplate(
           hovertemplate += `${yName}: %{customdata.Y}<br>`;
         } else {
           hovertemplate += `${yName}: %{y}<br>`;
+        }
+      }
+      if (jointData.datasetMetaData?.featureMetaData) {
+        const identityFeatureName =
+          jointData.datasetMetaData.featureMetaData?.identity_feature_name;
+    
+        if (identityFeatureName) {
+          const jointDatasetFeatureName =
+            jointData.getJointDatasetFeatureName(identityFeatureName);
+    
+          if (jointDatasetFeatureName) {
+            hovertemplate += `${localization.Common.identityFeature} (${identityFeatureName}): %{customdata.ID}<br>`;
+          }
         }
       }
       if (chartProps.colorAxis) {

--- a/libs/dataset-explorer/src/lib/buildHoverTemplate.ts
+++ b/libs/dataset-explorer/src/lib/buildHoverTemplate.ts
@@ -13,7 +13,6 @@ export function buildHoverTemplate(
   jointData: JointDataset,
   chartProps: IGenericChartProps
 ): string {
-  console.log(jointData);
   let hovertemplate = "";
   const xName = jointData.metaDict[chartProps.xAxis.property].label;
   const yName = jointData.metaDict[chartProps.yAxis.property].label;
@@ -31,19 +30,6 @@ export function buildHoverTemplate(
           hovertemplate += `${yName}: %{customdata.Y}<br>`;
         } else {
           hovertemplate += `${yName}: %{y}<br>`;
-        }
-      }
-      if (jointData.datasetMetaData?.featureMetaData) {
-        const identityFeatureName =
-          jointData.datasetMetaData.featureMetaData?.identity_feature_name;
-    
-        if (identityFeatureName) {
-          const jointDatasetFeatureName =
-            jointData.getJointDatasetFeatureName(identityFeatureName);
-    
-          if (jointDatasetFeatureName) {
-            hovertemplate += `${localization.Common.identityFeature} (${identityFeatureName}): %{customdata.ID}<br>`;
-          }
         }
       }
       if (chartProps.colorAxis) {

--- a/libs/dataset-explorer/src/lib/buildScatterTemplate.ts
+++ b/libs/dataset-explorer/src/lib/buildScatterTemplate.ts
@@ -28,6 +28,19 @@ export function buildScatterTemplate(
       hovertemplate += `${yName}: ${y}<br>`;
     }
   }
+  if (jointData.datasetMetaData?.featureMetaData) {
+    const identityFeatureName =
+      jointData.datasetMetaData.featureMetaData?.identity_feature_name;
+
+    if (identityFeatureName) {
+      const jointDatasetFeatureName =
+        jointData.getJointDatasetFeatureName(identityFeatureName);
+
+      if (jointDatasetFeatureName) {
+        hovertemplate += `${localization.Common.identityFeature} (${identityFeatureName}): ${customData.ID}<br>`;
+      }
+    }
+  }
   if (chartProps.colorAxis) {
     hovertemplate += `${
       jointData.metaDict[chartProps.colorAxis.property].label


### PR DESCRIPTION
## Description

 Add identity feature value to dataset explorer scatter plot.

## Checklist

Screenshot
![image](https://user-images.githubusercontent.com/47334368/184991651-8cfcb303-1e44-4fa4-b427-7e467f6d8cfe.png)


<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
