### PR TITLE
Correct predict call to predict_proba

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -144,7 +144,7 @@ class RAIInsights(RAIBaseInsights):
             self.predict_output = model.predict(
                 test.drop(columns=[target_column]))
             if hasattr(model, SKLearn.PREDICT_PROBA):
-                self.predict_proba_output = model.predict(
+                self.predict_proba_output = model.predict_proba(
                     test.drop(columns=[target_column]))
             else:
                 self.predict_proba_output = None

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -359,6 +359,9 @@ def validate_rai_insights(
         assert rai_insights.predict_output is not None
         if task_type == ModelTask.CLASSIFICATION:
             assert rai_insights.predict_proba_output is not None
+            assert isinstance(rai_insights.predict_proba_output, np.ndarray)
+            assert len(rai_insights.predict_proba_output.tolist()[0]) == \
+                len(rai_insights._classes)
 
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()

--- a/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
+++ b/responsibleai/tests/test_rai_insights_save_and_load_scenarios.py
@@ -314,6 +314,9 @@ def validate_rai_insights(
         assert rai_insights.predict_output is not None
         if task_type == ModelTask.CLASSIFICATION:
             assert rai_insights.predict_proba_output is not None
+            assert isinstance(rai_insights.predict_proba_output, np.ndarray)
+            assert len(rai_insights.predict_proba_output.tolist()[0]) == \
+                len(rai_insights._classes)
 
     if task_type == ModelTask.CLASSIFICATION:
         classes = train_data[target_column].unique()


### PR DESCRIPTION
## Description

It seems there was a miss from me in the PR https://github.com/microsoft/responsible-ai-toolbox/pull/1702 where I cache the predict output in predict_proba_output variable. This PR corrects this miss and adds a test.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
