### PR TITLE
update raiwidgets and responsibleai to erroranalysis 0.3.10 and interpret-community 0.27.0

### DIFF
--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -5,6 +5,6 @@ rai-core-flask==0.4.0
 itsdangerous==2.0.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.3.9
+erroranalysis>=0.3.10
 fairlearn>=0.7.0
 raiutils>=0.2.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,8 +1,8 @@
 dice-ml>=0.8,<0.9
 econml>=0.13.1
 jsonschema
-erroranalysis>=0.3.9
-interpret-community>=0.26.0
+erroranalysis>=0.3.10
+interpret-community>=0.27.0
 lightgbm>=2.0.11
 numpy>=1.17.2
 numba<0.54.0


### PR DESCRIPTION
## Description

update raiwidgets and responsibleai to erroranalysis 0.3.10 and interpret-community 0.27.0

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
