### PR TITLE
fix failing RAI Insights test due to change in EA _string_ind_data type

### DIFF
--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -342,24 +342,15 @@ def validate_rai_insights(
     assert rai_insights.target_column == target_column
     assert rai_insights.task_type == task_type
     assert rai_insights.categorical_features == (categorical_features or [])
+    expected_length = 0
     if categorical_features is not None:
-        assert len(rai_insights.categorical_features) == \
-            len(categorical_features)
-        assert len(rai_insights._categories) == len(categorical_features)
-        assert len(rai_insights._categorical_indexes) == \
-            len(categorical_features)
-        assert len(rai_insights._category_dictionary) == \
-            len(categorical_features)
-        if len(categorical_features) == 0:
-            assert isinstance(rai_insights._string_ind_data, list)
-        else:
-            assert isinstance(rai_insights._string_ind_data, np.ndarray)
-    else:
-        assert len(rai_insights.categorical_features) == 0
-        assert len(rai_insights._categories) == 0
-        assert len(rai_insights._categorical_indexes) == 0
-        assert len(rai_insights._category_dictionary) == 0
-        assert isinstance(rai_insights._string_ind_data, list)
+        expected_length = len(categorical_features)
+    assert len(rai_insights.categorical_features) == expected_length
+    assert len(rai_insights._categories) == expected_length
+    assert len(rai_insights._categorical_indexes) == expected_length
+    assert len(rai_insights._category_dictionary) == expected_length
+    for ind_data in rai_insights._string_ind_data:
+        assert len(ind_data) == expected_length
 
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()


### PR DESCRIPTION
## Description

Fix failing RAI Insights test due to change in EA _string_ind_data type.
_string_ind_data used to be inconsistently either list or numpy array which was fixed in recent PR https://github.com/microsoft/responsible-ai-toolbox/pull/1617 , however the test in RAIInsights [test_rai_insights.py](https://github.com/microsoft/responsible-ai-toolbox/compare/ilmat/fix-failing-ea-test?expand=1#diff-0d456f28ad34578123400b42943282e30fa40cfc7c10aed2bb5671975cce040b) file is incorrectly validating the type is list.
This test started failing in gated build after the release of erroranalysis 0.3.9 to pypi.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
