### PR TITLE
Add validations to catch empty train/test scenarios

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -287,6 +287,12 @@ class RAIInsights(RAIBaseInsights):
                     'The serializer should be serializable via pickle')
 
         if isinstance(train, pd.DataFrame) and isinstance(test, pd.DataFrame):
+            if len(train) <= 0 or len(test) <= 0:
+                raise UserConfigValidationException(
+                    'Either of the train/test are empty. '
+                    'Please provide non-empty dataframes for train '
+                    'and test sets.'
+                )
             if test.shape[0] > maximum_rows_for_test:
                 msg_fmt = 'The test data has {0} rows, ' +\
                     'but limit is set to {1} rows. ' +\

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -60,6 +60,40 @@ class TestRAIInsightsValidations:
             "adjust maximum_rows_for_test" in \
             str(ucve.value)
 
+    def test_empty_train_or_test_datasets(self):
+        X_train, X_test, y_train, y_test, _, _ = \
+            create_iris_data()
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+        X_test_empty = pd.DataFrame(columns=X_test.columns)
+        X_train_empty = pd.DataFrame(columns=X_train.columns)
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match='Either of the train/test are empty. '
+                      'Please provide non-empty dataframes for train '
+                      'and test sets.'):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test_empty,
+                target_column=TARGET,
+                task_type='classification')
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match='Either of the train/test are empty. '
+                      'Please provide non-empty dataframes for train '
+                      'and test sets.'):
+            RAIInsights(
+                model=model,
+                train=X_train_empty,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification')
+
     def test_validate_bad_target_name(self):
         X_train, X_test, y_train, y_test, _, _ = \
             create_iris_data()


### PR DESCRIPTION
## Description

Adding these validations to make sure the downstream predict calls don't fail unexpectedly. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
