### PR TITLE
Avoid additional predict call in case of ModelAnalyzer

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -145,16 +145,11 @@ def compute_matrix(analyzer, features, filters, composite_filters,
         input_data = input_data.to_numpy()
     if is_model_analyzer:
         pred_y = analyzer.model.predict(input_data)
-    if is_model_analyzer:
-        if analyzer.model_task == ModelTask.CLASSIFICATION:
-            diff = analyzer.model.predict(input_data) != true_y
-        else:
-            diff = analyzer.model.predict(input_data) - true_y
+
+    if analyzer.model_task == ModelTask.CLASSIFICATION:
+        diff = pred_y != true_y
     else:
-        if analyzer.model_task == ModelTask.CLASSIFICATION:
-            diff = pred_y != true_y
-        else:
-            diff = pred_y - true_y
+        diff = pred_y - true_y
     if not isinstance(diff, np.ndarray):
         diff = np.array(diff)
     if not isinstance(pred_y, np.ndarray):


### PR DESCRIPTION
## Description

Looks like in case the model is present in erroranalysis, we are doing an additional predict() call. This is ok for small datasets but for large datasets every predict call adds sometime to response time. Hence, removing the additional predict call.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
