### PR TITLE
fix RAI dashboard for vision models crashing when selecting individual datapoints in data analysis

### DIFF
--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -24,6 +24,7 @@ export * from "./lib/Context/ModelAssessmentContext";
 export * from "./lib/util/array";
 export * from "./lib/util/buildInitialContext";
 export * from "./lib/util/DatasetUtils";
+export * from "./lib/util/ExplanationUtils";
 export * from "./lib/util/FluentUIStyles";
 export * from "./lib/util/JointDataset";
 export * from "./lib/util/JointDatasetUtils";

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortList.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortList.tsx
@@ -9,6 +9,7 @@ import {
   IExplanationModelMetadata,
   ModelTypes
 } from "../../Interfaces/IExplanationContext";
+import { IsMulticlass } from "../../util/ExplanationUtils";
 import { JointDataset } from "../../util/JointDataset";
 import { limitStringLength } from "../../util/string";
 import { Cohort } from "../Cohort";
@@ -26,7 +27,7 @@ export class CohortList extends React.PureComponent<ICohortListProps> {
     let modelType: string;
     if (this.props.metadata.modelType === ModelTypes.Binary) {
       modelType = localization.Interpret.CohortBanner.binaryClassifier;
-    } else if (this.props.metadata.modelType === ModelTypes.Multiclass) {
+    } else if (IsMulticlass(this.props.metadata.modelType)) {
       modelType = localization.Interpret.CohortBanner.multiclassClassifier;
     } else {
       modelType = localization.Interpret.CohortBanner.regressor;

--- a/libs/core-ui/src/lib/Interfaces/IExplanationContext.ts
+++ b/libs/core-ui/src/lib/Interfaces/IExplanationContext.ts
@@ -9,7 +9,8 @@ export enum ModelTypes {
   Regression = "regression",
   Binary = "binary",
   Multiclass = "multiclass",
-  Image = "image"
+  ImageMulticlass = "imagemulticlass",
+  TextMulticlass = "textmulticlass"
 }
 
 export interface IExplanationContext {

--- a/libs/core-ui/src/lib/Interfaces/IModelExplanationData.ts
+++ b/libs/core-ui/src/lib/Interfaces/IModelExplanationData.ts
@@ -12,5 +12,9 @@ export interface IModelExplanationData {
   precomputedExplanations?: IPrecomputedExplanations;
 }
 
-export type Method = "classifier" | "regressor" | "image";
+export type Method =
+  | "classifier"
+  | "regressor"
+  | "imageclassifier"
+  | "textclassifier";
 export type ModelClass = "Tree" | "EBM" | "blackbox";

--- a/libs/core-ui/src/lib/util/ExplanationUtils.ts
+++ b/libs/core-ui/src/lib/util/ExplanationUtils.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ModelTypes } from "../Interfaces/IExplanationContext";
+
+export function IsMulticlass(modelType: ModelTypes): boolean {
+  return (
+    modelType === ModelTypes.Multiclass ||
+    modelType === ModelTypes.ImageMulticlass ||
+    modelType === ModelTypes.TextMulticlass
+  );
+}
+
+export function IsClassifier(modelType: ModelTypes): boolean {
+  return (
+    modelType === ModelTypes.Binary ||
+    modelType === ModelTypes.Multiclass ||
+    modelType === ModelTypes.ImageMulticlass ||
+    modelType === ModelTypes.TextMulticlass
+  );
+}

--- a/libs/core-ui/src/lib/util/JointDataset.ts
+++ b/libs/core-ui/src/lib/util/JointDataset.ts
@@ -14,6 +14,7 @@ import {
   IExplanationModelMetadata,
   ModelTypes
 } from "../Interfaces/IExplanationContext";
+import { IsMulticlass } from "../util/ExplanationUtils";
 import {
   WeightVectors,
   WeightVectorOption
@@ -266,7 +267,7 @@ export class JointDataset {
           treatAsCategorical: true
         };
       }
-      if (args.metadata.modelType === ModelTypes.Multiclass) {
+      if (IsMulticlass(args.metadata.modelType)) {
         this.metaDict[JointDataset.ClassificationError] = {
           abbridgedLabel: localization.Interpret.Columns.classificationOutcome,
           category: ColumnCategories.Outcome,
@@ -379,7 +380,7 @@ export class JointDataset {
       row[JointDataset.ClassificationError] = predictionCategory;
       return;
     }
-    if (modelType === ModelTypes.Multiclass) {
+    if (IsMulticlass(modelType)) {
       row[JointDataset.ClassificationError] =
         row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
           ? MulticlassClassificationEnum.Misclassified

--- a/libs/core-ui/src/lib/util/StatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtils.ts
@@ -243,7 +243,7 @@ export const generateMetrics: (
       return generateRegressionStats(trueYSubset, predYSubset, errorsSubset);
     });
   }
-  if (modelType === ModelTypes.Image) {
+  if (modelType === ModelTypes.ImageMulticlass) {
     return selectionIndexes.map((selectionArray) => {
       const trueYSubset = selectionArray.map((i) => trueYs[i]);
       const predYSubset = selectionArray.map((i) => predYs[i]);

--- a/libs/core-ui/src/lib/util/buildInitialContext.ts
+++ b/libs/core-ui/src/lib/util/buildInitialContext.ts
@@ -102,15 +102,18 @@ export function getModelType(
 ): ModelTypes {
   // If Python provides a hint, use it!
   if (method) {
-    if (method === "image") {
-      return ModelTypes.Image;
-    }
     if (method === ModelTypes.Regression.valueOf() || method === "regressor") {
       return ModelTypes.Regression;
     } else if (method === ModelTypes.Binary.valueOf()) {
       return ModelTypes.Binary;
     } else if (method === ModelTypes.Multiclass.valueOf()) {
       return ModelTypes.Multiclass;
+    } else if (method === "imageclassifier") {
+      // TODO: split this into binary/multiclass once we support binary
+      return ModelTypes.ImageMulticlass;
+    } else if (method === "textclassifier") {
+      // TODO: split this into binary/multiclass once we support binary
+      return ModelTypes.TextMulticlass;
     }
   }
   switch (getClassLength(precomputedExplanations, probabilityY)) {

--- a/libs/dataset-explorer/src/lib/getGroupedData.ts
+++ b/libs/dataset-explorer/src/lib/getGroupedData.ts
@@ -7,6 +7,7 @@ import {
   IGenericChartProps,
   JointDataset
 } from "@responsible-ai/core-ui";
+import { TransformStyle } from "plotly.js";
 
 import { buildScatterTemplate } from "./buildScatterTemplate";
 import { IDatasetExplorerSeries } from "./getDatasetScatter";
@@ -16,7 +17,7 @@ export function getGroupedData(
   yData: number[],
   customData: any,
   groups: any,
-  styles: any,
+  styles: TransformStyle[] | undefined,
   jointData: JointDataset,
   chartProps?: IGenericChartProps
 ): IDatasetExplorerSeries[] {
@@ -46,14 +47,16 @@ export function getGroupedData(
     });
   }
   groupedData.forEach((d: any, index: number) => {
-    result.push({
-      color:
-        styles?.[index].value.marker?.color || getPrimaryChartColor(getTheme()),
-      data: d,
-      marker: {
-        symbol: styles?.[index].value.marker?.symbol || "circle"
-      }
-    });
+    if (styles) {
+      result.push({
+        color:
+          styles[index].value.marker?.color || getPrimaryChartColor(getTheme()),
+        data: d,
+        marker: {
+          symbol: styles[index].value.marker?.symbol?.toString() || "circle"
+        }
+      });
+    }
   });
   return result;
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
@@ -7,6 +7,7 @@ import {
   ModelTypes,
   ModelAssessmentContext,
   defaultModelAssessmentContext,
+  IsMulticlass,
   ITelemetryEvent,
   TelemetryLevels,
   TelemetryEventName
@@ -41,7 +42,7 @@ export class MetricSelector extends React.Component<IMetricSelectorProps> {
     } else if (modelType === ModelTypes.Regression) {
       options.push(this.addDropdownOption(Metrics.MeanSquaredError));
       options.push(this.addDropdownOption(Metrics.MeanAbsoluteError));
-    } else if (modelType === ModelTypes.Multiclass) {
+    } else if (IsMulticlass(modelType)) {
       dropdownStyles = {
         dropdown: { marginRight: "20px", width: 235 }
       };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -41,7 +41,8 @@ import {
   IFilter,
   WeightVectorOption,
   EditCohort,
-  ShiftCohort
+  ShiftCohort,
+  IsMulticlass
 } from "@responsible-ai/core-ui";
 import { DatasetExplorerTab } from "@responsible-ai/dataset-explorer";
 import { GlobalExplanationTab } from "@responsible-ai/interpret";
@@ -201,7 +202,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       );
     } else if (modelType === ModelTypes.Binary) {
       classLength = 2;
-    } else if (modelType === ModelTypes.Multiclass) {
+    } else if (IsMulticlass(modelType)) {
       classLength = new Set(
         [...(props.trueY || [])].concat(props.predictedY || [])
       ).size;
@@ -289,7 +290,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
     };
     const weightVectorOptions = [];
-    if (modelMetadata.modelType === ModelTypes.Multiclass) {
+    if (IsMulticlass(modelMetadata.modelType)) {
       weightVectorOptions.push(WeightVectors.AbsAvg);
     }
     modelMetadata.classNames.forEach((name, index) => {
@@ -333,10 +334,9 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       predictionTab: PredictionTabKeys.CorrectPredictionTab,
       selectedCohort: cohorts[0],
       selectedFeatures,
-      selectedWeightVector:
-        modelMetadata.modelType === ModelTypes.Multiclass
-          ? WeightVectors.AbsAvg
-          : 0,
+      selectedWeightVector: IsMulticlass(modelMetadata.modelType)
+        ? WeightVectors.AbsAvg
+        : 0,
       selectedWhatIfIndex: undefined,
       showMessageBar: false,
       viewType: ViewTypeKeys.ErrorAnalysisView,

--- a/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportance/Beehive.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportance/Beehive.tsx
@@ -12,6 +12,7 @@ import {
 } from "@fluentui/react";
 import {
   IExplanationContext,
+  IsMulticlass,
   ModelTypes,
   ModelExplanationUtils,
   FluentUIStyles
@@ -460,6 +461,8 @@ export class Beehive extends React.PureComponent<
         plotlyProps,
         this.props.selectedRow
       );
+      const modelMetadata =
+        this.props.dashboardContext.explanationContext.modelMetadata;
       return (
         <div className={beehiveStyles.aggregateChart}>
           <div className={beehiveStyles.topControls}>
@@ -510,8 +513,7 @@ export class Beehive extends React.PureComponent<
                 }
                 max={Math.min(
                   Beehive.maxFeatures,
-                  this.props.dashboardContext.explanationContext.modelMetadata
-                    .featureNames.length
+                  modelMetadata.featureNames.length
                 )}
                 min={1}
                 step={1}
@@ -520,8 +522,7 @@ export class Beehive extends React.PureComponent<
                 showValue
               />
             </div>
-            {this.props.dashboardContext.explanationContext.modelMetadata
-              .modelType === ModelTypes.Multiclass && (
+            {IsMulticlass(modelMetadata.modelType) && (
               <div>
                 <div className={beehiveStyles.selectorLabel}>
                   <span>{localization.Interpret.CrossClass.label}</span>
@@ -641,6 +642,8 @@ export class Beehive extends React.PureComponent<
     if (this.state.calloutContent) {
       this.onDismiss();
     } else {
+      const modelMetadata =
+        this.props.dashboardContext.explanationContext.modelMetadata;
       const calloutContent = (
         <div>
           <span>
@@ -649,8 +652,7 @@ export class Beehive extends React.PureComponent<
                 .globalImportanceExplanation
             }
           </span>
-          {this.props.dashboardContext.explanationContext.modelMetadata
-            .modelType === ModelTypes.Multiclass && (
+          {IsMulticlass(modelMetadata.modelType) && (
             <span>
               {
                 localization.Interpret.FeatureImportanceWrapper

--- a/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportance/Violin.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportance/Violin.tsx
@@ -13,6 +13,7 @@ import {
 } from "@fluentui/react";
 import {
   IExplanationContext,
+  IsMulticlass,
   ModelTypes,
   ModelExplanationUtils,
   FluentUIStyles
@@ -333,6 +334,8 @@ export class Violin extends React.PureComponent<
         -0.5,
         this.props.config.topK - 0.5
       ]);
+      const modelMetadata =
+        this.props.dashboardContext.explanationContext.modelMetadata;
       return (
         <div className={violinStyles.aggregateChart}>
           <div className={violinStyles.topControls}>
@@ -346,8 +349,7 @@ export class Violin extends React.PureComponent<
               useComboBoxAsMenuWidth
               styles={FluentUIStyles.smallDropdownStyle}
             />
-            {this.props.dashboardContext.explanationContext.modelMetadata
-              .modelType !== ModelTypes.Regression &&
+            {modelMetadata.modelType !== ModelTypes.Regression &&
               this.groupByOptions.length > 1 && (
                 <ComboBox
                   label={localization.Interpret.Violin.groupBy}
@@ -380,8 +382,7 @@ export class Violin extends React.PureComponent<
                 className={violinStyles.featureSlider}
                 max={Math.min(
                   Violin.maxFeatures,
-                  this.props.dashboardContext.explanationContext.modelMetadata
-                    .featureNames.length
+                  modelMetadata.featureNames.length
                 )}
                 min={1}
                 step={1}
@@ -390,8 +391,7 @@ export class Violin extends React.PureComponent<
                 showValue
               />
             </div>
-            {this.props.dashboardContext.explanationContext.modelMetadata
-              .modelType === ModelTypes.Multiclass && (
+            {IsMulticlass(modelMetadata.modelType) && (
               <div>
                 <div className={violinStyles.selectorLabel}>
                   <span className={violinStyles.selectorSpan}>
@@ -580,8 +580,10 @@ export class Violin extends React.PureComponent<
                 .globalImportanceExplanation
             }
           </span>
-          {this.props.dashboardContext.explanationContext.modelMetadata
-            .modelType === ModelTypes.Multiclass && (
+          {IsMulticlass(
+            this.props.dashboardContext.explanationContext.modelMetadata
+              .modelType
+          ) && (
             <span>
               {
                 localization.Interpret.FeatureImportanceWrapper

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
@@ -12,7 +12,7 @@ import {
 import {
   Cohort,
   IExplanationModelMetadata,
-  ModelTypes,
+  IsClassifier,
   WeightVectorOption,
   ChartTypes,
   LabelWithCallout,
@@ -85,8 +85,7 @@ export class SidePanel extends React.Component<
           onChange={this.onChartTypeChange}
           id="ChartTypeSelection"
         />
-        {(this.props.metadata.modelType === ModelTypes.Multiclass ||
-          this.props.metadata.modelType === ModelTypes.Binary) &&
+        {IsClassifier(this.props.metadata.modelType) &&
           this.state.weightOptions && (
             <div>
               <LabelWithCallout
@@ -147,10 +146,7 @@ export class SidePanel extends React.Component<
   };
 
   private getWeightOptions(): IDropdownOption[] | undefined {
-    if (
-      this.props.metadata.modelType === ModelTypes.Multiclass ||
-      this.props.metadata.modelType === ModelTypes.Binary
-    ) {
+    if (IsClassifier(this.props.metadata.modelType)) {
       return this.props.weightOptions.map((option) => {
         return {
           key: option,

--- a/libs/interpret/src/lib/MLIDashboard/Controls/Scatter/ExplanationExploration.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/Scatter/ExplanationExploration.tsx
@@ -9,7 +9,7 @@ import {
   DefaultButton,
   IconButton
 } from "@fluentui/react";
-import { ModelTypes, FluentUIStyles } from "@responsible-ai/core-ui";
+import { FluentUIStyles, IsClassifier } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { AccessibleChart, IPlotlyProperty } from "@responsible-ai/mlchartlib";
 import _ from "lodash";
@@ -77,8 +77,7 @@ export class ExplanationExploration extends React.PureComponent<
       const weightContext = this.props.dashboardContext.weightContext;
       const modelType =
         this.props.dashboardContext.explanationContext.modelMetadata.modelType;
-      const includeWeightDropdown =
-        modelType === ModelTypes.Multiclass || modelType === ModelTypes.Binary;
+      const includeWeightDropdown = IsClassifier(modelType);
       let plotProp = ScatterUtils.populatePlotlyProps(
         projectedData,
         _.cloneDeep(this.plotlyProps)

--- a/libs/interpret/src/lib/MLIDashboard/Controls/SinglePointFeatureImportance.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/SinglePointFeatureImportance.tsx
@@ -10,6 +10,7 @@ import {
 } from "@fluentui/react";
 import {
   IExplanationContext,
+  IsClassifier,
   ModelTypes,
   ILocalExplanation,
   ModelExplanationUtils,
@@ -215,19 +216,13 @@ export class SinglePointFeatureImportance extends React.PureComponent<
     //     return result;
     // }
     const modelType = this.props.explanationContext.modelMetadata.modelType;
-    if (
-      modelType !== ModelTypes.Multiclass &&
-      modelType !== ModelTypes.Binary
-    ) {
+    if (!IsClassifier(modelType)) {
       result.push({
         key: FeatureKeys.AbsoluteLocal,
         text: localization.Interpret.BarChart.absoluteLocal
       });
     }
-    if (
-      modelType === ModelTypes.Multiclass ||
-      modelType === ModelTypes.Binary
-    ) {
+    if (IsClassifier(modelType)) {
       result.push(
         ...this.props.explanationContext.modelMetadata.classNames.map(
           (className, index) => ({
@@ -245,8 +240,7 @@ export class SinglePointFeatureImportance extends React.PureComponent<
       return FeatureKeys.AbsoluteGlobal;
     }
     const modelType = this.props.explanationContext.modelMetadata.modelType;
-    return modelType === ModelTypes.Multiclass ||
-      modelType === ModelTypes.Binary
+    return IsClassifier(modelType)
       ? this.props.explanationContext.testDataset.predictedY[
           this.props.selectedRow
         ]

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -20,6 +20,8 @@ import {
 } from "@fluentui/react";
 import {
   IExplanationModelMetadata,
+  IsClassifier,
+  IsMulticlass,
   ModelTypes,
   WeightVectorOption,
   JointDataset,
@@ -207,8 +209,7 @@ export class LocalImportancePlots extends React.Component<
                   </Stack.Item>
                 </Stack>
 
-                {(this.props.metadata.modelType === ModelTypes.Multiclass ||
-                  this.props.metadata.modelType === ModelTypes.Binary) && (
+                {IsClassifier(this.props.metadata.modelType) && (
                   <div>
                     <ClassImportanceWeights
                       onWeightChange={this.props.onWeightChange}
@@ -305,7 +306,7 @@ export class LocalImportancePlots extends React.Component<
                 calloutProps={FluentUIStyles.calloutProps}
                 styles={FluentUIStyles.limitedSizeMenuDropdown}
               />
-              {this.props.metadata.modelType === ModelTypes.Multiclass && (
+              {IsMulticlass(this.props.metadata.modelType) && (
                 <ComboBox
                   autoComplete={"on"}
                   className={classNames.iceClassSelection}

--- a/libs/interpret/src/lib/MLIDashboard/SharedComponents/BarChart.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/SharedComponents/BarChart.tsx
@@ -3,8 +3,8 @@
 
 import {
   IExplanationModelMetadata,
-  ModelTypes,
-  ModelExplanationUtils
+  ModelExplanationUtils,
+  IsMulticlass
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { IPlotlyProperty, PlotlyThemes } from "@responsible-ai/mlchartlib";
@@ -166,7 +166,7 @@ export class BarChart extends React.PureComponent<IBarChartProps> {
           sortedIndexVector,
           singleSeries,
           this.props.modelMetadata.featureNames,
-          this.props.modelMetadata.modelType === ModelTypes.Multiclass
+          IsMulticlass(this.props.modelMetadata.modelType)
             ? this.props.modelMetadata.classNames[classIndex]
             : undefined,
           this.props.additionalRowData
@@ -177,7 +177,7 @@ export class BarChart extends React.PureComponent<IBarChartProps> {
           text.unshift(
             ...BarChart.buildInterceptTooltip(
               this.props.intercept[classIndex],
-              this.props.modelMetadata.modelType === ModelTypes.Multiclass
+              IsMulticlass(this.props.modelMetadata.modelType)
                 ? this.props.modelMetadata.classNames[classIndex]
                 : undefined
             )
@@ -187,10 +187,9 @@ export class BarChart extends React.PureComponent<IBarChartProps> {
         const orientation = "v";
         baseSeries.data.push({
           hoverinfo: "text",
-          name:
-            this.props.modelMetadata.modelType === ModelTypes.Multiclass
-              ? this.props.modelMetadata.classNames[classIndex]
-              : "",
+          name: IsMulticlass(this.props.modelMetadata.modelType)
+            ? this.props.modelMetadata.classNames[classIndex]
+            : "",
           orientation,
           text,
           type: "bar",

--- a/libs/interpret/src/lib/MLIDashboard/buildInitialExplanationContext.ts
+++ b/libs/interpret/src/lib/MLIDashboard/buildInitialExplanationContext.ts
@@ -4,6 +4,7 @@
 import {
   Cohort,
   IMultiClassLocalFeatureImportance,
+  IsMulticlass,
   ISingleClassLocalFeatureImportance,
   WeightVectors,
   JointDataset,
@@ -190,7 +191,7 @@ export function buildInitialExplanationContext(
     [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
   };
   const weightVectorOptions = [];
-  if (modelMetadata.modelType === ModelTypes.Multiclass) {
+  if (IsMulticlass(modelMetadata.modelType)) {
     weightVectorOptions.push(WeightVectors.AbsAvg);
   }
   modelMetadata.classNames.forEach((name, index) => {
@@ -207,10 +208,9 @@ export function buildInitialExplanationContext(
     modelMetadata,
     requestPredictions: props.requestPredictions,
     selectedCohort: cohorts[0],
-    selectedWeightVector:
-      modelMetadata.modelType === ModelTypes.Multiclass
-        ? WeightVectors.AbsAvg
-        : 0,
+    selectedWeightVector: IsMulticlass(modelMetadata.modelType)
+      ? WeightVectors.AbsAvg
+      : 0,
     showingDataSizeWarning: jointDataset.datasetRowCount > rowWarningSize,
     validationWarnings: validationCheck.errorStrings,
     weightVectorLabels,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/ProcessPreBuiltCohort.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/ProcessPreBuiltCohort.ts
@@ -5,7 +5,7 @@ import {
   ErrorCohort,
   JointDataset,
   IFilter,
-  ModelTypes,
+  IsClassifier,
   FilterMethods,
   Cohort,
   IPreBuiltFilter
@@ -113,10 +113,7 @@ function translatePreBuiltCohortFilterForTarget(
   if (cohortColumnName === CohortColumnNames.TrueY) {
     filterColumnName = JointDataset.TrueYLabel;
   }
-  if (
-    jointDataset.getModelType() === ModelTypes.Multiclass ||
-    jointDataset.getModelType() === ModelTypes.Binary
-  ) {
+  if (IsClassifier(jointDataset.getModelType())) {
     const modelClasses = jointDataset.getModelClasses();
     const index = preBuiltCohortFilter.arg
       .map((modelClass) => modelClasses.indexOf(modelClass))

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -16,7 +16,8 @@ import {
   getModelType,
   MetricCohortStats,
   DatasetTaskType,
-  Method
+  Method,
+  ModelTypes
 } from "@responsible-ai/core-ui";
 import { ErrorAnalysisOptions } from "@responsible-ai/error-analysis";
 import { localization } from "@responsible-ai/localization";
@@ -130,7 +131,9 @@ function buildModelMetadata(
       ? "regressor"
       : "classifier";
   if (props.dataset.task_type === DatasetTaskType.ImageClassification) {
-    method = "image";
+    method = "imageclassifier";
+  } else if (props.dataset.task_type === DatasetTaskType.TextClassification) {
+    method = "textclassifier";
   }
   const modelType = getModelType(
     method,
@@ -194,14 +197,20 @@ function buildModelMetadata(
     featureNamesAbridged = featureNames;
   }
   let classNames = props.dataset.class_names;
-  const classLength = getClassLength(
-    props.modelExplanationData?.[0]?.precomputedExplanations,
-    props.dataset.probability_y
-  );
-  if (!classNames || classNames.length !== classLength) {
-    classNames = buildIndexedNames(
-      classLength,
-      localization.ErrorAnalysis.defaultClassNames
+  if (modelType !== ModelTypes.ImageMulticlass) {
+    const classLength = getClassLength(
+      props.modelExplanationData?.[0]?.precomputedExplanations,
+      props.dataset.probability_y
+    );
+    if (!classNames || classNames.length !== classLength) {
+      classNames = buildIndexedNames(
+        classLength,
+        localization.ErrorAnalysis.defaultClassNames
+      );
+    }
+  } else if (!classNames) {
+    throw new Error(
+      "Invalid input data for image classification, class names required."
     );
   }
   const featureIsCategorical = ModelMetadata.buildIsCategorical(

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -27,6 +27,7 @@ import {
   ErrorCohort,
   ILabeledStatistic,
   ITelemetryEvent,
+  IsMulticlass,
   TelemetryLevels,
   TelemetryEventName,
   DatasetTaskType,
@@ -176,7 +177,7 @@ export class ModelOverview extends React.Component<
 
     const selectableMetrics = getSelectableMetrics(
       this.context.dataset.task_type,
-      this.context.jointDataset.getModelType() === ModelTypes.Multiclass
+      IsMulticlass(this.context.jointDataset.getModelType())
     );
 
     const columns: string[] = [

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -14,11 +14,11 @@ import {
 } from "@responsible-ai/causality";
 import {
   WeightVectorOption,
-  ModelTypes,
   WeightVectors,
   ModelAssessmentContext,
   defaultModelAssessmentContext,
-  IModelAssessmentContext
+  IModelAssessmentContext,
+  IsMulticlass
 } from "@responsible-ai/core-ui";
 import { CounterfactualsTab } from "@responsible-ai/counterfactuals";
 import {
@@ -91,7 +91,7 @@ export class TabsView extends React.PureComponent<
       [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
     };
     const weightVectorOptions = [];
-    if (props.modelMetadata.modelType === ModelTypes.Multiclass) {
+    if (IsMulticlass(props.modelMetadata.modelType)) {
       weightVectorOptions.push(WeightVectors.AbsAvg);
     }
     props.modelMetadata.classNames.forEach((name, index) => {
@@ -112,10 +112,9 @@ export class TabsView extends React.PureComponent<
       mapShiftErrorAnalysisOption: ErrorAnalysisOptions.TreeMap,
       mapShiftVisible: false,
       selectedFeatures: props.dataset.feature_names,
-      selectedWeightVector:
-        props.modelMetadata.modelType === ModelTypes.Multiclass
-          ? WeightVectors.AbsAvg
-          : 0,
+      selectedWeightVector: IsMulticlass(props.modelMetadata.modelType)
+        ? WeightVectors.AbsAvg
+        : 0,
       weightVectorLabels,
       weightVectorOptions
     };


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix RAI dashboard for vision models crashing when selecting individual datapoints in data analysis.

This PR refactors the UI backend code to handle tabular, image and text multiclass scenarios more consistently with a helper method IsMulticlass.  We were previously only doing certain transformations for multiclass tabular case which was causing the crash to appear.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
