### PR TITLE
Change multiclass F1_Score metrics to Macro_F1_Score/Micro_F1_Score

### DIFF
--- a/erroranalysis/erroranalysis/_internal/constants.py
+++ b/erroranalysis/erroranalysis/_internal/constants.py
@@ -74,8 +74,8 @@ class Metrics(str, Enum):
     'selection rate'. The multiclass classification
     metrics are 'macro_precision_score',
     'micro_precision_score', 'macro_recall_score',
-    'micro_recall_score', 'f1_score',
-    'accuracy_score' and 'error_rate'.
+    'micro_recall_score', 'macro_f1_score',
+    'micro_f1_score', 'accuracy_score' and 'error_rate'.
     """
     ACCURACY_SCORE = 'accuracy_score'
     MEAN_PREDICTION = 'mean_prediction'
@@ -190,6 +190,7 @@ multiclass_classification_metrics = [
     Metrics.MICRO_PRECISION_SCORE,
     Metrics.MACRO_RECALL_SCORE,
     Metrics.MICRO_RECALL_SCORE,
-    Metrics.F1_SCORE,
+    Metrics.MACRO_F1_SCORE,
+    Metrics.MICRO_F1_SCORE,
     Metrics.ACCURACY_SCORE,
     Metrics.ERROR_RATE]

--- a/erroranalysis/tests/test_metrics.py
+++ b/erroranalysis/tests/test_metrics.py
@@ -29,8 +29,6 @@ class TestMetrics:
     def test_multiclass_classification_metrics(self, metric):
         if metric == Metrics.ERROR_RATE:
             pytest.skip('Not implemented')
-        if metric == Metrics.F1_SCORE:
-            pytest.skip('The default binary option raises error')
         y_true = np.array([1, 0, 2, 1, 0, 1])
         y_pred = np.array([0, 0, 2, 1, 0, 1])
         assert isinstance(metric_to_func[metric](y_true, y_pred), float)


### PR DESCRIPTION
## Description

Change multiclass F1_Score metrics to Macro_F1_Score/Micro_F1_Score. Seems like for multiclass case F1 score is not a validate metric.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
