### PR TITLE
Vision dashboard UI Fixups

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
@@ -4,10 +4,11 @@
 import {
   FocusZone,
   Stack,
-  DefaultButton,
   Image,
   IRectangle,
-  mergeStyles
+  mergeStyles,
+  Dropdown,
+  IDropdownOption
 } from "@fluentui/react";
 import { IVisionListItem } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
@@ -25,13 +26,34 @@ export interface IDataCharacteristicsProps {
 }
 export interface IDataCharacteristicsState {
   columnCount: number[];
-  items: Map<string, IVisionListItem[]>;
-  labels: string[];
-  labelVisibilities: Map<string, boolean>;
+  dropdownOptionsPredicted: IDropdownOption[];
+  dropdownOptionsTrue: IDropdownOption[];
+  itemsPredicted: Map<string, IVisionListItem[]>;
+  itemsTrue: Map<string, IVisionListItem[]>;
+  labelType: string;
+  labelTypeDropdownOptions: IDropdownOption[];
+  labelVisibilitiesPredicted: Map<string, boolean>;
+  labelVisibilitiesTrue: Map<string, boolean>;
   renderStartIndex: number[];
+  selectedKeysPredicted: string[];
+  selectedKeysTrue: string[];
   showBackArrow: boolean[];
 }
+
+interface IItemsData {
+  dropdownOptions: IDropdownOption[];
+  items: Map<string, IVisionListItem[]>;
+  labelVisibilities: Map<string, boolean>;
+  selectedKeys: string[];
+}
+
 const stackTokens = { childrenGap: "l1" };
+const labelTypes = {
+  predictedY: "predictedY",
+  trueY: "trueY"
+};
+
+const SelectAllKey = "selectAll";
 export class DataCharacteristics extends React.Component<
   IDataCharacteristicsProps,
   IDataCharacteristicsState
@@ -42,15 +64,27 @@ export class DataCharacteristics extends React.Component<
     this.rowHeight = 0;
     this.state = {
       columnCount: [],
-      items: new Map(),
-      labels: [],
-      labelVisibilities: new Map(),
+      dropdownOptionsPredicted: [],
+      dropdownOptionsTrue: [],
+      itemsPredicted: new Map(),
+      itemsTrue: new Map(),
+      labelType: labelTypes.predictedY,
+      labelTypeDropdownOptions: [],
+      labelVisibilitiesPredicted: new Map(),
+      labelVisibilitiesTrue: new Map(),
       renderStartIndex: [],
+      selectedKeysPredicted: [],
+      selectedKeysTrue: [],
       showBackArrow: []
     };
   }
 
   public componentDidMount(): void {
+    const labelTypeDropdownOptions: IDropdownOption[] = [
+      { key: labelTypes.predictedY, text: labelTypes.predictedY },
+      { key: labelTypes.trueY, text: labelTypes.trueY }
+    ];
+    this.setState({ labelTypeDropdownOptions });
     this.processData();
   }
 
@@ -62,7 +96,8 @@ export class DataCharacteristics extends React.Component<
 
   public render(): React.ReactNode {
     const classNames = dataCharacteristicsStyles();
-    const items = this.state.items;
+    const predicted = this.state.labelType === labelTypes.predictedY;
+    const items = predicted ? this.state.itemsPredicted : this.state.itemsTrue;
     let keys = [];
     for (const key of items.keys()) {
       keys.push(key);
@@ -81,32 +116,36 @@ export class DataCharacteristics extends React.Component<
               <Stack.Item className={classNames.labelsContainer}>
                 <Stack horizontal tokens={{ childrenGap: "s1" }}>
                   <Stack.Item>
-                    <Stack horizontal>
-                      {this.state.labels.map((label) => (
-                        <Stack.Item key={label}>
-                          {this.state.labelVisibilities.get(label) && (
-                            <DefaultButton
-                              text={label}
-                              iconProps={{ iconName: "Cancel" }}
-                              onClick={() => {
-                                const visibilities =
-                                  this.state.labelVisibilities;
-                                visibilities.set(label, false);
-                                this.setState({
-                                  labelVisibilities: visibilities
-                                });
-                              }}
-                            />
-                          )}
-                        </Stack.Item>
-                      ))}
-                    </Stack>
+                    <Dropdown
+                      id="labelTypeDropdown"
+                      label={
+                        localization.InterpretVision.Dashboard.labelTypeDropdown
+                      }
+                      options={this.state.labelTypeDropdownOptions}
+                      selectedKey={this.state.labelType}
+                      onChange={this.onLabelTypeChange}
+                    />
                   </Stack.Item>
                   <Stack.Item>
-                    <DefaultButton
-                      primary
-                      text={localization.InterpretVision.Dashboard.showAll}
-                      onClick={this.showAll}
+                    <Dropdown
+                      id="labelVisibilitySelectorsDropdown"
+                      className={classNames.dropdown}
+                      label={
+                        localization.InterpretVision.Dashboard
+                          .labelVisibilityDropdown
+                      }
+                      options={
+                        this.state.labelType === labelTypes.predictedY
+                          ? this.state.dropdownOptionsPredicted
+                          : this.state.dropdownOptionsTrue
+                      }
+                      selectedKeys={
+                        this.state.labelType === labelTypes.predictedY
+                          ? this.state.selectedKeysPredicted
+                          : this.state.selectedKeysTrue
+                      }
+                      onChange={this.onLabelVisibilitySelect}
+                      multiSelect
                     />
                   </Stack.Item>
                 </Stack>
@@ -122,6 +161,9 @@ export class DataCharacteristics extends React.Component<
           >
             {keys.map((label, index) => {
               const list = items.get(label);
+              const labelVisibilities = predicted
+                ? this.state.labelVisibilitiesPredicted
+                : this.state.labelVisibilitiesTrue;
               if (!list) {
                 return <div />;
               }
@@ -131,14 +173,16 @@ export class DataCharacteristics extends React.Component<
                   tokens={stackTokens}
                   className={classNames.instanceContainer}
                 >
-                  {this.state.labelVisibilities.get(label.toString()) && (
+                  {labelVisibilities.get(label.toString()) && (
                     <Stack.Item>
                       <DataCharacteristicsRow
                         columnCount={this.state.columnCount[index]}
                         index={index}
                         imageDim={this.props.imageDim}
                         label={label}
+                        labelType={this.state.labelType}
                         list={list}
+                        processData={this.processData}
                         renderStartIndex={this.state.renderStartIndex}
                         showBackArrow={this.state.showBackArrow}
                         totalListLength={this.props.data.length}
@@ -190,22 +234,22 @@ export class DataCharacteristics extends React.Component<
     );
   };
 
-  private processData = (): void => {
-    const examples: IVisionListItem[] = this.props.data;
-    const columnCount: number[] = [];
+  private generateItems = (
+    type: string,
+    examples: IVisionListItem[]
+  ): IItemsData => {
+    const dropdownOptions: IDropdownOption[] = [];
     const items: Map<string, IVisionListItem[]> = new Map();
-    const labels: string[] = [];
     const labelVisibilities: Map<string, boolean> = new Map();
-    const renderStartIndex: number[] = [];
-    const showBackArrow: boolean[] = [];
-
+    const selectedKeys: string[] = [];
     examples.forEach((example) => {
-      const label = example.predictedY;
+      const label = example[type].toString();
       if (!label || !items) {
         return;
       }
-      if (!labels.includes(label)) {
-        labels.push(label);
+      if (!selectedKeys.includes(label)) {
+        dropdownOptions.push({ key: label, text: label });
+        selectedKeys.push(label);
         labelVisibilities.set(label, true);
       }
       if (items.has(label)) {
@@ -221,23 +265,166 @@ export class DataCharacteristics extends React.Component<
         items.set(label, arr);
       }
     });
-    labels.forEach(() => {
+    selectedKeys.push(SelectAllKey);
+    dropdownOptions.push({
+      key: SelectAllKey,
+      text: localization.InterpretVision.Dashboard.selectAll
+    });
+    dropdownOptions.sort((a, b) => {
+      if (b.key === SelectAllKey) {
+        return 1;
+      }
+      if (a.key === SelectAllKey || a.key < b.key) {
+        return -1;
+      }
+      return 1;
+    });
+    return {
+      dropdownOptions,
+      items,
+      labelVisibilities,
+      selectedKeys
+    };
+  };
+
+  private processData = (): void => {
+    const examples: IVisionListItem[] = this.props.data;
+    const columnCount: number[] = [];
+    const renderStartIndex: number[] = [];
+    const showBackArrow: boolean[] = [];
+
+    const predicted: IItemsData = this.generateItems(
+      labelTypes.predictedY,
+      examples
+    );
+    const dropdownOptionsPredicted: IDropdownOption[] =
+      predicted.dropdownOptions;
+    const itemsPredicted: Map<string, IVisionListItem[]> = predicted.items;
+    const labelVisibilitiesPredicted: Map<string, boolean> =
+      predicted.labelVisibilities;
+    const selectedKeysPredicted: string[] = predicted.selectedKeys;
+
+    const trues: IItemsData = this.generateItems(labelTypes.trueY, examples);
+    const dropdownOptionsTrue: IDropdownOption[] = trues.dropdownOptions;
+    const itemsTrue: Map<string, IVisionListItem[]> = trues.items;
+    const labelVisibilitiesTrue: Map<string, boolean> = trues.labelVisibilities;
+    const selectedKeysTrue: string[] = trues.selectedKeys;
+
+    selectedKeysPredicted.forEach(() => {
       renderStartIndex.push(0);
       showBackArrow.push(false);
       columnCount.push(0);
     });
     this.setState({
       columnCount,
-      items,
-      labels,
-      labelVisibilities,
+      dropdownOptionsPredicted,
+      dropdownOptionsTrue,
+      itemsPredicted,
+      itemsTrue,
+      labelVisibilitiesPredicted,
+      labelVisibilitiesTrue,
       renderStartIndex,
+      selectedKeysPredicted,
+      selectedKeysTrue,
       showBackArrow
     });
   };
 
+  private onLabelTypeChange = (
+    _event: React.FormEvent<HTMLDivElement>,
+    item?: IDropdownOption<any> | undefined
+  ): void => {
+    if (item) {
+      this.setState({ labelType: item.key.toString() });
+    }
+  };
+
+  private onLabelVisibilitySelect = (
+    _event: React.FormEvent<HTMLDivElement>,
+    item?: IDropdownOption<any> | undefined
+  ): void => {
+    if (item) {
+      const predicted = this.state.labelType === labelTypes.predictedY;
+
+      if (item.key === SelectAllKey) {
+        const dropdownOptions = predicted
+          ? this.state.dropdownOptionsPredicted
+          : this.state.dropdownOptionsTrue;
+        const selectedKeys: string[] = [];
+        const labelVisibilities: Map<string, boolean> = new Map();
+        if (
+          (predicted &&
+            this.state.selectedKeysPredicted.length >=
+              dropdownOptions.length - 1) ||
+          (!predicted &&
+            this.state.selectedKeysTrue.length >= dropdownOptions.length - 1)
+        ) {
+          dropdownOptions.forEach((option, index) => {
+            if (index !== 0) {
+              labelVisibilities.set(option.key.toString(), false);
+            }
+          });
+        } else {
+          dropdownOptions.forEach((option, index) => {
+            if (index !== 0) {
+              selectedKeys.push(option.key.toString());
+              labelVisibilities.set(option.key.toString(), true);
+            }
+          });
+          selectedKeys.push(SelectAllKey);
+        }
+        if (predicted) {
+          this.setState({
+            labelVisibilitiesPredicted: labelVisibilities,
+            selectedKeysPredicted: [...selectedKeys]
+          });
+        } else {
+          this.setState({
+            labelVisibilitiesTrue: labelVisibilities,
+            selectedKeysTrue: [...selectedKeys]
+          });
+        }
+        return;
+      }
+
+      let selectedKeys: string[] = [];
+      let labelVisibilities: Map<string, boolean> = new Map();
+
+      if (predicted) {
+        selectedKeys = this.state.selectedKeysPredicted;
+        labelVisibilities = this.state.labelVisibilitiesPredicted;
+      } else {
+        selectedKeys = this.state.selectedKeysTrue;
+        labelVisibilities = this.state.labelVisibilitiesTrue;
+      }
+
+      if (selectedKeys.includes(SelectAllKey)) {
+        selectedKeys.splice(selectedKeys.indexOf(SelectAllKey), 1);
+      }
+      const key = item.key.toString();
+      selectedKeys.includes(key)
+        ? selectedKeys.splice(selectedKeys.indexOf(key), 1)
+        : selectedKeys.push(key);
+      labelVisibilities.set(key, !labelVisibilities.get(key));
+      if (predicted) {
+        this.setState({
+          labelVisibilitiesPredicted: labelVisibilities,
+          selectedKeysPredicted: [...selectedKeys]
+        });
+      } else {
+        this.setState({
+          labelVisibilitiesTrue: labelVisibilities,
+          selectedKeysTrue: [...selectedKeys]
+        });
+      }
+    }
+  };
+
   private sortKeys(keys: string[]): string[] {
-    const { items } = this.state;
+    const items =
+      this.state.labelType === labelTypes.predictedY
+        ? this.state.itemsPredicted
+        : this.state.itemsTrue;
     keys.sort(function (a, b) {
       const aItems = items.get(a);
       const bItems = items.get(b);
@@ -247,6 +434,9 @@ export class DataCharacteristics extends React.Component<
       const bCount = bItems?.filter(
         (item) => item.predictedY !== item.trueY
       ).length;
+      if (aCount === bCount) {
+        return a > b ? 1 : -1;
+      }
       return !aCount || !bCount ? 0 : bCount - aCount;
     });
     return keys;
@@ -298,12 +488,4 @@ export class DataCharacteristics extends React.Component<
     };
     return getItemCountForPage;
   }
-
-  private showAll = () => {
-    const visibilities = this.state.labelVisibilities;
-    for (const label of visibilities.keys()) {
-      visibilities.set(label, true);
-    }
-    this.setState({ labelVisibilities: visibilities });
-  };
 }

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
@@ -21,11 +21,13 @@ export interface IDataCharacteristicsRowProps {
   index: number;
   imageDim: number;
   label: string;
+  labelType: string;
   list: IVisionListItem[];
   renderStartIndex: number[];
   showBackArrow: boolean[];
   totalListLength: number;
   onRenderCell: (item?: IVisionListItem | undefined) => JSX.Element;
+  processData: () => void;
   loadPrevItems: (index: number) => () => void;
   loadNextItems: (index: number) => () => void;
   getPageHeight: () => number;

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.styles.ts
@@ -24,6 +24,7 @@ export interface IFlyoutStyles {
   sectionIndent: IStyle;
   separator: IStyle;
   title: IStyle;
+  indentedTitle: IStyle;
 }
 
 export const flyoutStyles: () => IProcessedStyleSet<IFlyoutStyles> = () => {
@@ -58,6 +59,9 @@ export const flyoutStyles: () => IProcessedStyleSet<IFlyoutStyles> = () => {
       maxHeight: "250px",
       maxWidth: "250px"
     },
+    indentedTitle: mergeStyles(title, {
+      marginLeft: "6%"
+    }),
     label: {
       bottom: 20,
       position: "relative",
@@ -68,7 +72,8 @@ export const flyoutStyles: () => IProcessedStyleSet<IFlyoutStyles> = () => {
       overflow: "hidden"
     },
     sectionIndent: {
-      marginLeft: "6%"
+      overflow: "hidden",
+      width: "100%"
     },
     separator: {
       width: "100%"

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.tsx
@@ -95,8 +95,7 @@ export class Flyout extends React.Component<IFlyoutProps, IFlyoutState> {
           closeButtonAriaLabel="Close"
           onDismiss={callback}
           isLightDismiss
-          type={PanelType.custom}
-          customWidth="700px"
+          type={PanelType.medium}
           className={classNames.mainContainer}
         >
           <Stack tokens={stackTokens.medium}>
@@ -197,7 +196,7 @@ export class Flyout extends React.Component<IFlyoutProps, IFlyoutState> {
               className={classNames.sectionIndent}
             >
               <Stack.Item>
-                <Text variant="large" className={classNames.title}>
+                <Text variant="large" className={classNames.indentedTitle}>
                   {localization.InterpretVision.Dashboard.panelExplanation}
                 </Text>
               </Stack.Item>
@@ -225,7 +224,7 @@ export class Flyout extends React.Component<IFlyoutProps, IFlyoutState> {
               className={classNames.sectionIndent}
             >
               <Stack.Item>
-                <Text variant="large" className={classNames.title}>
+                <Text variant="large" className={classNames.indentedTitle}>
                   {localization.InterpretVision.Dashboard.panelInformation}
                 </Text>
               </Stack.Item>

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.styles.ts
@@ -5,67 +5,82 @@ import {
   IStyle,
   mergeStyleSets,
   IProcessedStyleSet,
-  FontSizes
+  FontSizes,
+  getTheme,
+  mergeStyles
 } from "@fluentui/react";
 
 export interface IDatasetExplorerTabStyles {
+  indicator: IStyle;
+  errorIndicator: IStyle;
+  successIndicator: IStyle;
   list: IStyle;
   tile: IStyle;
   label: IStyle;
+  labelPredicted: IStyle;
   labelContainer: IStyle;
   image: IStyle;
   imageFrame: IStyle;
   imageSizer: IStyle;
-  selectedImage: IStyle;
 }
 
 export const imageListStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> =
   () => {
+    const theme = getTheme();
+    const indicator: IStyle = {
+      borderRadius: 45,
+      marginLeft: 5,
+      marginTop: 2,
+      textAlign: "center"
+    };
     return mergeStyleSets<IDatasetExplorerTabStyles>({
+      errorIndicator: mergeStyles(indicator, {
+        backgroundColor: theme.semanticColors.errorBackground
+      }),
       image: {
-        left: -6,
+        left: -20,
         position: "absolute",
-        top: -5,
-        width: "100%"
+        top: 22
       },
       imageFrame: {
         bottom: 2,
-        left: 2,
+        left: 1,
         position: "absolute",
         right: 2,
         top: 2
       },
       imageSizer: {
-        marginBottom: "2%",
-        paddingBottom: "100%"
+        overflow: "hidden"
       },
+      indicator,
       label: {
         color: "white",
         fontSize: FontSizes.small,
-        fontWeight: "600"
+        fontWeight: "600",
+        paddingLeft: 10
       },
       labelContainer: {
-        background: "rgba(0,0,0,0.3)",
+        background: "rgba(0,0,0,0.4)",
         boxSizing: "border-box",
-        padding: 10,
-        position: "absolute",
-        textAlign: "center"
+        paddingBottom: 5,
+        paddingTop: 2,
+        position: "relative",
+        textAlign: "start",
+        top: 4,
+        width: "98%"
+      },
+      labelPredicted: {
+        color: "black",
+        fontSize: FontSizes.small
       },
       list: {
         fontSize: 0,
         overflow: "hidden",
         position: "relative"
       },
-      selectedImage: {
-        border: "5px solid blue",
-        bottom: 2,
-        height: "90%",
-        left: 2,
-        position: "absolute",
-        right: 2,
-        top: 2,
-        width: "90%"
-      },
+      successIndicator: mergeStyles(indicator, {
+        backgroundColor: theme.semanticColors.successBackground
+      }),
       tile: {
         float: "left",
         outline: "none",

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
@@ -27,7 +27,6 @@ export interface IImageListState {
   data: IVisionListItem[];
   filter: string;
   filteredItems: IVisionListItem[];
-  selectedItems: boolean[];
 }
 
 const RowsPerPage = 3;
@@ -54,8 +53,7 @@ export class ImageList extends React.Component<
     this.state = {
       data: [],
       filter: this.props.searchValue.toLowerCase(),
-      filteredItems: [],
-      selectedItems: []
+      filteredItems: []
     };
   }
 
@@ -92,21 +90,17 @@ export class ImageList extends React.Component<
 
   public componentDidMount() {
     const data = this.props.data;
-    const selectedItems: boolean[] = [];
-    for (let i = 0; i < data.length; i++) {
-      selectedItems.push(false);
-    }
-    this.setState({ data, filteredItems: data, selectedItems });
+    this.setState({ data, filteredItems: data });
   }
 
   public render(): React.ReactNode {
     const classNames = imageListStyles();
-    const items = this.state.filteredItems;
+
     return (
       <FocusZone>
         <List
           key={this.props.imageDim}
-          items={items}
+          items={this.state.filteredItems}
           onRenderCell={this.onRenderCell}
           className={classNames.list}
           getPageHeight={this.getPageHeight}
@@ -127,7 +121,7 @@ export class ImageList extends React.Component<
         tokens={stackTokens}
         className={classNames.tile}
         style={{
-          height: this.props.imageDim * 1.05,
+          height: this.props.imageDim * 1.1,
           width: `${100 / this.columnCount}%`
         }}
       >
@@ -136,11 +130,9 @@ export class ImageList extends React.Component<
           style={{ paddingBottom: this.props.imageDim / 1.4 }}
         >
           <Stack.Item
-            className={
-              item.selected ? classNames.selectedImage : classNames.imageFrame
-            }
+            className={classNames.imageFrame}
             style={{
-              height: this.props.imageDim * 1.05,
+              height: this.props.imageDim,
               overflow: "hidden",
               width: this.props.imageDim - ImagePadding
             }}
@@ -153,6 +145,21 @@ export class ImageList extends React.Component<
               width={this.props.imageDim}
               className={classNames.image}
             />
+          </Stack.Item>
+          <Stack.Item
+            className={
+              item?.predictedY === item?.trueY
+                ? classNames.successIndicator
+                : classNames.errorIndicator
+            }
+            style={{
+              left: ImagePadding,
+              maxWidth: this.props.imageDim
+            }}
+          >
+            <Text className={classNames.labelPredicted}>
+              {item?.predictedY}
+            </Text>
           </Stack.Item>
           <Stack.Item
             className={classNames.labelContainer}
@@ -180,20 +187,6 @@ export class ImageList extends React.Component<
     if (!item) {
       return;
     }
-    const { selectedItems } = this.state;
-    selectedItems[item.index] = !selectedItems[item.index];
-    this.setState({ selectedItems: [...selectedItems] });
-
-    let items = this.state.filteredItems;
-    items = items.map((i) => {
-      if (i.index === item.index) {
-        i.selected = !i.selected;
-      }
-      return i;
-    });
-
-    this.setState({ filteredItems: [...items] });
-
     this.props.selectItem(item);
   };
 

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.styles.ts
@@ -15,6 +15,7 @@ export interface IDatasetExplorerTab {
   filterButton: IStyle;
   searchBox: IStyle;
   toolBarContainer: IStyle;
+  legendIndicator: IStyle;
   itemsSelectedContainer: IStyle;
   mainContainer: IStyle;
   mainImageContainer: IStyle;
@@ -56,8 +57,14 @@ export const visionExplanationDashboardStyles: () => IProcessedStyleSet<IDataset
         overflow: "auto"
       },
       itemsSelectedContainer: {
-        height: "100%",
+        height: "32px",
         textAlign: "center"
+      },
+      legendIndicator: {
+        paddingBottom: 2,
+        paddingLeft: 20,
+        paddingRight: 20,
+        paddingTop: 2
       },
       mainContainer: {
         alignItems: "center",

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
@@ -6,7 +6,9 @@ import {
   Stack,
   PivotItem,
   Slider,
-  Separator
+  Separator,
+  Text,
+  mergeStyles
 } from "@fluentui/react";
 import {
   defaultModelAssessmentContext,
@@ -24,6 +26,7 @@ import React from "react";
 
 import { CohortToolBar } from "./Controls/CohortToolBar";
 import { Flyout } from "./Controls/Flyout";
+import { imageListStyles } from "./Controls/ImageList.styles";
 import { PageSizeSelectors } from "./Controls/PageSizeSelectors";
 import { Pivots } from "./Controls/Pivots";
 import { TabsView } from "./Controls/TabsView";
@@ -94,6 +97,7 @@ export class VisionExplanationDashboard extends React.Component<
 
   public render(): React.ReactNode {
     const classNames = visionExplanationDashboardStyles();
+    const imageStyles = imageListStyles();
     return (
       <Stack
         horizontal={false}
@@ -140,7 +144,7 @@ export class VisionExplanationDashboard extends React.Component<
               />
             </Stack.Item>
             {this.state.selectedKey !==
-              VisionDatasetExplorerTabOptions.ImageExplorerView && (
+            VisionDatasetExplorerTabOptions.ImageExplorerView ? (
               <Stack.Item>
                 <PageSizeSelectors
                   selectedKey={this.state.selectedKey}
@@ -148,6 +152,38 @@ export class VisionExplanationDashboard extends React.Component<
                   onPageSizeSelect={this.onPageSizeSelect}
                 />
               </Stack.Item>
+            ) : (
+              <Stack
+                horizontal
+                tokens={{ childrenGap: "l1" }}
+                verticalAlign="center"
+              >
+                <Stack.Item>
+                  <Text>
+                    {localization.InterpretVision.Dashboard.predictedLabel}
+                  </Text>
+                </Stack.Item>
+                <Stack.Item
+                  className={mergeStyles(
+                    imageStyles.errorIndicator,
+                    classNames.legendIndicator
+                  )}
+                >
+                  <Text className={imageStyles.labelPredicted}>
+                    {localization.InterpretVision.Dashboard.legendFailure}
+                  </Text>
+                </Stack.Item>
+                <Stack.Item
+                  className={mergeStyles(
+                    imageStyles.successIndicator,
+                    classNames.legendIndicator
+                  )}
+                >
+                  <Text className={imageStyles.labelPredicted}>
+                    {localization.InterpretVision.Dashboard.legendSuccess}
+                  </Text>
+                </Stack.Item>
+              </Stack>
             )}
           </Stack>
         </Stack.Item>

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1345,16 +1345,16 @@
       "predictedY": "Predicted: ",
       "rows": "Rows: ",
       "search": "Search",
+      "selectAll": "Select all",
       "settings": "Settings",
       "showAll": "Show all",
-      "selectAll": "Select all",
       "tabOptionFirst": "Image explorer view",
       "tabOptionSecond": "Table view",
       "tabOptionThird": "Data characteristics",
       "thumbnailSize": "Thumbnail size",
       "titleBarError": "Error instances",
       "titleBarSuccess": "Success instances",
-      "trueY": "Ground truh: "
+      "trueY": "Ground truth: "
     }
   },
   "ModelAssessment": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Does not depend on any other open PRs**

Fixups for the Vision dashboard UI to be consistent with latest Figma designs. Includes the following features:

- flyout panel now shows item index, predicted y, true y, and external metadata
- image list now shows both predicted and true labels
- data characteristics label visibility selection moved to a dropdown
- can choose between sorting by true labels and predicted labels in data characteristics

![Screenshot (65)](https://user-images.githubusercontent.com/69280655/188538672-2728053f-04e4-4842-9f36-2aee26d7c390.png)
![Screenshot (66)](https://user-images.githubusercontent.com/69280655/188538681-e1542ed9-bdd0-4b6a-82f9-0716aa015eb3.png)
![Screenshot (67)](https://user-images.githubusercontent.com/69280655/188538689-0bf8ca44-b150-42ea-965d-e25363323f47.png)
![Screenshot (68)](https://user-images.githubusercontent.com/69280655/188538693-a9489673-4a49-4add-8555-cd70249c4170.png)
![Screenshot (69)](https://user-images.githubusercontent.com/69280655/188538700-e5421925-cafc-4d8a-9a31-d5608e7062a8.png)

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
