### PR TITLE
add mini-table to feature importances view

### DIFF
--- a/libs/dataset-explorer/src/index.ts
+++ b/libs/dataset-explorer/src/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./lib/DatasetExplorerTab";
 export * from "./lib/DataAnalysisTab";
+export * from "./lib/TableView/TableView";

--- a/libs/dataset-explorer/src/lib/DataAnalysisTab.tsx
+++ b/libs/dataset-explorer/src/lib/DataAnalysisTab.tsx
@@ -15,7 +15,7 @@ import React from "react";
 import { dataAnalysisTabStyles } from "./DataAnalysisTab.styles";
 import { DataBalanceTab } from "./DataBalanceTab";
 import { DatasetExplorerTab } from "./DatasetExplorerTab";
-import { TableView } from "./TableView/TableView";
+import { TableViewTab } from "./TableView/TableViewTab";
 
 interface IDataAnalysisTabProps {
   onAllSelectedItemsChange: (allSelectedItems: IObjectWithKey[]) => void;
@@ -50,7 +50,7 @@ export class DataAnalysisTab extends React.Component<IDataAnalysisTabProps> {
           itemKey={DataAnalysisTabOptions.TableView}
           headerText={localization.ModelAssessment.ComponentNames.TableView}
         >
-          <TableView
+          <TableViewTab
             features={this.context.modelMetadata.featureNames}
             jointDataset={this.context.jointDataset}
             selectedCohort={this.context.selectedErrorCohort}

--- a/libs/dataset-explorer/src/lib/TableView/TableView.styles.ts
+++ b/libs/dataset-explorer/src/lib/TableView/TableView.styles.ts
@@ -7,14 +7,13 @@ import {
   IStyle,
   mergeStyleSets
 } from "@fluentui/react";
-import { descriptionMaxWidth, hideXlDown } from "@responsible-ai/core-ui";
 
 export interface ITableViewStyles {
   chevronButton: IStyle;
+  detailsList: IStyle;
   header: IStyle;
   headerCount: IStyle;
   headerTitle: IStyle;
-  infoWithText: IStyle;
   selectionCounter: IStyle;
   tabularDataView: IStyle;
 }
@@ -27,6 +26,10 @@ export const tableViewStyles: () => IProcessedStyleSet<ITableViewStyles> =
         marginLeft: 48,
         paddingTop: 6,
         width: 36
+      },
+      detailsList: {
+        height: "500px",
+        position: "relative"
       },
       header: {
         margin: `8px 0`,
@@ -48,11 +51,6 @@ export const tableViewStyles: () => IProcessedStyleSet<ITableViewStyles> =
           paddingTop: 4
         }
       ],
-      infoWithText: {
-        maxWidth: descriptionMaxWidth,
-        paddingLeft: 25,
-        ...hideXlDown
-      },
       selectionCounter: {
         paddingLeft: 25,
         paddingTop: 12

--- a/libs/dataset-explorer/src/lib/TableView/TableView.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableView.tsx
@@ -8,8 +8,10 @@ import {
   Fabric,
   IGroup,
   MarqueeSelection,
+  mergeStyles,
   ScrollablePane,
   ScrollbarVisibility,
+  SelectAllVisibility,
   Selection,
   SelectionMode,
   Stack,
@@ -30,10 +32,15 @@ import { localization } from "@responsible-ai/localization";
 import React from "react";
 
 import { tableViewStyles } from "./TableView.styles";
-import { onRenderDetailsHeader } from "./TableViewDetailsHeader";
+import { generateOnRenderDetailsHeader } from "./TableViewDetailsHeader";
 import { onRenderGroupHeader } from "./TableViewGroupHeader";
 import { ITableViewProps } from "./TableViewProps";
 import { IITableViewState, ITableViewTableState } from "./TableViewState";
+
+// Constants related to table view height, which should change in mini-view with num rows
+const headerHeight = 80;
+const rowHeight = 44;
+const maxHeight = 500;
 
 export class TableView extends React.Component<
   ITableViewProps,
@@ -42,16 +49,22 @@ export class TableView extends React.Component<
   public static contextType = ModelAssessmentContext;
   public context: React.ContextType<typeof ModelAssessmentContext> =
     defaultModelAssessmentContext;
-  private readonly maxSelectable = 5;
-
+  private readonly maxSelectableTabular = 5;
+  private readonly maxSelectableText = 1;
   private selection: Selection = new Selection({
     onSelectionChanged: (): void => {
       const c = this.selection.getSelectedCount();
       const indices = this.selection.getSelectedIndices();
-      if (c === this.maxSelectable) {
+      const hasTextImportances =
+        !!this.context.modelExplanationData?.precomputedExplanations
+          ?.textFeatureImportance;
+      const maxSelectable = hasTextImportances
+        ? this.maxSelectableText
+        : this.maxSelectableTabular;
+      if (c === maxSelectable) {
         this.setState({ selectedIndices: indices });
       }
-      if (c > this.maxSelectable) {
+      if (c > maxSelectable) {
         for (const index of indices) {
           if (!this.state.selectedIndices.includes(index)) {
             this.setState({ indexToUnselect: index });
@@ -70,17 +83,39 @@ export class TableView extends React.Component<
     super(props);
 
     const tableState = this.updateItems();
+    const selectedIndices: number[] = [];
 
     this.state = {
       indexToUnselect: undefined,
-      selectedIndices: [],
+      selectedIndices,
       ...tableState
     };
+
+    if (this.props.subsetSelectedItems) {
+      this.selection.setItems(tableState.rows);
+      this.props.subsetSelectedItems.forEach((_, index) =>
+        this.selection.setIndexSelected(index, true, true)
+      );
+    }
   }
 
   public componentDidUpdate(prevProps: ITableViewProps): void {
-    if (this.props.selectedCohort !== prevProps.selectedCohort) {
-      this.setState(this.updateItems());
+    if (
+      this.props.selectedCohort !== prevProps.selectedCohort ||
+      this.props.subsetSelectedItems !== prevProps.subsetSelectedItems
+    ) {
+      const newItems = this.updateItems();
+      let selectedIndices = this.state.selectedIndices;
+      if (this.props.subsetSelectedItems) {
+        this.selection.setItems(newItems.rows);
+        selectedIndices = this.props.subsetSelectedItems.map(
+          (_, index) => index
+        );
+        selectedIndices.forEach((index) =>
+          this.selection.setIndexSelected(index, true, true)
+        );
+      }
+      this.setState(newItems, () => this.setState({ selectedIndices }));
     }
     if (this.state.indexToUnselect) {
       this.selection.toggleIndexSelected(this.state.indexToUnselect);
@@ -89,38 +124,58 @@ export class TableView extends React.Component<
   }
 
   public render(): React.ReactNode {
-    if (this.state.rows === undefined || this.state.columns === undefined) {
+    if (
+      this.state.rows === undefined ||
+      this.state.columns === undefined ||
+      this.state.rows.length === 0
+    ) {
       return React.Fragment;
     }
     const hasTextImportances =
       !!this.context.modelExplanationData?.precomputedExplanations
         ?.textFeatureImportance;
     const classNames = tableViewStyles();
+    let height = this.state.rows.length * rowHeight + headerHeight;
+    if (height > maxHeight) {
+      height = maxHeight;
+    }
+    let selectAllVisibility = SelectAllVisibility.hidden;
+    let selectionMode = SelectionMode.multiple;
+    if (hasTextImportances) {
+      if (this.props.subsetSelectedItems) {
+        selectAllVisibility = SelectAllVisibility.none;
+        selectionMode = SelectionMode.none;
+      } else {
+        selectionMode = SelectionMode.single;
+      }
+    }
     return (
-      <Stack tokens={{ padding: "l1" }}>
-        <Stack.Item className={classNames.infoWithText}>
-          <Text variant="medium">
-            {localization.ModelAssessment.FeatureImportances.IndividualFeature}
-          </Text>
-        </Stack.Item>
-        <Stack.Item className={classNames.selectionCounter}>
-          <LabelWithCallout
-            label={localization.formatString(
-              localization.ModelAssessment.FeatureImportances.SelectionCounter,
-              this.selection.count,
-              this.maxSelectable
-            )}
-            calloutTitle={undefined}
-            renderOnNewLayer
-            type="label"
-          >
-            <Text>
-              {localization.ModelAssessment.FeatureImportances.SelectionLimit}
-            </Text>
-          </LabelWithCallout>
-        </Stack.Item>
+      <Stack>
+        {!hasTextImportances && (
+          <Stack.Item className={classNames.selectionCounter}>
+            <LabelWithCallout
+              label={localization.formatString(
+                localization.ModelAssessment.FeatureImportances
+                  .SelectionCounter,
+                this.selection.count,
+                this.maxSelectableTabular
+              )}
+              calloutTitle={undefined}
+              renderOnNewLayer
+              type="label"
+            >
+              <Text>
+                {localization.ModelAssessment.FeatureImportances.SelectionLimit}
+              </Text>
+            </LabelWithCallout>
+          </Stack.Item>
+        )}
         <Stack.Item className={classNames.tabularDataView}>
-          <div style={{ height: "500px", position: "relative" }}>
+          <div
+            className={mergeStyles(classNames.detailsList, {
+              height: `${height.toString()}px`
+            })}
+          >
             <Fabric>
               <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
                 <MarqueeSelection selection={this.selection}>
@@ -131,7 +186,9 @@ export class TableView extends React.Component<
                     setKey="set"
                     layoutMode={DetailsListLayoutMode.fixedColumns}
                     constrainMode={ConstrainMode.unconstrained}
-                    onRenderDetailsHeader={onRenderDetailsHeader}
+                    onRenderDetailsHeader={generateOnRenderDetailsHeader(
+                      selectAllVisibility
+                    )}
                     selectionPreservedOnEmptyClick
                     ariaLabelForSelectionColumn={
                       localization.ModelAssessment.FeatureImportances
@@ -145,11 +202,7 @@ export class TableView extends React.Component<
                       onRenderHeader: onRenderGroupHeader,
                       showEmptyGroups: true
                     }}
-                    selectionMode={
-                      hasTextImportances
-                        ? SelectionMode.single
-                        : SelectionMode.multiple
-                    }
+                    selectionMode={selectionMode}
                     selection={this.selection}
                   />
                 </MarqueeSelection>
@@ -164,63 +217,68 @@ export class TableView extends React.Component<
   private updateItems(): ITableViewTableState {
     let groups: IGroup[] | undefined;
 
-    // assume classifier by default, otherwise regressor
-    if (
-      this.props.modelType &&
-      this.props.modelType === ModelTypes.Regression
-    ) {
-      // don't use groups since there are no correct/incorrect buckets
-      this.props.selectedCohort.cohort.sort();
+    let filteredDataRows: Array<{ [key: string]: number }> = [];
+    if (this.props.subsetSelectedItems) {
+      filteredDataRows = this.props.subsetSelectedItems.map((row) => {
+        return this.props.jointDataset.getRow(row[0]);
+      });
     } else {
-      this.props.selectedCohort.cohort.sortByGroup(
-        JointDataset.IndexLabel,
-        (row) =>
-          row[JointDataset.TrueYLabel] === row[JointDataset.PredictedYLabel]
-      );
-      // find first incorrect item
-      const firstIncorrectItemIndex =
-        this.props.selectedCohort.cohort.filteredData.findIndex(
+      // assume classifier by default, otherwise regressor
+      if (
+        this.props.modelType &&
+        this.props.modelType === ModelTypes.Regression
+      ) {
+        // don't use groups since there are no correct/incorrect buckets
+        this.props.selectedCohort.cohort.sort();
+      } else {
+        this.props.selectedCohort.cohort.sortByGroup(
+          JointDataset.IndexLabel,
           (row) =>
-            row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
+            row[JointDataset.TrueYLabel] === row[JointDataset.PredictedYLabel]
         );
-      const noIncorrectItem = firstIncorrectItemIndex === -1;
+        // find first incorrect item
+        const firstIncorrectItemIndex =
+          this.props.selectedCohort.cohort.filteredData.findIndex(
+            (row) =>
+              row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
+          );
+        const noIncorrectItem = firstIncorrectItemIndex === -1;
 
-      groups = [
-        {
-          count: noIncorrectItem
-            ? this.props.selectedCohort.cohort.filteredData.length
-            : firstIncorrectItemIndex,
-          isCollapsed: true,
-          key: "groupCorrect",
-          level: 0,
-          name: localization.ModelAssessment.FeatureImportances
-            .CorrectPredictions,
-          startIndex: 0
-        },
-        {
-          count: noIncorrectItem
-            ? 0
-            : this.props.selectedCohort.cohort.filteredData.length -
-              firstIncorrectItemIndex,
-          key: "groupIncorrect",
-          level: 0,
-          name: localization.ModelAssessment.FeatureImportances
-            .IncorrectPredictions,
-          startIndex: firstIncorrectItemIndex
-        }
-      ];
+        groups = [
+          {
+            count: noIncorrectItem
+              ? this.props.selectedCohort.cohort.filteredData.length
+              : firstIncorrectItemIndex,
+            isCollapsed: true,
+            key: "groupCorrect",
+            level: 0,
+            name: localization.ModelAssessment.FeatureImportances
+              .CorrectPredictions,
+            startIndex: 0
+          },
+          {
+            count: noIncorrectItem
+              ? 0
+              : this.props.selectedCohort.cohort.filteredData.length -
+                firstIncorrectItemIndex,
+            key: "groupIncorrect",
+            level: 0,
+            name: localization.ModelAssessment.FeatureImportances
+              .IncorrectPredictions,
+            startIndex: firstIncorrectItemIndex
+          }
+        ];
+      }
+      filteredDataRows = this.props.selectedCohort.cohort.filteredData;
     }
 
-    const cohortData = this.props.selectedCohort.cohort.filteredData;
-    const numRows: number = cohortData.length;
-    const indices = this.props.selectedCohort.cohort.filteredData.map(
-      (row: { [key: string]: number }) => {
-        return row[JointDataset.IndexLabel] as number;
-      }
-    );
+    const numRows: number = filteredDataRows.length;
+    const indices = filteredDataRows.map((row: { [key: string]: number }) => {
+      return row[JointDataset.IndexLabel] as number;
+    });
 
     const rows = constructRows(
-      cohortData,
+      filteredDataRows,
       this.props.jointDataset,
       numRows,
       () => false, // don't filter any items

--- a/libs/dataset-explorer/src/lib/TableView/TableViewDetailsHeader.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewDetailsHeader.tsx
@@ -6,26 +6,32 @@ import {
   IDetailsHeaderProps,
   IRenderFunction,
   SelectAllVisibility,
+  Stack,
   TooltipHost
 } from "@fluentui/react";
 import React from "react";
 
-export const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (
-  props,
-  defaultRender
-) => {
-  if (!props) {
-    return <div />;
-  }
-  const onRenderColumnHeaderTooltip: IRenderFunction<IDetailsColumnRenderTooltipProps> =
-    (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />;
-  return (
-    <div>
-      {defaultRender?.({
-        ...props,
-        onRenderColumnHeaderTooltip,
-        selectAllVisibility: SelectAllVisibility.hidden
-      })}
-    </div>
-  );
-};
+export function generateOnRenderDetailsHeader(
+  selectAllVisibility: SelectAllVisibility
+): IRenderFunction<IDetailsHeaderProps> {
+  const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (
+    props,
+    defaultRender
+  ) => {
+    if (!props) {
+      return <Stack />;
+    }
+    const onRenderColumnHeaderTooltip: IRenderFunction<IDetailsColumnRenderTooltipProps> =
+      (tooltipHostProps) => <TooltipHost {...tooltipHostProps} />;
+    return (
+      <Stack>
+        {defaultRender?.({
+          ...props,
+          onRenderColumnHeaderTooltip,
+          selectAllVisibility
+        })}
+      </Stack>
+    );
+  };
+  return onRenderDetailsHeader;
+}

--- a/libs/dataset-explorer/src/lib/TableView/TableViewProps.ts
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewProps.ts
@@ -15,5 +15,6 @@ export interface ITableViewProps {
   selectedCohort: ErrorCohort;
   modelType?: ModelTypes;
   onAllSelectedItemsChange: (allSelectedItems: IObjectWithKey[]) => void;
+  subsetSelectedItems?: IObjectWithKey[];
   telemetryHook?: (message: ITelemetryEvent) => void;
 }

--- a/libs/dataset-explorer/src/lib/TableView/TableViewTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewTab.styles.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IProcessedStyleSet, IStyle, mergeStyleSets } from "@fluentui/react";
+import { descriptionMaxWidth, hideXlDown } from "@responsible-ai/core-ui";
+
+export interface ITableViewTabStyles {
+  infoWithText: IStyle;
+}
+
+export const tableViewTabStyles: () => IProcessedStyleSet<ITableViewTabStyles> =
+  () => {
+    return mergeStyleSets({
+      infoWithText: {
+        maxWidth: descriptionMaxWidth,
+        paddingLeft: 25,
+        ...hideXlDown
+      }
+    });
+  };

--- a/libs/dataset-explorer/src/lib/TableView/TableViewTab.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewTab.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Stack, Text } from "@fluentui/react";
+import {
+  defaultModelAssessmentContext,
+  ModelAssessmentContext
+} from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+import React from "react";
+
+import { TableView } from "./TableView";
+import { ITableViewProps } from "./TableViewProps";
+import { tableViewTabStyles } from "./TableViewTab.styles";
+
+export class TableViewTab extends React.Component<ITableViewProps> {
+  public static contextType = ModelAssessmentContext;
+  public context: React.ContextType<typeof ModelAssessmentContext> =
+    defaultModelAssessmentContext;
+
+  public render(): React.ReactNode {
+    const hasTextImportances =
+      !!this.context.modelExplanationData?.precomputedExplanations
+        ?.textFeatureImportance;
+    const classNames = tableViewTabStyles();
+    return (
+      <Stack tokens={{ padding: "l1" }}>
+        <Stack.Item className={classNames.infoWithText}>
+          {!hasTextImportances && (
+            <Text variant="medium">
+              {
+                localization.ModelAssessment.FeatureImportances
+                  .IndividualFeatureTabular
+              }
+            </Text>
+          )}
+          {hasTextImportances && (
+            <Text variant="medium">
+              {
+                localization.ModelAssessment.FeatureImportances
+                  .IndividualFeatureText
+              }
+            </Text>
+          )}
+        </Stack.Item>
+        <Stack.Item>
+          <TableView
+            features={this.props.features}
+            jointDataset={this.props.jointDataset}
+            selectedCohort={this.props.selectedCohort}
+            modelType={this.props.modelType}
+            onAllSelectedItemsChange={this.props.onAllSelectedItemsChange}
+            telemetryHook={this.props.telemetryHook}
+          />
+        </Stack.Item>
+      </Stack>
+    );
+  }
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1569,12 +1569,17 @@
       "GlobalExplanation": "Aggregate feature importance",
       "IncorrectPredictions": "Incorrect predictions",
       "InfoTitle": "Additional information on data analysis table view",
-      "IndividualFeature": "Select a datapoint by clicking on a datapoint (up to 5 datapoints) in the table to view their local feature importance values (local explanation) and individual conditional expectation (ICE) plots.",
+      "IndividualFeatureTabular": "Select a datapoint by clicking on a datapoint (up to 5 datapoints) in the table to view their local feature importance values (local explanation) and individual conditional expectation (ICE) plots.",
+      "IndividualFeatureText": "Select a datapoint by clicking on a datapoint in the table to view the local feature importance values (local explanation).",
       "LocalExplanation": "Individual feature importance",
       "SelectionCounter": "{0}/{1} datapoints selected",
       "SelectionLimit": "Up to 5 datapoints can be selected at this time.",
       "RowCheckboxAriaLabel": "Row checkbox",
       "SelectionColumnAriaLabel": "Toggle selection"
+    },
+    "IndividualFeatureImportanceView": {
+      "SmallInstanceSelection": "Instance selection",
+      "SmallTableText": "(change instances to explain in data analysis)"
     },
     "MainMenu": {
       "DashboardSettings": "Dashboard configuration",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceState.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceState.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IObjectWithKey } from "@fluentui/react";
+
+export interface IIndividualFeatureImportanceState {
+  allSubsetSelectedItems: IObjectWithKey[];
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.styles.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  getTheme,
+  IStackTokens,
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet
+} from "@fluentui/react";
+
+export const verticalComponentTokens: IStackTokens = { padding: "l1" };
+export const horizontalComponentTokens: IStackTokens = {
+  childrenGap: "l1",
+  padding: `0px 0px 0px 25px`
+};
+
+export interface IIndividualFeatureImportanceViewStyles {
+  boldText: IStyle;
+}
+
+export const individualFeatureImportanceStyles: () => IProcessedStyleSet<IIndividualFeatureImportanceViewStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<IIndividualFeatureImportanceViewStyles>({
+      boldText: {
+        fontSize: theme.fonts.large.fontSize,
+        margin: "0px",
+        padding: 0
+      }
+    });
+  };

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.tsx
@@ -1,29 +1,70 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Stack } from "@fluentui/react";
+import { IObjectWithKey, Label, Stack, Text } from "@fluentui/react";
 import {
   defaultModelAssessmentContext,
   ModelAssessmentContext
 } from "@responsible-ai/core-ui";
+import { TableView } from "@responsible-ai/dataset-explorer";
+import { localization } from "@responsible-ai/localization";
 import React from "react";
 
 import { IIndividualFeatureImportanceProps } from "./IndividualFeatureImportanceProps";
+import { IIndividualFeatureImportanceState } from "./IndividualFeatureImportanceState";
+import {
+  horizontalComponentTokens,
+  individualFeatureImportanceStyles,
+  verticalComponentTokens
+} from "./IndividualFeatureImportanceView.styles";
 import { TabularLocalImportancePlots } from "./TabularLocalImportancePlots";
 import { TextLocalImportancePlots } from "./TextLocalImportancePlots";
 
-export class IndividualFeatureImportanceView extends React.Component<IIndividualFeatureImportanceProps> {
+export class IndividualFeatureImportanceView extends React.Component<
+  IIndividualFeatureImportanceProps,
+  IIndividualFeatureImportanceState
+> {
   public static contextType = ModelAssessmentContext;
   public context: React.ContextType<typeof ModelAssessmentContext> =
     defaultModelAssessmentContext;
+
+  public constructor(props: IIndividualFeatureImportanceProps) {
+    super(props);
+    this.state = {
+      allSubsetSelectedItems: []
+    };
+  }
 
   public render(): React.ReactNode {
     const hasTextImportances =
       !!this.context.modelExplanationData?.precomputedExplanations
         ?.textFeatureImportance;
-
+    const classNames = individualFeatureImportanceStyles();
     return (
-      <Stack tokens={{ padding: "l1" }}>
+      <Stack tokens={verticalComponentTokens}>
+        <Stack horizontal tokens={horizontalComponentTokens}>
+          <Label className={classNames.boldText}>
+            {
+              localization.ModelAssessment.IndividualFeatureImportanceView
+                .SmallInstanceSelection
+            }
+          </Label>
+          <Text variant="large">
+            {
+              localization.ModelAssessment.IndividualFeatureImportanceView
+                .SmallTableText
+            }
+          </Text>
+        </Stack>
+        <TableView
+          features={this.props.features}
+          jointDataset={this.props.jointDataset}
+          selectedCohort={this.props.selectedCohort}
+          modelType={this.props.modelType}
+          onAllSelectedItemsChange={this.onAllSubsetSelectedItemsChange}
+          telemetryHook={this.props.telemetryHook}
+          subsetSelectedItems={this.props.allSelectedItems}
+        />
         {!hasTextImportances && (
           <TabularLocalImportancePlots
             features={this.context.modelMetadata.featureNames}
@@ -35,7 +76,7 @@ export class IndividualFeatureImportanceView extends React.Component<IIndividual
             onWeightChange={this.props.onWeightChange}
             selectedCohort={this.context.selectedErrorCohort}
             modelType={this.props.modelType}
-            selectedItems={this.props.allSelectedItems}
+            selectedItems={this.state.allSubsetSelectedItems}
             telemetryHook={this.props.telemetryHook}
           />
         )}
@@ -52,4 +93,10 @@ export class IndividualFeatureImportanceView extends React.Component<IIndividual
       </Stack>
     );
   }
+
+  private onAllSubsetSelectedItemsChange = (
+    allSubsetSelectedItems: IObjectWithKey[]
+  ): void => {
+    this.setState({ allSubsetSelectedItems });
+  };
 }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/utils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/utils.ts
@@ -41,8 +41,17 @@ export function getInfo(
       body = localization.Interpret.DatasetExplorer.helperText;
       title = localization.Interpret.DatasetExplorer.infoTitle;
     } else if (dataAnalysisOption === DataAnalysisTabOptions.TableView) {
-      body = localization.ModelAssessment.FeatureImportances.IndividualFeature;
       title = localization.ModelAssessment.FeatureImportances.InfoTitle;
+      let hasTextImportances = false;
+      if (props?.modelExplanationData) {
+        hasTextImportances =
+          !!props.modelExplanationData[0]?.precomputedExplanations
+            ?.textFeatureImportance;
+      }
+      body = hasTextImportances
+        ? localization.ModelAssessment.FeatureImportances.IndividualFeatureText
+        : localization.ModelAssessment.FeatureImportances
+            .IndividualFeatureTabular;
     }
   } else if (tabKey === GlobalTabKeys.CausalAnalysisTab) {
     if (causalAnalysisOption === CausalAnalysisOptions.Aggregate) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a mini-table to the feature importances view for tabular and text scenarios.

Screenshot of mini-table in feature importances view from text scenario:

![image](https://user-images.githubusercontent.com/24683184/187824477-2536695c-65f0-4ef8-b9cd-b04e786514c3.png)

Screenshot of mini-table in feature importances view from tabular scenario:

![image](https://user-images.githubusercontent.com/24683184/187824566-d13f6894-0fd2-4247-b544-3dab09c58d12.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
