### PR TITLE
for RAI text dashboard, remove radio buttons and legend text when avg of abs value local importances selected

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
@@ -148,19 +148,23 @@ export class TextExplanationView extends React.PureComponent<
                   weightLabels={this.props.weightLabels}
                 />
               </Stack.Item>
-              <Stack.Item id="TextChoiceGroup">
-                <ChoiceGroup
-                  defaultSelectedKey="all"
-                  options={options}
-                  onChange={this.changeRadioButton}
-                  required
-                />
-              </Stack.Item>
-              <Stack.Item>
-                <Text variant={"small"}>
-                  {localization.InterpretText.View.legendText}
-                </Text>
-              </Stack.Item>
+              {this.props.selectedWeightVector !== WeightVectors.AbsAvg && (
+                <Stack.Item id="TextChoiceGroup">
+                  <ChoiceGroup
+                    defaultSelectedKey="all"
+                    options={options}
+                    onChange={this.changeRadioButton}
+                    required
+                  />
+                </Stack.Item>
+              )}
+              {this.props.selectedWeightVector !== WeightVectors.AbsAvg && (
+                <Stack.Item>
+                  <Text variant={"small"}>
+                    {localization.InterpretText.View.legendText}
+                  </Text>
+                </Stack.Item>
+              )}
             </Stack>
           </Stack.Item>
         </Stack>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

For the RAI text dashboard, the radio buttons to select positive/negative/all importances are not relevant when the option "Average of absolute value" is selected for class importance weights.  Hence, this PR removes those options to simplify the dashboard for users.

View of RAI text dashboard when "Average of absolute value" is selected:
![image](https://user-images.githubusercontent.com/24683184/187833644-089ba541-b682-4bfd-9b6f-40367a7e83c3.png)

View of RAI text dashboard when any class is selected:
![image](https://user-images.githubusercontent.com/24683184/187833710-d6c632dc-5b06-4223-91ae-34d8560177db.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
