### PR TITLE
in RAI text dashboard, fix topK and maxK on slidebar not updating when selecting different text documents

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/TextExplanationView.tsx
@@ -48,6 +48,8 @@ const componentStackTokens: IStackTokens = {
   padding: "m"
 };
 
+const MaxImportantWords = 15;
+
 export class TextExplanationView extends React.PureComponent<
   ITextExplanationViewProps,
   ITextExplanationViewState
@@ -62,12 +64,14 @@ export class TextExplanationView extends React.PureComponent<
       this.props.dataSummary.localExplanations,
       weightVector
     );
+    const maxK = this.calculateMaxKImportances(importances);
+    const topK = this.calculateTopKImportances(importances);
     this.state = {
       importances,
-      maxK: Math.min(15, Math.ceil(Utils.countNonzeros(importances))),
+      maxK,
       radio: RadioKeys.All,
       text: this.props.dataSummary.text,
-      topK: Math.ceil(Utils.countNonzeros(importances) / 2)
+      topK
     };
   }
 
@@ -117,7 +121,7 @@ export class TextExplanationView extends React.PureComponent<
                   min={1}
                   max={this.state.maxK}
                   step={1}
-                  defaultValue={this.state.topK}
+                  value={this.state.topK}
                   showValue
                   onChange={this.setTopK}
                 />
@@ -175,7 +179,28 @@ export class TextExplanationView extends React.PureComponent<
       this.props.dataSummary.localExplanations,
       weightOption
     );
-    this.setState({ importances, text: this.props.dataSummary.text });
+    const topK = this.calculateTopKImportances(importances);
+    const maxK = this.calculateMaxKImportances(importances);
+    this.setState({
+      importances,
+      maxK,
+      text: this.props.dataSummary.text,
+      topK
+    });
+  }
+
+  private calculateTopKImportances(importances: number[]): number {
+    return Math.min(
+      MaxImportantWords,
+      Math.ceil(Utils.countNonzeros(importances) / 2)
+    );
+  }
+
+  private calculateMaxKImportances(importances: number[]): number {
+    return Math.min(
+      MaxImportantWords,
+      Math.ceil(Utils.countNonzeros(importances))
+    );
   }
 
   private computeImportancesForWeightVector(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In RAI text dashboard, the slidebar is currently not updating when selecting different instances correctly.  We should recompute the current set value and the max value in the slidebar when the user selects different documents/instances.  It is questionable though if we indeed want to "reset" the current topK value, as the user may want to keep the same number of top words when selecting different instances, but I think it is better to do this since the current value may not make sense when looking at documents that vary in # of words significantly.  However for maxK parameter (the max number of words user can view in text highlighting component) we definitely should recompute this value and it is a clear bug not to do this.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
