### PR TITLE
[Accessibility] Add headings & change counterfactual text color

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualList.styles.ts
+++ b/libs/counterfactuals/src/lib/CounterfactualList.styles.ts
@@ -32,7 +32,7 @@ export const counterfactualListStyle: () => IProcessedStyleSet<ICounterfactualLi
         }
       },
       editCell: {
-        color: theme.palette.green,
+        color: theme.semanticColors.bodyText,
         fontWeight: "bold"
       },
       highlightRow: {

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/MainMenu.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/MainMenu.tsx
@@ -181,7 +181,7 @@ export class MainMenu extends React.PureComponent<
           // cursor should not change when hovering because we don't want users to think that something will happen if they click
           styles={{ rootHovered: { cursor: "default" } }}
         >
-          {cohortInfoTitle}
+          <h2>{cohortInfoTitle}</h2>
         </CommandButton>
       </TooltipHost>
     );

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -124,7 +124,7 @@ export class TabsView extends React.PureComponent<
               {t.key === GlobalTabKeys.ErrorAnalysisTab &&
                 this.props.errorAnalysisData?.[0] && (
                   <>
-                    <div
+                    <h3
                       className={classNames.sectionHeader}
                       id="errorAnalysisHeader"
                     >
@@ -134,7 +134,7 @@ export class TabsView extends React.PureComponent<
                             .ErrorAnalysis
                         }
                       </Text>
-                    </div>
+                    </h3>
                     <ErrorAnalysisViewTab
                       disabledView={disabledView}
                       tree={this.props.errorAnalysisData[0].tree}
@@ -175,14 +175,14 @@ export class TabsView extends React.PureComponent<
                 )}
               {t.key === GlobalTabKeys.ModelOverviewTab && (
                 <>
-                  <div className={classNames.sectionHeader}>
+                  <h3 className={classNames.sectionHeader}>
                     <Text variant={"xxLarge"} id="modelStatisticsHeader">
                       {
                         localization.ModelAssessment.ComponentNames
                           .ModelOverview
                       }
                     </Text>
-                  </div>
+                  </h3>
                   <ModelOverview
                     showNewModelOverviewExperience={isFlightActive(
                       newModelOverviewExperienceFlight,
@@ -211,14 +211,14 @@ export class TabsView extends React.PureComponent<
               {t.key === GlobalTabKeys.FeatureImportancesTab &&
                 this.props.modelExplanationData?.[0] && (
                   <>
-                    <div className={classNames.sectionHeader}>
+                    <h3 className={classNames.sectionHeader}>
                       <Text variant={"xxLarge"} id="featureImportanceHeader">
                         {
                           localization.ModelAssessment.ComponentNames
                             .FeatureImportances
                         }
                       </Text>
-                    </div>
+                    </h3>
                     <FeatureImportancesTab
                       modelMetadata={this.props.modelMetadata}
                       modelExplanationData={this.props.modelExplanationData}
@@ -234,7 +234,7 @@ export class TabsView extends React.PureComponent<
               {t.key === GlobalTabKeys.CausalAnalysisTab &&
                 this.props.causalAnalysisData?.[0] && (
                   <>
-                    <div
+                    <h3
                       className={classNames.sectionHeader}
                       id="causalAnalysisHeader"
                     >
@@ -244,7 +244,7 @@ export class TabsView extends React.PureComponent<
                             .CausalAnalysis
                         }
                       </Text>
-                    </div>
+                    </h3>
                     <CausalInsightsTab
                       data={this.props.causalAnalysisData?.[0]}
                       telemetryHook={this.props.telemetryHook}
@@ -255,14 +255,14 @@ export class TabsView extends React.PureComponent<
               {t.key === GlobalTabKeys.CounterfactualsTab &&
                 this.props.counterfactualData?.[0] && (
                   <>
-                    <div className={classNames.sectionHeader}>
+                    <h3 className={classNames.sectionHeader}>
                       <Text variant={"xxLarge"}>
                         {
                           localization.ModelAssessment.ComponentNames
                             .Counterfactuals
                         }
                       </Text>
-                    </div>
+                    </h3>
                     <CounterfactualsTab
                       data={this.props.counterfactualData?.[0]}
                       telemetryHook={this.props.telemetryHook}


### PR DESCRIPTION
Signed-off-by: Ruby Zhu <zhenzhu@microsoft.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

This PR fix two bugs:
[Bug 1919769](https://msdata.visualstudio.com/Vienna/_workitems/edit/1919769): A11yUsable - Counterfactuals - bold green sections in the table would be less clear to a color blind user

Before fix:
![image](https://user-images.githubusercontent.com/76190371/184992921-022f187f-ca0b-49aa-a37c-baf3138bbdbe.png)

After fix:
![image](https://user-images.githubusercontent.com/76190371/184992864-d1811f6b-9ba8-402b-90ed-714ffdf37f48.png)


[Bug 1919775](https://msdata.visualstudio.com/Vienna/_workitems/edit/1919775): A11yMAS - Headings should be used to convey structure and help screen readers navigate

Before fix:
![image](https://user-images.githubusercontent.com/76190371/184992647-82b20b23-4859-4b76-97a9-d0ae99f456f4.png)
After fix:
![image](https://user-images.githubusercontent.com/76190371/184992712-47d9874a-6301-48a7-96c4-4cee0b9068ce.png)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
