### PR TITLE
Fix "Clear” button of Search field under 'Feature List' dialog is not Functional and Focus indicator is not visible on all four sides for “Tree map” and "heat map" tabs.

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -34,7 +34,7 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
         width: "100%"
       },
       errorAnalysisView: flexLgDown,
-      errorAnalysisWrapper: { paddingLeft: "15px" },
+      errorAnalysisWrapper: { paddingLeft: "15px", marginTop: "10px" },
       featureList: {
         padding: "16px 0 10px 0"
       },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -34,7 +34,7 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
         width: "100%"
       },
       errorAnalysisView: flexLgDown,
-      errorAnalysisWrapper: { paddingLeft: "15px", marginTop: "10px" },
+      errorAnalysisWrapper: { marginTop: "10px", paddingLeft: "15px" },
       featureList: {
         padding: "16px 0 10px 0"
       },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -155,7 +155,7 @@ export class FeatureList extends React.Component<
   public render(): React.ReactNode {
     return (
       <Panel
-        headerText="Feature List"
+        headerText={localization.ErrorAnalysis.FeatureList.featureList}
         isOpen={this.props.isOpen}
         focusTrapZoneProps={focusTrapZoneProps}
         // You MUST provide this prop! Otherwise screen readers will just say "button" with no label.
@@ -180,7 +180,9 @@ export class FeatureList extends React.Component<
                 placeholder="Search"
                 styles={searchBoxStyles}
                 onSearch={this.onSearch}
-                onClear={this.onSearch}
+                onClear={() => {
+                  this.onSearch("");
+                }}
                 onChange={(_, newValue?: string): void => {
                   if (newValue === undefined) {
                     return;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -180,9 +180,6 @@ export class FeatureList extends React.Component<
                 placeholder="Search"
                 styles={searchBoxStyles}
                 onSearch={this.onSearch}
-                onClear={() => {
-                  this.onSearch("");
-                }}
                 onChange={(_, newValue?: string): void => {
                   if (newValue === undefined) {
                     return;

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -199,6 +199,7 @@
       "subText": "Learn about the selected cohort. Edit its cohort name. Delete this cohort."
     },
     "FeatureList": {
+      "featureList": "Feature List",
       "apply": "Apply",
       "features": "Features",
       "importances": "Importances",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix:
1. [Functional -Azure Machine Learning - Feature List>Search box]: "Clear” button of Search field under 'Feature List' dialog is not Functional. - onsearch was being called with no params resulting in no action. Removing onclear worked.
![searchAccFix](https://user-images.githubusercontent.com/33799331/190249998-dee1c35a-881f-4b36-86d3-dd070c661baa.gif)


3. [Usable - Azure Machine Learning - Model demo page>Error analysis]: Focus indicator is not visible on all four sides for “Tree map” and "heat map" tabs. - Since the above margin was consuming focus zone on adding margin to tabs, focus zone is visible. Similar design is present in Model overview component as well.

![image](https://user-images.githubusercontent.com/33799331/190250143-2e7a4bba-a15c-4fd1-adf1-7313844fe6be.png)
![image](https://user-images.githubusercontent.com/33799331/190250198-e03b3465-925d-4164-b490-a875e3a1fcb1.png)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes. - NA
- [ ] Documentation was updated if it was needed.
