### PR TITLE
Fix developer blog link in notebook

### DIFF
--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -262,7 +262,7 @@
    "id": "3a6d610b",
    "metadata": {},
    "source": [
-    "See this [developer blog](https://aka.ms/raidashboardblog) (Model Debugging Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
+    "See this [developer blog](https://techcommunity.microsoft.com/t5/ai-machine-learning-blog/responsible-ai-dashboard-a-one-stop-shop-for-operationalizing/ba-p/3030944) (Model Debugging Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
    ]
   }
  ],

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
@@ -226,7 +226,7 @@
    "id": "3a6d610b",
    "metadata": {},
    "source": [
-    "See this [developer blog](aka.ms/raidashboardblog) (Decision Making Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
+    "See this [developer blog](https://techcommunity.microsoft.com/t5/ai-machine-learning-blog/responsible-ai-dashboard-a-one-stop-shop-for-operationalizing/ba-p/3030944) (Decision Making Flow section) to learn more about this use case and how to use the dashboard to debug your housing price prediction model."
    ]
   }
  ],


### PR DESCRIPTION
## Description

Fix developer blog link in notebook responsibleaidashboard-housing-decision-making.ipynb

Similar issue to https://github.com/microsoft/responsible-ai-toolbox/pull/1713 but in a different notebook

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
