### PR TITLE
Change 'Accuracy' to 'Accuracy score' in ModelOverview

### DIFF
--- a/libs/e2e/src/lib/describer/modelAssessment/modelOverview/describeModelOverview.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/modelOverview/describeModelOverview.ts
@@ -198,7 +198,7 @@ function ensureAllModelOverviewDatasetCohortsViewBasicElementsArePresent(
               ","
             )}.`
           : `${initialCohorts[0].name}, ${displayedMetric.replace(" ", ",")}. ${
-              datasetShape.isRegression ? "Mean absolute error" : "Accuracy"
+              datasetShape.isRegression ? "Mean absolute error" : "Accuracy score"
             }.`;
       cy.get(Locators.ModelOverviewMetricChartBars)
         .first()

--- a/libs/e2e/src/lib/describer/modelAssessment/modelOverview/describeModelOverview.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/modelOverview/describeModelOverview.ts
@@ -198,7 +198,9 @@ function ensureAllModelOverviewDatasetCohortsViewBasicElementsArePresent(
               ","
             )}.`
           : `${initialCohorts[0].name}, ${displayedMetric.replace(" ", ",")}. ${
-              datasetShape.isRegression ? "Mean absolute error" : "Accuracy score"
+              datasetShape.isRegression
+                ? "Mean absolute error"
+                : "Accuracy score"
             }.`;
       cy.get(Locators.ModelOverviewMetricChartBars)
         .first()

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1595,7 +1595,7 @@
     "ModelOverview": {
       "metrics": {
         "accuracy": {
-          "name": "Accuracy",
+          "name": "Accuracy score",
           "description": "The fraction of data points classified correctly."
         },
         "f1Score": {


### PR DESCRIPTION
## Description

Looks like in error analysis we show "Accuracy score"

![image](https://user-images.githubusercontent.com/47334368/189397199-530af2a6-283c-466d-bc58-2d8878b873b1.png)

While in ModelOverview we say "Accuracy"
![image](https://user-images.githubusercontent.com/47334368/189397350-7a9772c9-9db3-4055-a0c1-20a1558991c8.png)

Making it "Accuracy score" in ModelOverview as well.
![image](https://user-images.githubusercontent.com/47334368/189397447-4c9faad5-7e30-4fb7-bf8a-3062627ca4a9.png)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
