### PR TITLE
Enable flake8-breakpoint and fix errors

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -278,7 +278,7 @@ def compute_matrix(analyzer, features, filters, composite_filters,
             # fix counts to include skipped categories
             fix_counts = []
             counts_idx = 0
-            for idx, catdf in enumerate(cutdf.cat.categories):
+            for idx, _ in enumerate(cutdf.cat.categories):
                 if idx not in catn:
                     fix_counts.append(0)
                 else:

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -12,7 +12,7 @@ from responsibleai.exceptions import (DuplicateManagerConfigException,
 
 
 def verify_counterfactual_object(counterfactual_obj, feature_importance=False):
-    counterfactual_obj.cf_examples_list is not None
+    assert counterfactual_obj.cf_examples_list is not None
     if feature_importance:
         assert counterfactual_obj.local_importance is not None
         assert counterfactual_obj.summary_importance is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W504, B014
+ignore = W504
 enable-extensions = G,C,B
 select = E,F,W,C
 copyright-check = True
@@ -9,7 +9,7 @@ exclude =
     node_modules/
 
 per-file-ignores =
-    rai_core_flask/*:D100,D107
+    rai_core_flask/*:D100,D107,B014
     rai_core_flask/tests/*:D100,D101
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
-ignore = W504
-enable-extensions = G,C
+ignore = W504, B014
+enable-extensions = G,C,B
 select = E,F,W,C
 copyright-check = True
 copyright-regexp = # Copyright \(c\) Microsoft Corporation\n# Licensed under the MIT license.


### PR DESCRIPTION
## Description

It seems the plugin `flake8-breakpoint` is not enabled in linting because of missing configuration in setup.cfg. Enabling this fixes the following error:-

```
.\erroranalysis\erroranalysis\_internal\matrix_filter.py:281:22: B007 Loop control variable 'catdf' not used within the loop body. If this is intended, start the name with an underscore.
.\rai_core_flask\rai_core_flask\flask_helper.py:82:9: B014 Redundant exception types in `except (socket.error, OSError):`.  Write `except OSError:`, which catches exactly the same exceptions.
.\responsibleai\responsibleai\feature_metadata.py:49:9: B602 import of debug module found
.\responsibleai\responsibleai\feature_metadata.py:51:9: B601 builtin function "breakpoint" found
.\responsibleai\tests\counterfactual_manager_validator.py:15:5: B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
