### PR TITLE
fixed the link to developer blog for housing example

### DIFF
--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -262,7 +262,7 @@
    "id": "3a6d610b",
    "metadata": {},
    "source": [
-    "See this [developer blog](aka.ms/raidashboardblog) (Model Debugging Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
+    "See this [developer blog](https://aka.ms/raidashboardblog) (Model Debugging Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
    ]
   }
  ],


### PR DESCRIPTION
The link was broken and would point to https://github.com/microsoft/responsible-ai-toolbox/blob/352c30c8f4557393dfa635f97b3c3770ed2c9831/notebooks/responsibleaidashboard/aka.ms/raidashboardblog

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
