### PR TITLE
Cache predict() and predict_proba() output

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -54,6 +54,7 @@ _RANGE_TYPE = 'range_type'
 _UNIQUE_VALUES = 'unique_values'
 _MIN_VALUE = 'min_value'
 _MAX_VALUE = 'max_value'
+_MODEL = "model"
 
 
 class RAIInsights(RAIBaseInsights):
@@ -138,13 +139,17 @@ class RAIInsights(RAIBaseInsights):
 
         self._try_add_data_balance()
 
-        # Cache predictions of the model
-        self.predict_output = model.predict(
-            test.drop(columns=[target_column]))
-        if hasattr(model, SKLearn.PREDICT_PROBA):
-            self.predict_proba_output = model.predict(
+        if model is not None:
+            # Cache predictions of the model
+            self.predict_output = model.predict(
                 test.drop(columns=[target_column]))
+            if hasattr(model, SKLearn.PREDICT_PROBA):
+                self.predict_proba_output = model.predict(
+                    test.drop(columns=[target_column]))
+            else:
+                self.predict_proba_output = None
         else:
+            self.predict_output = None
             self.predict_proba_output = None
 
     def _initialize_managers(self):
@@ -735,6 +740,11 @@ class RAIInsights(RAIBaseInsights):
         :param path: The directory path to data location.
         :type path: str
         """
+        if inst.__dict__[_MODEL] is None:
+            inst.__dict__[_PREDICT_OUTPUT] = None
+            inst.__dict__[_PREDICT_PROBA_OUTPUT] = None
+            return
+
         prediction_output_path = Path(path) / _PREDICTIONS
 
         with open(prediction_output_path / (

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -47,6 +47,8 @@ _TRAIN_LABELS = 'train_labels'
 _JSON_EXTENSION = '.json'
 _PREDICT = 'predict'
 _PREDICT_PROBA = 'predict_proba'
+_PREDICT_OUTPUT = 'predict_output'
+_PREDICT_PROBA_OUTPUT = 'predict_proba_output'
 _COLUMN_NAME = 'column_name'
 _RANGE_TYPE = 'range_type'
 _UNIQUE_VALUES = 'unique_values'
@@ -135,6 +137,15 @@ class RAIInsights(RAIBaseInsights):
             serializer)
 
         self._try_add_data_balance()
+
+        # Cache predictions of the model
+        self.predict_output = model.predict(
+            test.drop(columns=[target_column]))
+        if hasattr(model, SKLearn.PREDICT_PROBA):
+            self.predict_proba_output = model.predict(
+                test.drop(columns=[target_column]))
+        else:
+            self.predict_proba_output = None
 
     def _initialize_managers(self):
         """Initializes the managers.
@@ -347,9 +358,9 @@ class RAIInsights(RAIBaseInsights):
             if model is not None:
                 # Pick one row from train and test data
                 small_train_data = train.iloc[0:1].drop(
-                    [target_column], axis=1)
+                    columns=[target_column])
                 small_test_data = test.iloc[0:1].drop(
-                    [target_column], axis=1)
+                    columns=[target_column])
 
                 small_train_features_before = list(small_train_data.columns)
 
@@ -468,8 +479,6 @@ class RAIInsights(RAIBaseInsights):
         :return: The filtered test data.
         :rtype: pandas.DataFrame
         """
-        pred_y = self.model.predict(
-            self.test.drop(columns=[self.target_column]))
         filter_data_with_cohort = FilterDataWithCohortFilters(
             model=self.model,
             dataset=self.test.drop(columns=[self.target_column]),
@@ -477,7 +486,7 @@ class RAIInsights(RAIBaseInsights):
             categorical_features=self.categorical_features,
             categories=self._categories,
             true_y=self.test[self.target_column],
-            pred_y=pred_y,
+            pred_y=self.predict_output,
             model_task=self.task_type)
 
         return filter_data_with_cohort.filter_data_from_cohort(
@@ -608,20 +617,14 @@ class RAIInsights(RAIBaseInsights):
         if self.model is None:
             return
 
-        test_without_target_column = self.test.drop(
-            [self.target_column], axis=1)
-
-        predict_output = self.model.predict(test_without_target_column)
         self._write_to_file(
             prediction_output_path / (_PREDICT + _JSON_EXTENSION),
-            json.dumps(predict_output.tolist()))
+            json.dumps(self.predict_output.tolist()))
 
-        if hasattr(self.model, SKLearn.PREDICT_PROBA):
-            predict_proba_output = self.model.predict_proba(
-                test_without_target_column)
+        if self.predict_proba_output is not None:
             self._write_to_file(
                 prediction_output_path / (_PREDICT_PROBA + _JSON_EXTENSION),
-                json.dumps(predict_proba_output.tolist()))
+                json.dumps(self.predict_proba_output.tolist()))
 
     def _save_metadata(self, path):
         """Save the metadata like target column, categorical features,
@@ -724,6 +727,31 @@ class RAIInsights(RAIBaseInsights):
                     inst.__dict__[_TARGET_COLUMN]]))
 
     @staticmethod
+    def _load_predictions(inst, path):
+        """Load the predict() and predict_proba() output.
+
+        :param inst: RAIBaseInsights object instance.
+        :type inst: RAIBaseInsights
+        :param path: The directory path to data location.
+        :type path: str
+        """
+        prediction_output_path = Path(path) / _PREDICTIONS
+
+        with open(prediction_output_path / (
+                _PREDICT + _JSON_EXTENSION), 'r') as file:
+            predict_output = json.load(file)
+        inst.__dict__[_PREDICT_OUTPUT] = np.array(predict_output)
+
+        if inst.__dict__[_TASK_TYPE] == ModelTask.CLASSIFICATION:
+            with open(prediction_output_path / (
+                    _PREDICT_PROBA + _JSON_EXTENSION), 'r') as file:
+                predict_proba_output = json.load(file)
+            inst.__dict__[_PREDICT_PROBA_OUTPUT] = np.array(
+                predict_proba_output)
+        else:
+            inst.__dict__[_PREDICT_PROBA_OUTPUT] = None
+
+    @staticmethod
     def load(path):
         """Load the RAIInsights from the given path.
 
@@ -747,5 +775,7 @@ class RAIInsights(RAIBaseInsights):
         # load current state
         RAIBaseInsights._load(path, inst, manager_map,
                               RAIInsights._load_metadata)
+
+        RAIInsights._load_predictions(inst, path)
 
         return inst

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -352,8 +352,10 @@ def validate_rai_insights(
     for ind_data in rai_insights._string_ind_data:
         assert len(ind_data) == expected_length
 
+    assert rai_insights.predict_output is not None
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()
         classes.sort()
         np.testing.assert_array_equal(rai_insights._classes,
                                       classes)
+        assert rai_insights.predict_proba_output is not None

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -352,10 +352,16 @@ def validate_rai_insights(
     for ind_data in rai_insights._string_ind_data:
         assert len(ind_data) == expected_length
 
-    assert rai_insights.predict_output is not None
+    if rai_insights.model is None:
+        assert rai_insights.predict_output is None
+        assert rai_insights.predict_proba_output is None
+    else:
+        assert rai_insights.predict_output is not None
+        if task_type == ModelTask.CLASSIFICATION:
+            assert rai_insights.predict_proba_output is not None
+
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()
         classes.sort()
         np.testing.assert_array_equal(rai_insights._classes,
                                       classes)
-        assert rai_insights.predict_proba_output is not None

--- a/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
+++ b/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
@@ -8,15 +8,14 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 import pytest
+from tests.common_utils import (create_adult_income_dataset,
+                                create_binary_classification_dataset,
+                                create_complex_classification_pipeline,
+                                create_iris_data, create_lightgbm_classifier)
 
 from responsibleai import ModelTask, RAIInsights
 from responsibleai._internal.constants import ManagerNames
 from responsibleai.feature_metadata import FeatureMetadata
-
-from .common_utils import (create_adult_income_dataset,
-                           create_binary_classification_dataset,
-                           create_complex_classification_pipeline,
-                           create_iris_data, create_lightgbm_classifier)
 
 LABELS = 'labels'
 
@@ -307,10 +306,17 @@ def validate_rai_insights(
     if feature_metadata is not None:
         assert rai_insights._feature_metadata == feature_metadata
     assert target_column not in rai_insights._feature_columns
-    assert rai_insights.predict_output is not None
+
+    if rai_insights.model is None:
+        assert rai_insights.predict_output is None
+        assert rai_insights.predict_proba_output is None
+    else:
+        assert rai_insights.predict_output is not None
+        if task_type == ModelTask.CLASSIFICATION:
+            assert rai_insights.predict_proba_output is not None
+
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()
         classes.sort()
         np.testing.assert_array_equal(rai_insights._classes,
                                       classes)
-        assert rai_insights.predict_proba_output is not None

--- a/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
+++ b/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
@@ -307,8 +307,10 @@ def validate_rai_insights(
     if feature_metadata is not None:
         assert rai_insights._feature_metadata == feature_metadata
     assert target_column not in rai_insights._feature_columns
+    assert rai_insights.predict_output is not None
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()
         classes.sort()
         np.testing.assert_array_equal(rai_insights._classes,
                                       classes)
+        assert rai_insights.predict_proba_output is not None


### PR DESCRIPTION
## Description

Caching the predict() and predict_proba() output saves time when the size of the datasets is large.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
