### PR TITLE
fix flaky test test_rai_insights_add_save_load_save on dataset fetch

### DIFF
--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -22,6 +22,8 @@ from sklearn.preprocessing import (FunctionTransformer, OneHotEncoder,
                                    StandardScaler)
 from xgboost import XGBClassifier
 
+from raiutils.common.retries import retry_function
+
 
 def create_sklearn_random_forest_classifier(X, y):
     rfc = RandomForestClassifier(n_estimators=10, max_depth=4,
@@ -189,8 +191,23 @@ def create_housing_data(create_small_dataset=True):
     return x_train, x_test, y_train, y_test, housing.feature_names
 
 
+class FetchDiceAdultCensusIncomeDataset(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        return helpers.load_adult_income_dataset()
+
+
 def create_adult_income_dataset(create_small_dataset=True):
-    dataset = helpers.load_adult_income_dataset()
+    fetcher = FetchDiceAdultCensusIncomeDataset()
+    action_name = "Adult dataset download"
+    err_msg = "Failed to download adult dataset"
+    max_retries = 4
+    retry_delay = 60
+    dataset = retry_function(fetcher.fetch, action_name, err_msg,
+                             max_retries=max_retries,
+                             retry_delay=retry_delay)
     continuous_features = ['age', 'hours_per_week']
     target_name = 'income'
     target = dataset[target_name]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The test test_rai_insights_add_save_load_save is flaky has been erroring including on the build:

https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3087387703/jobs/4992705136

The underlying error was a networking issue:

```
>           raise FileNotFoundError(f"{path} not found.")
E           FileNotFoundError: https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data not found.
```

Adding simple retry logic around it via raiutils retry_function method makes the test more reliable.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
