### PR TITLE
touch ups from designer feedback to RAI dashboard for text data

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
@@ -5,6 +5,7 @@ import {
   ChoiceGroup,
   IChoiceGroupOption,
   IStackTokens,
+  Label,
   Slider,
   Stack,
   Text
@@ -85,22 +86,7 @@ export class TextExplanationView extends React.PureComponent<
     return (
       <Stack>
         <Stack tokens={componentStackTokens} horizontal>
-          <Stack.Item
-            align="stretch"
-            grow
-            disableShrink
-            className={classNames.textHighlighting}
-          >
-            <TextHighlighting
-              text={this.state.text}
-              localExplanations={this.state.importances}
-              topK={this.state.topK}
-              radio={this.state.radio}
-            />
-          </Stack.Item>
-          <Stack.Item align="end">
-            <TextFeatureLegend />
-          </Stack.Item>
+          <Text>{localization.InterpretText.View.legendText}</Text>
         </Stack>
         <Stack tokens={componentStackTokens} horizontal>
           <Stack.Item grow disableShrink>
@@ -123,22 +109,18 @@ export class TextExplanationView extends React.PureComponent<
                     )}
                 </Text>
               </Stack.Item>
+              <Stack.Item>
+                <Label>{localization.InterpretText.View.importantWords}</Label>
+              </Stack.Item>
               <Stack.Item id="TextTopKSlider">
                 <Slider
                   min={1}
                   max={this.state.maxK}
                   step={1}
                   defaultValue={this.state.topK}
-                  showValue={false}
+                  showValue
                   onChange={this.setTopK}
                 />
-              </Stack.Item>
-              <Stack.Item align="center">
-                <Text variant={"large"}>
-                  {`${this.state.topK.toString()} ${
-                    localization.InterpretText.View.importantWords
-                  }`}
-                </Text>
               </Stack.Item>
               <Stack.Item>
                 <ClassImportanceWeights
@@ -158,14 +140,25 @@ export class TextExplanationView extends React.PureComponent<
                   />
                 </Stack.Item>
               )}
-              {this.props.selectedWeightVector !== WeightVectors.AbsAvg && (
-                <Stack.Item>
-                  <Text variant={"small"}>
-                    {localization.InterpretText.View.legendText}
-                  </Text>
-                </Stack.Item>
-              )}
             </Stack>
+          </Stack.Item>
+        </Stack>
+        <Stack tokens={componentStackTokens} horizontal>
+          <Stack.Item
+            align="stretch"
+            grow
+            disableShrink
+            className={classNames.textHighlighting}
+          >
+            <TextHighlighting
+              text={this.state.text}
+              localExplanations={this.state.importances}
+              topK={this.state.topK}
+              radio={this.state.radio}
+            />
+          </Stack.Item>
+          <Stack.Item align="end">
+            <TextFeatureLegend />
           </Stack.Item>
         </Stack>
       </Stack>

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1290,12 +1290,12 @@
   "InterpretText": {
     "View": {
       "interpretibilityDashboard": "Interpretability Dashboard",
-      "importantWords": "Most Important Words",
+      "importantWords": "Show most Important Words",
       "topFeatureList": "Top feature list analysis",
       "allButton": "ALL FEATURES",
       "negButton": "NEGATIVE FEATURES",
       "posButton": "POSITIVE FEATURES",
-      "legendText": "Positive scalar feature importances represents the extent that the word was important towards the classification of your selected label, and negative scalar feature importances represents words that encouraged your model away from your selected label.",
+      "legendText": "Positive scalar feature importances represent the extent that the words were important towards the classification of your selected label, and negative scalar feature importances represent words that encouraged your model away from your selected label.",
       "label": "Label",
       "colon": ": "
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor touch-ups to the text dashboard based on designer feedback including:

1.) Moving legend text explaining positive and negative importance values to the top
2.) Moving the highlighted text back to the bottom of the view
3.) Changing slidebar to make words above the slidebar, and showing the value to the right of the slidebar

![image](https://user-images.githubusercontent.com/24683184/188966986-72d6b39a-df92-4ac9-bdb2-bc9457a53e82.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
