### PR TITLE
fix images in data characteristics panel hiding the success/failure instances

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.styles.ts
@@ -50,10 +50,7 @@ export const dataCharacteristicsStyles: () => IProcessedStyleSet<IDataCharacteri
         top: -5
       },
       image: {
-        height: "auto",
-        left: 0,
-        position: "relative",
-        top: 0
+        position: "relative"
       },
       indicator: {
         marginBottom: 20

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
@@ -8,7 +8,8 @@ import {
   IRectangle,
   mergeStyles,
   Dropdown,
-  IDropdownOption
+  IDropdownOption,
+  ImageFit
 } from "@fluentui/react";
 import { IVisionListItem } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
@@ -173,10 +174,11 @@ export class DataCharacteristics extends React.Component<
   private onRenderCell = (
     item?: IVisionListItem | undefined
   ): React.ReactElement => {
+    const imageDim = this.props.imageDim;
     const classNames = dataCharacteristicsStyles();
     const indicatorStyle = mergeStyles(
       classNames.indicator,
-      { width: this.props.imageDim },
+      { width: imageDim },
       item?.predictedY === item?.trueY
         ? classNames.successIndicator
         : classNames.errorIndicator
@@ -185,15 +187,14 @@ export class DataCharacteristics extends React.Component<
       <div />
     ) : (
       <Stack className={classNames.tile}>
-        <Stack.Item
-          style={{ height: this.props.imageDim, width: this.props.imageDim }}
-        >
+        <Stack.Item style={{ height: imageDim, width: imageDim }}>
           <Image
             alt={item?.predictedY}
             src={`data:image/jpg;base64,${item?.image}`}
             onClick={this.callbackWrapper(item)}
             className={classNames.image}
-            style={{ width: this.props.imageDim }}
+            style={{ display: "inline", height: imageDim }}
+            imageFit={ImageFit.none}
           />
         </Stack.Item>
         <div className={indicatorStyle} />

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
@@ -53,16 +53,6 @@ const leftArrow: IIconProps = {
 };
 
 export class DataCharacteristicsRow extends React.Component<IDataCharacteristicsRowProps> {
-  /*
-  public componentDidUpdate(prevProps: IDataCharacteristicsRowProps): void {
-    if (
-      prevProps.labelType !== this.props.labelType ||
-      prevProps.list !== this.props.list
-    ) {
-      this.setState({ list: [...this.props.list] });
-    }
-  }
-*/
   public render(): React.ReactNode {
     const classNames = dataCharacteristicsStyles();
     const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the images in the data characteristics tab hiding the failure/success indicators (the blue/red boxes) for certain image dimensions.

Screenshot before the changes on the fridge dataset:

![image](https://user-images.githubusercontent.com/24683184/191099958-cb5182da-1ca6-4537-817c-80fe67159f3e.png)

Screenshot after the changes on the fridge dataset:

![image](https://user-images.githubusercontent.com/24683184/191099984-bc8a8d75-8e85-4cc5-b949-5abcd42fe8fc.png)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
