### PR TITLE
fix table view for image and text based on discussions for local importances and data analysis

### DIFF
--- a/libs/dataset-explorer/src/lib/DataAnalysisTab.tsx
+++ b/libs/dataset-explorer/src/lib/DataAnalysisTab.tsx
@@ -55,7 +55,6 @@ export class DataAnalysisTab extends React.Component<IDataAnalysisTabProps> {
             jointDataset={this.context.jointDataset}
             selectedCohort={this.context.selectedErrorCohort}
             modelType={this.context.modelMetadata.modelType}
-            onAllSelectedItemsChange={this.props.onAllSelectedItemsChange}
             telemetryHook={this.props.telemetryHook}
           />
         </PivotItem>

--- a/libs/dataset-explorer/src/lib/TableView/TableView.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableView.tsx
@@ -50,33 +50,40 @@ export class TableView extends React.Component<
     defaultModelAssessmentContext;
   private readonly maxSelectableTabular = 5;
   private readonly maxSelectableText = 1;
-  private selection: Selection = new Selection({
-    onSelectionChanged: (): void => {
-      const c = this.selection.getSelectedCount();
-      const indices = this.selection.getSelectedIndices();
-      const hasTextImportances =
-        !!this.context.modelExplanationData?.precomputedExplanations
-          ?.textFeatureImportance;
-      const maxSelectable = hasTextImportances
-        ? this.maxSelectableText
-        : this.maxSelectableTabular;
-      if (c === maxSelectable) {
-        this.setState({ selectedIndices: indices });
-      }
-      if (c > maxSelectable) {
-        for (const index of indices) {
-          if (!this.state.selectedIndices.includes(index)) {
-            this.setState({ indexToUnselect: index });
+  private selection?: Selection | undefined = this.props
+    .onAllSelectedItemsChange
+    ? new Selection({
+        onSelectionChanged: (): void => {
+          if (this.selection) {
+            const c = this.selection.getSelectedCount();
+            const indices = this.selection.getSelectedIndices();
+            const hasTextImportances =
+              !!this.context.modelExplanationData?.precomputedExplanations
+                ?.textFeatureImportance;
+            const maxSelectable = hasTextImportances
+              ? this.maxSelectableText
+              : this.maxSelectableTabular;
+            if (c === maxSelectable) {
+              this.setState({ selectedIndices: indices });
+            }
+            if (c > maxSelectable) {
+              for (const index of indices) {
+                if (!this.state.selectedIndices.includes(index)) {
+                  this.setState({ indexToUnselect: index });
+                }
+              }
+            }
+            this.props.onAllSelectedItemsChange?.(
+              this.selection.getSelection()
+            );
+            this.props.telemetryHook?.({
+              level: TelemetryLevels.ButtonClick,
+              type: TelemetryEventName.IndividualFeatureImportanceSelectedDatapointsUpdated
+            });
           }
         }
-      }
-      this.props.onAllSelectedItemsChange(this.selection.getSelection());
-      this.props.telemetryHook?.({
-        level: TelemetryLevels.ButtonClick,
-        type: TelemetryEventName.IndividualFeatureImportanceSelectedDatapointsUpdated
-      });
-    }
-  });
+      })
+    : this.props.onAllSelectedItemsChange;
 
   public constructor(props: ITableViewProps) {
     super(props);
@@ -87,35 +94,16 @@ export class TableView extends React.Component<
       selectedIndices,
       ...tableState
     };
-
-    if (this.props.subsetSelectedItems) {
-      this.selection.setItems(tableState.rows);
-      this.props.subsetSelectedItems.forEach((_, index) =>
-        this.selection.setIndexSelected(index, true, true)
-      );
-    }
   }
 
   public componentDidUpdate(prevProps: ITableViewProps): void {
-    if (
-      this.props.selectedCohort !== prevProps.selectedCohort ||
-      this.props.subsetSelectedItems !== prevProps.subsetSelectedItems
-    ) {
+    if (this.props.selectedCohort !== prevProps.selectedCohort) {
       const newItems = this.updateItems();
-      let selectedIndices = this.state.selectedIndices;
-      if (this.props.subsetSelectedItems) {
-        this.selection.setItems(newItems.rows);
-        selectedIndices = this.props.subsetSelectedItems.map(
-          (_, index) => index
-        );
-        selectedIndices.forEach((index) =>
-          this.selection.setIndexSelected(index, true, true)
-        );
-      }
+      const selectedIndices = this.state.selectedIndices;
       this.setState(newItems, () => this.setState({ selectedIndices }));
     }
     if (this.state.indexToUnselect) {
-      this.selection.toggleIndexSelected(this.state.indexToUnselect);
+      this.selection?.toggleIndexSelected(this.state.indexToUnselect);
       this.setState({ indexToUnselect: undefined });
     }
   }
@@ -138,23 +126,22 @@ export class TableView extends React.Component<
     }
     let selectAllVisibility = SelectAllVisibility.hidden;
     let selectionMode = SelectionMode.multiple;
-    if (hasTextImportances) {
-      if (this.props.subsetSelectedItems) {
-        selectAllVisibility = SelectAllVisibility.none;
-        selectionMode = SelectionMode.none;
-      } else {
-        selectionMode = SelectionMode.single;
-      }
+    if (!this.props.onAllSelectedItemsChange) {
+      selectAllVisibility = SelectAllVisibility.none;
+      selectionMode = SelectionMode.none;
+    } else if (hasTextImportances) {
+      selectionMode = SelectionMode.single;
     }
+
     return (
       <Stack>
-        {!hasTextImportances && (
+        {!hasTextImportances && !!this.props.onAllSelectedItemsChange && (
           <Stack.Item className={classNames.selectionCounter}>
             <LabelWithCallout
               label={localization.formatString(
                 localization.ModelAssessment.FeatureImportances
                   .SelectionCounter,
-                this.selection.count,
+                this.selection?.count,
                 this.maxSelectableTabular
               )}
               calloutTitle={undefined}
@@ -174,34 +161,13 @@ export class TableView extends React.Component<
             })}
           >
             <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
-              <MarqueeSelection selection={this.selection}>
-                <DetailsList
-                  items={this.state.rows}
-                  columns={this.state.columns}
-                  groups={this.state.groups}
-                  setKey="set"
-                  layoutMode={DetailsListLayoutMode.fixedColumns}
-                  constrainMode={ConstrainMode.unconstrained}
-                  onRenderDetailsHeader={generateOnRenderDetailsHeader(
-                    selectAllVisibility
-                  )}
-                  selectionPreservedOnEmptyClick
-                  ariaLabelForSelectionColumn={
-                    localization.ModelAssessment.FeatureImportances
-                      .SelectionColumnAriaLabel
-                  }
-                  checkButtonAriaLabel={
-                    localization.ModelAssessment.FeatureImportances
-                      .RowCheckboxAriaLabel
-                  }
-                  groupProps={{
-                    onRenderHeader: onRenderGroupHeader,
-                    showEmptyGroups: true
-                  }}
-                  selectionMode={selectionMode}
-                  selection={this.selection}
-                />
-              </MarqueeSelection>
+              {this.selection && (
+                <MarqueeSelection selection={this.selection}>
+                  {this.getDetailsList(selectAllVisibility, selectionMode)}
+                </MarqueeSelection>
+              )}
+              {!this.selection &&
+                this.getDetailsList(selectAllVisibility, selectionMode)}
             </ScrollablePane>
           </div>
         </Stack.Item>
@@ -209,63 +175,90 @@ export class TableView extends React.Component<
     );
   }
 
+  private getDetailsList(
+    selectAllVisibility: SelectAllVisibility,
+    selectionMode: SelectionMode
+  ): React.ReactNode {
+    return (
+      <DetailsList
+        items={this.state.rows}
+        columns={this.state.columns}
+        groups={this.state.groups}
+        setKey="set"
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        constrainMode={ConstrainMode.unconstrained}
+        onRenderDetailsHeader={generateOnRenderDetailsHeader(
+          selectAllVisibility
+        )}
+        selectionPreservedOnEmptyClick
+        ariaLabelForSelectionColumn={
+          localization.ModelAssessment.FeatureImportances
+            .SelectionColumnAriaLabel
+        }
+        checkButtonAriaLabel={
+          localization.ModelAssessment.FeatureImportances.RowCheckboxAriaLabel
+        }
+        groupProps={{
+          onRenderHeader: onRenderGroupHeader,
+          showEmptyGroups: true
+        }}
+        selectionMode={selectionMode}
+        selection={this.selection}
+      />
+    );
+  }
+
   private updateItems(): ITableViewTableState {
     let groups: IGroup[] | undefined;
 
     let filteredDataRows: Array<{ [key: string]: number }> = [];
-    if (this.props.subsetSelectedItems) {
-      filteredDataRows = this.props.subsetSelectedItems.map((row) => {
-        return this.props.jointDataset.getRow(row[0]);
-      });
+    // assume classifier by default, otherwise regressor
+    if (
+      this.props.modelType &&
+      this.props.modelType === ModelTypes.Regression
+    ) {
+      // don't use groups since there are no correct/incorrect buckets
+      this.props.selectedCohort.cohort.sort();
     } else {
-      // assume classifier by default, otherwise regressor
-      if (
-        this.props.modelType &&
-        this.props.modelType === ModelTypes.Regression
-      ) {
-        // don't use groups since there are no correct/incorrect buckets
-        this.props.selectedCohort.cohort.sort();
-      } else {
-        this.props.selectedCohort.cohort.sortByGroup(
-          JointDataset.IndexLabel,
+      this.props.selectedCohort.cohort.sortByGroup(
+        JointDataset.IndexLabel,
+        (row) =>
+          row[JointDataset.TrueYLabel] === row[JointDataset.PredictedYLabel]
+      );
+      // find first incorrect item
+      const firstIncorrectItemIndex =
+        this.props.selectedCohort.cohort.filteredData.findIndex(
           (row) =>
-            row[JointDataset.TrueYLabel] === row[JointDataset.PredictedYLabel]
+            row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
         );
-        // find first incorrect item
-        const firstIncorrectItemIndex =
-          this.props.selectedCohort.cohort.filteredData.findIndex(
-            (row) =>
-              row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
-          );
-        const noIncorrectItem = firstIncorrectItemIndex === -1;
+      const noIncorrectItem = firstIncorrectItemIndex === -1;
 
-        groups = [
-          {
-            count: noIncorrectItem
-              ? this.props.selectedCohort.cohort.filteredData.length
-              : firstIncorrectItemIndex,
-            isCollapsed: true,
-            key: "groupCorrect",
-            level: 0,
-            name: localization.ModelAssessment.FeatureImportances
-              .CorrectPredictions,
-            startIndex: 0
-          },
-          {
-            count: noIncorrectItem
-              ? 0
-              : this.props.selectedCohort.cohort.filteredData.length -
-                firstIncorrectItemIndex,
-            key: "groupIncorrect",
-            level: 0,
-            name: localization.ModelAssessment.FeatureImportances
-              .IncorrectPredictions,
-            startIndex: firstIncorrectItemIndex
-          }
-        ];
-      }
-      filteredDataRows = this.props.selectedCohort.cohort.filteredData;
+      groups = [
+        {
+          count: noIncorrectItem
+            ? this.props.selectedCohort.cohort.filteredData.length
+            : firstIncorrectItemIndex,
+          isCollapsed: true,
+          key: "groupCorrect",
+          level: 0,
+          name: localization.ModelAssessment.FeatureImportances
+            .CorrectPredictions,
+          startIndex: 0
+        },
+        {
+          count: noIncorrectItem
+            ? 0
+            : this.props.selectedCohort.cohort.filteredData.length -
+              firstIncorrectItemIndex,
+          key: "groupIncorrect",
+          level: 0,
+          name: localization.ModelAssessment.FeatureImportances
+            .IncorrectPredictions,
+          startIndex: firstIncorrectItemIndex
+        }
+      ];
     }
+    filteredDataRows = this.props.selectedCohort.cohort.filteredData;
 
     const numRows: number = filteredDataRows.length;
     const indices = filteredDataRows.map((row: { [key: string]: number }) => {

--- a/libs/dataset-explorer/src/lib/TableView/TableViewProps.ts
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewProps.ts
@@ -14,7 +14,6 @@ export interface ITableViewProps {
   jointDataset: JointDataset;
   selectedCohort: ErrorCohort;
   modelType?: ModelTypes;
-  onAllSelectedItemsChange: (allSelectedItems: IObjectWithKey[]) => void;
-  subsetSelectedItems?: IObjectWithKey[];
+  onAllSelectedItemsChange?: (allSelectedItems: IObjectWithKey[]) => void;
   telemetryHook?: (message: ITelemetryEvent) => void;
 }

--- a/libs/dataset-explorer/src/lib/TableView/TableViewTab.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableViewTab.tsx
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 import { Stack, Text } from "@fluentui/react";
-import {
-  defaultModelAssessmentContext,
-  ModelAssessmentContext
-} from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
@@ -14,34 +10,14 @@ import { ITableViewProps } from "./TableViewProps";
 import { tableViewTabStyles } from "./TableViewTab.styles";
 
 export class TableViewTab extends React.Component<ITableViewProps> {
-  public static contextType = ModelAssessmentContext;
-  public context: React.ContextType<typeof ModelAssessmentContext> =
-    defaultModelAssessmentContext;
-
   public render(): React.ReactNode {
-    const hasTextImportances =
-      !!this.context.modelExplanationData?.precomputedExplanations
-        ?.textFeatureImportance;
     const classNames = tableViewTabStyles();
     return (
       <Stack tokens={{ padding: "l1" }}>
         <Stack.Item className={classNames.infoWithText}>
-          {!hasTextImportances && (
-            <Text variant="medium">
-              {
-                localization.ModelAssessment.FeatureImportances
-                  .IndividualFeatureTabular
-              }
-            </Text>
-          )}
-          {hasTextImportances && (
-            <Text variant="medium">
-              {
-                localization.ModelAssessment.FeatureImportances
-                  .IndividualFeatureText
-              }
-            </Text>
-          )}
+          <Text variant="medium">
+            {localization.ModelAssessment.TableViewTab.Heading}
+          </Text>
         </Stack.Item>
         <Stack.Item>
           <TableView
@@ -49,7 +25,6 @@ export class TableViewTab extends React.Component<ITableViewProps> {
             jointDataset={this.props.jointDataset}
             selectedCohort={this.props.selectedCohort}
             modelType={this.props.modelType}
-            onAllSelectedItemsChange={this.props.onAllSelectedItemsChange}
             telemetryHook={this.props.telemetryHook}
           />
         </Stack.Item>

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1609,8 +1609,7 @@
       "SelectionColumnAriaLabel": "Toggle selection"
     },
     "IndividualFeatureImportanceView": {
-      "SmallInstanceSelection": "Instance selection",
-      "SmallTableText": "(change instances to explain in data analysis)"
+      "SmallInstanceSelection": "Instance selection"
     },
     "MainMenu": {
       "DashboardSettings": "Dashboard configuration",
@@ -1767,6 +1766,9 @@
       "infoTitle": "Additional information on model overview",
       "visualDisplayToggleLabel": "Show heatmap",
       "featureBasedViewDescription": "Select up to two features to see the model performance breakdown across feature-based cohorts (if one feature is selected) or intersectional cohorts (if two features are selected)."
+    },
+    "TableViewTab": {
+      "Heading": "View the dataset in a table format for all features and rows."
     }
   }
 }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/IndividualFeatureImportanceView.tsx
@@ -45,18 +45,23 @@ export class IndividualFeatureImportanceView extends React.Component<
         tokens={verticalComponentTokens}
         id="IndividualFeatureImportanceView"
       >
-        <Stack horizontal tokens={horizontalComponentTokens}>
+        <Stack
+          horizontal
+          tokens={horizontalComponentTokens}
+          verticalAlign="center"
+        >
           <Label className={classNames.boldText}>
             {
               localization.ModelAssessment.IndividualFeatureImportanceView
                 .SmallInstanceSelection
             }
           </Label>
-          <Text variant="large">
-            {
-              localization.ModelAssessment.IndividualFeatureImportanceView
-                .SmallTableText
-            }
+          <Text variant="medium">
+            {hasTextImportances
+              ? localization.ModelAssessment.FeatureImportances
+                  .IndividualFeatureText
+              : localization.ModelAssessment.FeatureImportances
+                  .IndividualFeatureTabular}
           </Text>
         </Stack>
         <TableView
@@ -85,7 +90,7 @@ export class IndividualFeatureImportanceView extends React.Component<
         {hasTextImportances && (
           <TextLocalImportancePlots
             jointDataset={this.context.jointDataset}
-            selectedItems={this.props.allSelectedItems}
+            selectedItems={this.state.allSubsetSelectedItems}
             selectedWeightVector={this.props.selectedWeightVector}
             weightOptions={this.props.weightOptions}
             weightLabels={this.props.weightLabels}


### PR DESCRIPTION
## Description

Based on recent discussions, we found that the table view is confusing for users.  As a short-term fix, the table view has been duplicated across data analysis and feature importances components.  In the longer term future, we are still discussing what the UI design might look like.  This PR fixes this, which was already partly done in:

https://github.com/microsoft/responsible-ai-toolbox/pull/1726

so that the heading text is more consistent, the data analysis table can't be selected, and the feature importances for the text dashboard can once again be selected (as PR broke the selection mechanism for text dashboard).

Screenshot where data analysis is no longer selectable:

![image](https://user-images.githubusercontent.com/24683184/191370354-d7d97c83-24d2-4faa-8146-24cdb139aaf8.png)

Local importance selection is fixed in text case again (with new header text):

![image](https://user-images.githubusercontent.com/24683184/191370439-7f16b6d0-865c-47d8-8520-60a61451daeb.png)

Updated local importances section for tabular data (with new header text):

![image](https://user-images.githubusercontent.com/24683184/191370607-1e48ca74-ac3c-4681-b06d-12d08f15b3e4.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
