### PR TITLE
refactor vision dashboard to remove getDerivedStateFromProps

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
@@ -14,18 +14,18 @@ import {
 import { IVisionListItem } from "@responsible-ai/core-ui";
 import React from "react";
 
+import { ISearchable } from "../Interfaces/ISearchable";
+import { getFilteredDataFromSearch } from "../utils/getFilteredData";
+
 import { imageListStyles } from "./ImageList.styles";
 
-export interface IImageListProps {
-  data: IVisionListItem[];
+export interface IImageListProps extends ISearchable {
+  items: IVisionListItem[];
   imageDim: number;
-  searchValue: string;
   selectItem: (item: IVisionListItem) => void;
 }
 
 export interface IImageListState {
-  data: IVisionListItem[];
-  filter: string;
   filteredItems: IVisionListItem[];
 }
 
@@ -49,46 +49,26 @@ export class ImageList extends React.Component<
     this.columnCount = 0;
     this.rowHeight = 0;
     this.state = {
-      data: [],
-      filter: this.props.searchValue.toLowerCase(),
       filteredItems: []
     };
   }
 
-  public static getDerivedStateFromProps(
-    props: IImageListProps,
-    state: IImageListState
-  ): Partial<IImageListState> {
-    if (props.data !== state.data && props.data.length > 0) {
-      return {
-        filter: "",
-        filteredItems: props.data
-      };
+  public componentDidUpdate(prevProps: IImageListProps): void {
+    if (
+      this.props.items !== prevProps.items ||
+      this.props.searchValue !== prevProps.searchValue
+    ) {
+      const searchVal = this.props.searchValue.toLowerCase();
+      let filteredItems: IVisionListItem[] = this.props.items;
+      if (searchVal.length > 0) {
+        filteredItems = getFilteredDataFromSearch(searchVal, filteredItems);
+      }
+      this.setState({ filteredItems });
     }
-
-    const searchVal = props.searchValue.toLowerCase();
-    if (searchVal.length === 0) {
-      return {
-        filter: searchVal,
-        filteredItems: state.data
-      };
-    }
-    if (searchVal !== state.filter) {
-      return {
-        filter: searchVal,
-        filteredItems: state.data.filter(
-          (item) =>
-            item.predictedY.toLowerCase().includes(searchVal) ||
-            item.trueY.toLowerCase().includes(searchVal)
-        )
-      };
-    }
-    return state;
   }
 
   public componentDidMount(): void {
-    const data = this.props.data;
-    this.setState({ data, filteredItems: data });
+    this.setState({ filteredItems: this.props.items });
   }
 
   public render(): React.ReactNode {

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TabsView.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TabsView.tsx
@@ -92,7 +92,7 @@ export class TabsView extends React.Component<ITabsViewProps> {
                 </Stack.Item>
                 <Stack.Item className={classNames.imageListContainer}>
                   <ImageList
-                    data={this.props.errorInstances}
+                    items={this.props.errorInstances}
                     imageDim={this.props.imageDim}
                     searchValue={this.props.searchValue}
                     selectItem={this.props.onItemSelect}
@@ -108,7 +108,7 @@ export class TabsView extends React.Component<ITabsViewProps> {
                 </Stack.Item>
                 <Stack.Item className={classNames.imageListContainer}>
                   <ImageList
-                    data={this.props.successInstances}
+                    items={this.props.successInstances}
                     imageDim={this.props.imageDim}
                     searchValue={this.props.searchValue}
                     selectItem={this.props.onItemSelect}

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Interfaces/ISearchable.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Interfaces/ISearchable.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface ISearchable {
+  searchValue: string;
+}

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getFilteredData.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getFilteredData.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IVisionListItem } from "@responsible-ai/core-ui";
+
+export function getFilteredDataFromSearch(
+  searchVal: string,
+  items: IVisionListItem[]
+): IVisionListItem[] {
+  return items.filter(
+    (item) =>
+      item.predictedY.toLowerCase().includes(searchVal) ||
+      item.trueY.toLowerCase().includes(searchVal)
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor vision dashboard to remove getDerivedStateFromProps

This method is deprecated and should be removed.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
