### PR TITLE
Fix [Keyboard navigation - Azure Machine Learning - Model overview - Dataset cohorts]: Focus indicator is overlapping with the "help me choose metrics" button.

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
@@ -31,12 +31,7 @@ export const modelOverviewStyles: () => IProcessedStyleSet<IModelOverviewStyles>
     const theme = getTheme();
     return mergeStyleSets<IModelOverviewStyles>({
       configurationActionButton: {
-        paddingTop: "44px",
-        selectors: {
-          "@media screen and (max-width: 1023px)": {
-            paddingBottom: "20px"
-          }
-        }
+        marginTop: "25px"
       },
       descriptionText: {
         color: theme.semanticColors.bodyText,


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix [Keyboard navigation - Azure Machine Learning - Model overview - Dataset cohorts]: Focus indicator is overlapping with the "help me choose metrics" button.

Due to padding, focus zone was starting in padding zone. On updating to margin, focus zone was fixed.

![HelpMeFocusZone](https://user-images.githubusercontent.com/33799331/190237932-04628643-5f1a-44e3-993e-5141dd39423b.gif)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes - NA
- [ ] Documentation was updated if it was needed.
