### PR TITLE
Add feature names to data sent to "requestPredictions" callback

### DIFF
--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -334,6 +334,30 @@ export class JointDataset {
     return result;
   }
 
+  // recover the dictionary representation of the eval dataset values with user
+  // feature names from a row.
+  // This includes subbing categorical values back in in place of indexes
+  public static datasetSliceWithUserFeatureNames(
+    row: { [key: string]: any },
+    metaDict: { [key: string]: IJointMeta },
+    length: number
+  ): any {
+    console.log(row);
+    let resultDict = {}
+    for (let i = 0; i < length; i++) {
+      const key = JointDataset.DataLabelRoot + i.toString();
+      let value = undefined
+      if (metaDict[key].isCategorical) {
+        value = metaDict[key].sortedCategoricalValues?.[row[key]];
+      } else {
+        value = row[key];
+      }
+      resultDict[metaDict[key].label] = value
+    }
+    console.log(resultDict);
+    return resultDict;
+  }
+
   // recover the array representation of just the local explanations from a row
   public static localExplanationSlice(
     row: { [key: string]: any },

--- a/libs/counterfactuals/src/util/getFetchPredictionPromise.ts
+++ b/libs/counterfactuals/src/util/getFetchPredictionPromise.ts
@@ -9,7 +9,7 @@ export function getFetchPredictionPromise(
   invokeModel: (data: any[], abortSignal: AbortSignal) => Promise<any[]>
 ) {
   const abortController = new AbortController();
-  const rawData = JointDataset.datasetSlice(
+  const rawData = JointDataset.datasetSliceWithUserFeatureNames(
     fetchingReference,
     jointDataset.metaDict,
     jointDataset.datasetFeatureCount

--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -97,14 +97,14 @@ class ResponsibleAIDashboardInput:
 
     def on_predict(self, data):
         try:
-            data = pd.DataFrame(
-                data, columns=self.dashboard_input.dataset.feature_names)
+            dataframe = pd.DataFrame.from_records(data)
             if (self._is_classifier):
                 prediction = convert_to_list(
-                    self._analysis.model.predict_proba(data), EXP_VIZ_ERR_MSG)
+                    self._analysis.model.predict_proba(dataframe),
+                    EXP_VIZ_ERR_MSG)
             else:
                 prediction = convert_to_list(
-                    self._analysis.model.predict(data), EXP_VIZ_ERR_MSG)
+                    self._analysis.model.predict(dataframe), EXP_VIZ_ERR_MSG)
             return {
                 WidgetRequestResponseConstants.data: prediction
             }

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_predict.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_predict.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import json
+
 from common_utils import CheckResponsibleAIDashboardInputTestResult
 
 from raiwidgets.responsibleai_dashboard_input import \
@@ -17,9 +19,14 @@ class TestResponsibleAIDashboardInputClassificationPredict(
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("Income", axis=1).values
+
+        test_pred_data_end_point = json.loads(test_data.head(1).drop(
+            "Income", axis=1).to_json(orient='records'))
+        test_pred_data = test_data.head(1).drop(
+            "Income", axis=1)
+
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
+            test_pred_data_end_point)
         knn_prediction = knn.predict_proba(test_pred_data)
 
         assert knn_prediction is not None
@@ -32,9 +39,12 @@ class TestResponsibleAIDashboardInputClassificationPredict(
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).values
+
+        test_pred_data_end_point = json.loads(
+            test_data.head(1).to_json(orient='records'))
+
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
+            test_pred_data_end_point)
 
         self.check_failure_criteria(
             flask_server_prediction_output,
@@ -51,9 +61,14 @@ class TestResponsibleAIDashboardInputRegressionPredict(
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("target", axis=1).values
+
+        test_pred_data_end_point = json.loads(test_data.head(1).drop(
+            "target", axis=1).to_json(orient='records'))
+        test_pred_data = test_data.head(1).drop(
+            "target", axis=1)
+
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
+            test_pred_data_end_point)
         rf_prediction = rf.predict(test_pred_data)
 
         assert rf_prediction is not None
@@ -71,9 +86,14 @@ class TestResponsibleAIDashboardInputMultiClassClassification(
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("target", axis=1).values
+
+        test_pred_data_end_point = json.loads(test_data.head(1).drop(
+            "target", axis=1).to_json(orient='records'))
+        test_pred_data = test_data.head(1).drop(
+            "target", axis=1)
+
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
+            test_pred_data_end_point)
         rf_prediction = rf.predict_proba(test_pred_data)
 
         assert rf_prediction is not None


### PR DESCRIPTION
## Description

When doing WhatIf analysis in counterfactual panel, the predict call (via `requestPredictions` callback) send raw data as plain array. This can be problematic as the order of values between the dashboard and SDK may not be consistent. Adding feature names to the data sent to the `requestPredictions` can help alleviate this problem. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
