### PR TITLE
in data characteristics of RAI vision dashboard, fix bug where labels to display is reset when changing number of rows

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
@@ -42,12 +42,14 @@ export class DataCharacteristics extends React.Component<
   }
 
   public componentDidMount(): void {
-    this.processData();
+    this.processData(true);
   }
 
   public componentDidUpdate(prevProps: IDataCharacteristicsProps): void {
-    if (prevProps.items !== this.props.items) {
-      this.processData();
+    if (this.props.items !== prevProps.items) {
+      this.processData(true);
+    } else if (this.props.searchValue !== prevProps.searchValue) {
+      this.processData(false);
     }
   }
 
@@ -139,7 +141,6 @@ export class DataCharacteristics extends React.Component<
                         label={label}
                         labelType={this.state.labelType}
                         list={list}
-                        processData={this.processData}
                         renderStartIndex={this.state.renderStartIndex}
                         showBackArrow={this.state.showBackArrow}
                         totalListLength={this.props.items.length}
@@ -162,12 +163,12 @@ export class DataCharacteristics extends React.Component<
     );
   }
 
-  private processData = (): void => {
+  private processData = (resetLabels: boolean): void => {
     const filteredItems = getFilteredDataFromSearch(
       this.props.searchValue,
       this.props.items
     );
-    this.setState(processItems(filteredItems));
+    this.setState(processItems(filteredItems, resetLabels, this.state));
   };
 
   private onRenderCell = (

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsHelper.ts
@@ -115,7 +115,9 @@ function generateItems(type: string, examples: IVisionListItem[]): IItemsData {
 }
 
 export function processItems(
-  items: IVisionListItem[]
+  items: IVisionListItem[],
+  resetLabels: boolean,
+  state: IDataCharacteristicsState
 ): Pick<
   IDataCharacteristicsState,
   | "columnCount"
@@ -138,15 +140,22 @@ export function processItems(
   const predicted: IItemsData = generateItems(labelTypes.predictedY, examples);
   const dropdownOptionsPredicted: IDropdownOption[] = predicted.dropdownOptions;
   const itemsPredicted: Map<string, IVisionListItem[]> = predicted.items;
-  const labelVisibilitiesPredicted: Map<string, boolean> =
-    predicted.labelVisibilities;
-  const selectedKeysPredicted: string[] = predicted.selectedKeys;
 
   const trues: IItemsData = generateItems(labelTypes.trueY, examples);
   const dropdownOptionsTrue: IDropdownOption[] = trues.dropdownOptions;
   const itemsTrue: Map<string, IVisionListItem[]> = trues.items;
-  const labelVisibilitiesTrue: Map<string, boolean> = trues.labelVisibilities;
-  const selectedKeysTrue: string[] = trues.selectedKeys;
+
+  let labelVisibilitiesPredicted: Map<string, boolean> =
+    predicted.labelVisibilities;
+  let selectedKeysPredicted: string[] = predicted.selectedKeys;
+  let labelVisibilitiesTrue: Map<string, boolean> = trues.labelVisibilities;
+  let selectedKeysTrue: string[] = trues.selectedKeys;
+  if (!resetLabels) {
+    labelVisibilitiesPredicted = state.labelVisibilitiesPredicted;
+    selectedKeysPredicted = state.selectedKeysPredicted;
+    labelVisibilitiesTrue = state.labelVisibilitiesTrue;
+    selectedKeysTrue = state.selectedKeysTrue;
+  }
 
   selectedKeysPredicted.forEach(() => {
     renderStartIndex.push(0);

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsRow.tsx
@@ -27,7 +27,6 @@ export interface IDataCharacteristicsRowProps {
   showBackArrow: boolean[];
   totalListLength: number;
   onRenderCell: (item?: IVisionListItem | undefined) => JSX.Element;
-  processData: () => void;
   loadPrevItems: (index: number) => () => void;
   loadNextItems: (index: number) => () => void;
   getPageHeight: () => number;

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TabsView.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TabsView.tsx
@@ -33,11 +33,33 @@ export interface ITabsViewProps {
   setSelectedCohort: (cohort: ErrorCohort) => void;
 }
 
+export interface ITabViewState {
+  items: IVisionListItem[];
+}
+
 const stackTokens = {
   childrenGap: "l1"
 };
 
-export class TabsView extends React.Component<ITabsViewProps> {
+export class TabsView extends React.Component<ITabsViewProps, ITabViewState> {
+  public constructor(props: ITabsViewProps) {
+    super(props);
+    this.state = {
+      items: this.props.errorInstances.concat(...this.props.successInstances)
+    };
+  }
+
+  public componentDidUpdate(prevProps: ITabsViewProps): void {
+    if (
+      this.props.errorInstances !== prevProps.errorInstances ||
+      this.props.successInstances !== prevProps.successInstances
+    ) {
+      this.setState({
+        items: this.props.errorInstances.concat(...this.props.successInstances)
+      });
+    }
+  }
+
   public render(): React.ReactNode {
     const classNames = visionExplanationDashboardStyles();
     switch (this.props.selectedKey) {
@@ -49,9 +71,7 @@ export class TabsView extends React.Component<ITabsViewProps> {
           >
             <Stack.Item style={{ width: "100%" }}>
               <DataCharacteristics
-                items={this.props.errorInstances.concat(
-                  ...this.props.successInstances
-                )}
+                items={this.state.items}
                 imageDim={this.props.imageDim}
                 numRows={this.props.numRows}
                 searchValue={this.props.searchValue}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In data characteristics of RAI vision dashboard, fix bug where labels to display is reset when changing number of rows.

Repro steps:
![image](https://user-images.githubusercontent.com/24683184/192569859-92cbbc6e-508e-4ecc-a16f-0aeba104479c.png)

select milk_bottle in the select labels to display combo box
change rows 
the select labels to display comobox gets reset

New behavior: the labels to display does not get reset.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
