### PR TITLE
Update MetricSelector.tsx to keep Precision and Recall metrics together in dropdown

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
@@ -47,8 +47,8 @@ export class MetricSelector extends React.Component<IMetricSelectorProps> {
       };
       options.push(this.addDropdownOption(Metrics.ErrorRate));
       options.push(this.addDropdownOption(Metrics.MacroPrecisionScore));
-      options.push(this.addDropdownOption(Metrics.MacroRecallScore));
       options.push(this.addDropdownOption(Metrics.MicroPrecisionScore));
+      options.push(this.addDropdownOption(Metrics.MacroRecallScore));
       options.push(this.addDropdownOption(Metrics.MicroRecallScore));
       options.push(this.addDropdownOption(Metrics.MicroF1Score));
       options.push(this.addDropdownOption(Metrics.MacroF1Score));


### PR DESCRIPTION
## Description

Seems like the Precision and Recall metrics are not together in the dropdown for multi-class case. 
Before:-
![image](https://user-images.githubusercontent.com/47334368/189244240-2809a4fb-3786-4292-babb-4cb9a03cbc4a.png)

After:-
![image](https://user-images.githubusercontent.com/47334368/189244370-0daf5ddb-c6cb-49be-bba7-84400fdbce66.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
