### PR TITLE
remove duplicate settings button in RAI dashboard for images

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Pivots.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Pivots.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Stack, Pivot, PivotItem, CommandBarButton } from "@fluentui/react";
+import { Stack, Pivot, PivotItem } from "@fluentui/react";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
@@ -17,46 +17,27 @@ export class Pivots extends React.Component<IPivotsProps> {
   public render(): React.ReactNode {
     const classNames = visionExplanationDashboardStyles();
     return (
-      <Stack>
-        <Stack.Item>
-          <Stack horizontal horizontalAlign="space-between" verticalAlign="end">
-            <Stack.Item>
-              <Pivot
-                selectedKey={this.props.selectedKey}
-                onLinkClick={this.props.onLinkClick}
-                linkSize={"normal"}
-                headersOnly
-                className={classNames.tabs}
-              >
-                <PivotItem
-                  headerText={
-                    localization.InterpretVision.Dashboard.tabOptionFirst
-                  }
-                  itemKey={VisionDatasetExplorerTabOptions.ImageExplorerView}
-                />
-                <PivotItem
-                  headerText={
-                    localization.InterpretVision.Dashboard.tabOptionSecond
-                  }
-                  itemKey={VisionDatasetExplorerTabOptions.TableView}
-                />
-                <PivotItem
-                  headerText={
-                    localization.InterpretVision.Dashboard.tabOptionThird
-                  }
-                  itemKey={VisionDatasetExplorerTabOptions.DataCharacteristics}
-                />
-              </Pivot>
-            </Stack.Item>
-            <Stack.Item>
-              <CommandBarButton
-                className={classNames.filterButton}
-                iconProps={{ iconName: "Settings" }}
-                text={localization.InterpretVision.Dashboard.settings}
-              />
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
+      <Stack horizontal horizontalAlign="space-between" verticalAlign="end">
+        <Pivot
+          selectedKey={this.props.selectedKey}
+          onLinkClick={this.props.onLinkClick}
+          linkSize={"normal"}
+          headersOnly
+          className={classNames.tabs}
+        >
+          <PivotItem
+            headerText={localization.InterpretVision.Dashboard.tabOptionFirst}
+            itemKey={VisionDatasetExplorerTabOptions.ImageExplorerView}
+          />
+          <PivotItem
+            headerText={localization.InterpretVision.Dashboard.tabOptionSecond}
+            itemKey={VisionDatasetExplorerTabOptions.TableView}
+          />
+          <PivotItem
+            headerText={localization.InterpretVision.Dashboard.tabOptionThird}
+            itemKey={VisionDatasetExplorerTabOptions.DataCharacteristics}
+          />
+        </Pivot>
       </Stack>
     );
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove duplicate settings button in RAI dashboard for images.
The settings button is a duplicate of the settings button at the top of the dashboard.

Before changes:
![image](https://user-images.githubusercontent.com/24683184/192550832-21357125-12c0-4508-b7df-c77ece35a7e6.png)

After changes:
![image](https://user-images.githubusercontent.com/24683184/192550981-daf813c5-1e35-4cc4-a186-cfff27b54c57.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
