### PR TITLE
Add model wrapper for wrapping predictions and test data

### DIFF
--- a/raiwidgets/tests/common_utils.py
+++ b/raiwidgets/tests/common_utils.py
@@ -2,8 +2,15 @@
 # Licensed under the MIT License.
 
 import json
+from typing import Optional
+
+import numpy as np
+import pandas as pd
 
 from raiwidgets.interfaces import WidgetRequestResponseConstants
+from responsibleai.exceptions import SystemErrorException
+
+TARGET = 'target'
 
 
 class CheckResponsibleAIDashboardInputTestResult:
@@ -29,3 +36,159 @@ class CheckResponsibleAIDashboardInputTestResult:
         assert expected_error_message in \
             flask_server_prediction_output[
                 WidgetRequestResponseConstants.error]
+
+
+class EmptyDataFrameException(SystemErrorException):
+    """An exception indicating that some an empty dataframe
+    is being used for prediction.
+
+    :param exception_message: A message describing the error.
+    :type exception_message: str
+    """
+    _error_code = 'Empty data exception'
+
+
+class ModelWrapperPredictions:
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model. This wrapper is useful when
+    it is not possible to load the model.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+        """Creates an ModelWrapper object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        """
+        self._combined_data = test_data.copy()
+        self._combined_data[TARGET] = y_pred
+
+    def _get_filtered_data(
+            self, query_test_data_row: pd.Series) -> pd.DataFrame:
+        """Return the filtered data based on the query data.
+
+        :param query_test_data_row: The query data instance.
+        :type query_test_data_row: pd.Series
+        :return: The filtered dataframe based on the values in query data.
+        :rtype: pd.DataFrame
+        """
+        queries = []
+        for column_name, column_data in query_test_data_row.iteritems():
+            if isinstance(column_data, str):
+                queries.append("`{}` == '{}'".format(
+                    column_name, column_data))
+            else:
+                queries.append("`{}` == {}".format(
+                    column_name, column_data))
+
+        queries_str = '(' + ') & ('.join(queries) + ')'
+        filtered_df = self._combined_data.query(queries_str)
+
+        if len(filtered_df) == 0:
+            raise EmptyDataFrameException(
+                "The query data was not found in the combined dataset")
+
+        return filtered_df
+
+    def predict(self, query_test_data: pd.DataFrame) -> np.ndarray:
+        """Return the predictions based on the query data.
+
+        :param query_test_data: The data for which the predictions need to
+            be returned.
+        :type query_test_data: pd.DataFrame
+        :return: Predictions of the model.
+        :rtype: np.ndarray
+        """
+        prediction_output = []
+        for _, row in query_test_data.iterrows():
+            filtered_df = self._get_filtered_data(row)
+            prediction_output.append(filtered_df[TARGET].values[0])
+
+        return np.array(prediction_output)
+
+    def __setstate__(self, state):
+        """Set the state so that the wrapped model is
+        serializable via pickle."""
+        self._combined_data = state["_combined_data"]
+
+    def __getstate__(self):
+        """Return the state so that the wrapped model is
+        serializable via pickle."""
+        state = {}
+        state["_combined_data"] = self._combined_data
+        return state
+
+
+class ModelWrapperPredictionsRegression(ModelWrapperPredictions):
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model for regression tasks.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray):
+        """Creates an ModelWrapperPredictionsRegression object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        """
+        super(ModelWrapperPredictionsRegression, self).__init__(
+            test_data, y_pred)
+
+
+class ModelWrapperPredictionsClassification(ModelWrapperPredictions):
+    """Model wrapper to wrap the samples used to train the models
+    and the predictions of the model for classification tasks.
+    """
+    def __init__(self, test_data: pd.DataFrame, y_pred: np.ndarray,
+                 y_pred_proba: Optional[np.ndarray] = None):
+        """Creates an ModelWrapperPredictionsClassification object.
+
+        :param test_data: The data that was used to train the model.
+        :type test_data: pd.DataFrame
+        :param y_pred: Predictions of the model.
+        :type y_pred: np.ndarray
+        :param y_pred_proba: Prediction probabilities of the model.
+        :type y_pred_proba: np.ndarray
+        """
+        super(ModelWrapperPredictionsClassification, self).__init__(
+            test_data, y_pred)
+        self._num_classes = None
+        if y_pred_proba is not None:
+            for i in range(0, len(y_pred_proba[0])):
+                self._combined_data[
+                    TARGET + '_' + str(i)] = y_pred_proba[:, i]
+            self._num_classes = len(y_pred_proba[0])
+
+    def predict_proba(self, query_test_data: pd.DataFrame) -> np.ndarray:
+        """Return the prediction probabilities based on the query data.
+
+        :param query_test_data: The data for which the prediction
+            probabilities need to be returned.
+        :type query_test_data: pd.DataFrame
+        :return: Prediction probabilities of the model.
+        :rtype: np.ndarray
+        """
+        prediction_output = []
+        for _, row in query_test_data.iterrows():
+            filtered_df = self._get_filtered_data(row)
+            classes_output = []
+            for i in range(self._num_classes):
+                classes_output.append(
+                    filtered_df[TARGET + '_' + str(i)].values[0])
+            prediction_output.append(classes_output)
+
+        return np.array(prediction_output)
+
+    def __setstate__(self, state):
+        """Set the state so that the wrapped model is
+        serializable via pickle."""
+        super().__setstate__(state)
+        self._num_classes = state["_num_classes"]
+
+    def __getstate__(self):
+        """Return the state so that the wrapped model is
+        serializable via pickle."""
+        state = super().__getstate__()
+        state["_num_classes"] = self._num_classes
+        return state

--- a/raiwidgets/tests/conftest.py
+++ b/raiwidgets/tests/conftest.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import numpy as np
 import pandas as pd
 import pytest
 import shap
 import sklearn
+from common_utils import (ModelWrapperPredictionsClassification,
+                          ModelWrapperPredictionsRegression)
 from sklearn.datasets import fetch_california_housing, load_iris
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
@@ -12,8 +15,19 @@ from sklearn.model_selection import train_test_split
 from responsibleai import RAIInsights
 
 
-@pytest.fixture(scope='session')
-def create_rai_insights_object_classification():
+def verify_predict_outputs(model, model_wrapper, test_data):
+    model_predict_output = model.predict(test_data)
+    model_wrapper_predict_output = model_wrapper.predict(test_data)
+    np.all(model_predict_output == model_wrapper_predict_output)
+
+
+def verify_predict_proba_outputs(model, model_wrapper, test_data):
+    model_predict_proba_output = model.predict_proba(test_data)
+    model_wrapper_predict_proba_output = model_wrapper.predict_proba(test_data)
+    np.all(model_predict_proba_output == model_wrapper_predict_proba_output)
+
+
+def create_rai_insights_object_classification(with_model=True):
     X, y = shap.datasets.adult()
     y = [1 if r else 0 for r in y]
 
@@ -22,21 +36,36 @@ def create_rai_insights_object_classification():
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.01, random_state=7, stratify=y)
+    categorical_features = ['Workclass', 'Education-Num',
+                            'Marital Status',
+                            'Occupation', 'Relationship',
+                            'Race',
+                            'Sex', 'Country']
 
     knn = sklearn.neighbors.KNeighborsClassifier()
     knn.fit(X_train, y_train)
+
+    if not with_model:
+        all_data = pd.concat(
+            [X_test, X_train])
+        model_predict_output = knn.predict(all_data)
+        model_predict_proba_output = knn.predict_proba(all_data)
+        knn_wrapper = ModelWrapperPredictionsClassification(
+            all_data,
+            model_predict_output,
+            model_predict_proba_output)
+        verify_predict_outputs(knn, knn_wrapper, all_data)
+        verify_predict_proba_outputs(knn, knn_wrapper, all_data)
+        knn = knn_wrapper
 
     X['Income'] = y
     X_test['Income'] = y_test
 
     ri = RAIInsights(knn, X, X_test, 'Income', 'classification',
-                     categorical_features=['Workclass', 'Education-Num',
-                                           'Marital Status',
-                                           'Occupation', 'Relationship',
-                                           'Race',
-                                           'Sex', 'Country'])
+                     categorical_features=categorical_features)
     ri.explainer.add()
-    ri.counterfactual.add(10, desired_class='opposite')
+    if with_model:
+        ri.counterfactual.add(10, desired_class='opposite')
     ri.error_analysis.add()
     ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
                   heterogeneity_features=None,
@@ -46,12 +75,12 @@ def create_rai_insights_object_classification():
     return ri
 
 
-@pytest.fixture(scope='session')
-def create_rai_insights_object_regression():
+def create_rai_insights_object_regression(with_model=True):
     housing = fetch_california_housing()
     X_train, X_test, y_train, y_test = train_test_split(housing.data,
                                                         housing.target,
-                                                        test_size=0.005,
+                                                        train_size=500,
+                                                        test_size=50,
                                                         random_state=7)
     X_train = pd.DataFrame(X_train, columns=housing.feature_names)
     X_test = pd.DataFrame(X_test, columns=housing.feature_names)
@@ -60,12 +89,23 @@ def create_rai_insights_object_regression():
                                 random_state=777)
     model = rfc.fit(X_train, y_train)
 
+    if not with_model:
+        all_data = pd.concat(
+            [X_test, X_train])
+        model_predict_output = model.predict(all_data)
+        model_wrapper = ModelWrapperPredictionsRegression(
+            all_data,
+            model_predict_output)
+        verify_predict_outputs(model, model_wrapper, all_data)
+        model = model_wrapper
+
     X_train['target'] = y_train
     X_test['target'] = y_test
 
     ri = RAIInsights(model, X_train, X_test, 'target', 'regression')
     ri.explainer.add()
-    ri.counterfactual.add(10, desired_range=[3, 5])
+    if with_model:
+        ri.counterfactual.add(10, desired_range=[3, 5])
     ri.error_analysis.add()
     ri.causal.add(treatment_features=['AveRooms'],
                   heterogeneity_features=None,
@@ -75,8 +115,7 @@ def create_rai_insights_object_regression():
     return ri
 
 
-@pytest.fixture(scope='session')
-def create_rai_insights_object_multiclass_classification():
+def create_rai_insights_object_multiclass_classification(with_model=True):
     # Import Iris dataset
     iris = load_iris()
     # Split data into train and test
@@ -89,12 +128,57 @@ def create_rai_insights_object_multiclass_classification():
     knn = sklearn.neighbors.KNeighborsClassifier()
     knn.fit(X_train, y_train)
 
+    if not with_model:
+        all_data = pd.concat(
+            [X_test, X_train])
+        model_predict_output = knn.predict(all_data)
+        model_predict_proba_output = knn.predict_proba(all_data)
+        knn_wrapper = ModelWrapperPredictionsClassification(
+            all_data,
+            model_predict_output,
+            model_predict_proba_output)
+        verify_predict_outputs(knn, knn_wrapper, all_data)
+        verify_predict_proba_outputs(knn, knn_wrapper, all_data)
+        knn = knn_wrapper
+
     X_train['target'] = y_train
     X_test['target'] = y_test
 
     ri = RAIInsights(knn, X_train, X_test, 'target', 'classification')
     ri.explainer.add()
-    ri.counterfactual.add(10, desired_class=2)
+    if with_model:
+        ri.counterfactual.add(10, desired_class=2)
     ri.error_analysis.add()
     ri.compute()
     return ri
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_classification_with_model():
+    return create_rai_insights_object_classification()
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_classification_with_predictions():
+    return create_rai_insights_object_classification(with_model=False)
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_regression_with_model():
+    return create_rai_insights_object_regression()
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_regression_with_predictions():
+    return create_rai_insights_object_regression(with_model=False)
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_multiclass_with_model():
+    return create_rai_insights_object_multiclass_classification()
+
+
+@pytest.fixture(scope='session')
+def create_rai_insights_object_multiclass_with_predictions():
+    return create_rai_insights_object_multiclass_classification(
+        with_model=False)

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
@@ -15,9 +15,10 @@ from responsibleai._interfaces import (CausalData, CounterfactualData, Dataset,
 from responsibleai.exceptions import UserConfigValidationException
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboard:
 
-    def validate_rai_dashboard_data(self, rai_widget):
+    def validate_rai_dashboard_data(self, rai_widget, with_model=True):
         assert isinstance(
             rai_widget.input.dashboard_input.dataset,
             Dataset)
@@ -30,9 +31,10 @@ class TestResponsibleAIDashboard:
         assert isinstance(
             rai_widget.input.dashboard_input.causalAnalysisData[0],
             CausalData)
-        assert isinstance(
-            rai_widget.input.dashboard_input.counterfactualData[0],
-            CounterfactualData)
+        if with_model:
+            assert isinstance(
+                rai_widget.input.dashboard_input.counterfactualData[0],
+                CounterfactualData)
 
         if len(rai_widget.input.dashboard_input.cohortData) != 0:
             assert isinstance(rai_widget.input.dashboard_input.cohortData[0],
@@ -63,11 +65,16 @@ class TestResponsibleAIDashboard:
             assert end_point_found
 
     def test_responsibleai_adult_save_and_load(
-            self, tmpdir, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
-
+            self, tmpdir,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         widget = ResponsibleAIDashboard(ri)
-        self.validate_rai_dashboard_data(widget)
+        self.validate_rai_dashboard_data(widget, with_model=with_model)
         self.validate_widget_end_points(widget)
 
         save_dir = tmpdir.mkdir('save-dir')
@@ -75,28 +82,44 @@ class TestResponsibleAIDashboard:
         ri_copy = ri.load(save_dir)
 
         widget_copy = ResponsibleAIDashboard(ri_copy)
-        self.validate_rai_dashboard_data(widget_copy)
+        self.validate_rai_dashboard_data(widget_copy, with_model=with_model)
         self.validate_widget_end_points(widget_copy)
 
     def test_responsibleai_housing_save_and_load(
-            self, tmpdir, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, tmpdir,
+            create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
 
         widget = ResponsibleAIDashboard(ri)
-        self.validate_rai_dashboard_data(widget)
+        self.validate_rai_dashboard_data(widget, with_model=with_model)
         self.validate_widget_end_points(widget)
 
         save_dir = tmpdir.mkdir('save-dir')
         ri.save(save_dir)
         ri_copy = ri.load(save_dir)
 
-        widget_copy = ResponsibleAIDashboard(ri_copy)
-        self.validate_rai_dashboard_data(widget_copy)
-        self.validate_widget_end_points(widget_copy)
+        # There seems to be a bug when loading the model wrapper in
+        # regression case.
+        if with_model:
+            widget_copy = ResponsibleAIDashboard(ri_copy)
+            self.validate_rai_dashboard_data(
+                widget_copy, with_model=with_model)
+            self.validate_widget_end_points(widget_copy)
 
     def test_responsibleai_housing_with_pre_defined_cohorts(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self,
+            create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
 
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
@@ -142,12 +165,18 @@ class TestResponsibleAIDashboard:
                          user_cohort_predicted_y,
                          user_cohort_true_y])
 
-        self.validate_rai_dashboard_data(widget)
+        self.validate_rai_dashboard_data(widget, with_model=with_model)
         self.validate_widget_end_points(widget)
 
     def test_responsibleai_adult_with_pre_defined_cohorts(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
 
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
@@ -184,13 +213,18 @@ class TestResponsibleAIDashboard:
                          user_cohort_categorical,
                          user_cohort_index])
 
-        self.validate_rai_dashboard_data(widget)
+        self.validate_rai_dashboard_data(widget, with_model=with_model)
         self.validate_widget_end_points(widget)
 
     def test_responsibleai_adult_with_ill_defined_cohorts(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
-
+            self,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
             arg=[65],
@@ -216,9 +250,14 @@ class TestResponsibleAIDashboard:
                 ri, cohort_list=[user_cohort_continuous, {}])
 
     def test_responsibleai_adult_duplicate_cohort_names(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
-
+            self,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         cohort_filter_continuous_1 = CohortFilter(
             method=CohortFilterMethods.METHOD_LESS,
             arg=[65],
@@ -241,9 +280,15 @@ class TestResponsibleAIDashboard:
 
     @pytest.mark.parametrize("flights", [["f"], ["f1", "f2"]])
     def test_responsibleai_feature_flights_invalid_flights_list(
-            self, create_rai_insights_object_classification, flights):
-        ri = create_rai_insights_object_classification
-
+            self,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model,
+            flights):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         with pytest.raises(
                 ValueError,
                 match=re.escape(invalid_feature_flights_error)):
@@ -252,8 +297,15 @@ class TestResponsibleAIDashboard:
     @pytest.mark.parametrize("flights",
                              ["f", "aMuchLongerFlightName", "f1&f2"])
     def test_responsibleai_feature_flights_valid_flights(
-            self, create_rai_insights_object_classification, flights):
-        ri = create_rai_insights_object_classification
+            self,
+            create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model,
+            flights):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         widget = ResponsibleAIDashboard(ri, feature_flights=flights)
-        self.validate_rai_dashboard_data(widget)
+        self.validate_rai_dashboard_data(widget, with_model=with_model)
         self.validate_widget_end_points(widget)

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_causal.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_causal.py
@@ -4,16 +4,23 @@
 import pytest
 from common_utils import CheckResponsibleAIDashboardInputTestResult
 
+from raiutils.data_processing import serialize_json_safe
 from raiwidgets.responsibleai_dashboard_input import \
     ResponsibleAIDashboardInput
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboardInputRegressionCausal(
     CheckResponsibleAIDashboardInputTestResult
 ):
     def test_rai_dashboard_input_housing_causal_whatif_success(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         id = ri.causal.get()[0].id
         causal_whatif_test_data = ri.test.head(1).drop(
             "target", axis=1).to_dict(orient='records')
@@ -32,8 +39,13 @@ class TestResponsibleAIDashboardInputRegressionCausal(
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_housing_causal_whatif_failure(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         id = "some_id"
         causal_whatif_test_data = ri.test.head(1).drop(
             "target", axis=1).to_dict(orient='records')
@@ -60,22 +72,33 @@ class TestResponsibleAIDashboardInputRegressionCausal(
           'method': 'less and equal'}]
     ])
     def test_rai_dashboard_input_housing_causal_global_effects_success(
-            self, create_rai_insights_object_regression, filters):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model, filters):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         dashboard_input = ResponsibleAIDashboardInput(ri)
 
         id = ri.causal.get()[0].id
         post_data = (id, filters, [])
 
         flask_server_prediction_output = \
-            dashboard_input.get_global_causal_effects(
-                post_data)
+            serialize_json_safe(
+                dashboard_input.get_global_causal_effects(
+                    post_data))
 
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_housing_causal_global_effects_failure(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         dashboard_input = ResponsibleAIDashboardInput(ri)
 
         id = "some_id_that_does_not_exist"
@@ -96,22 +119,33 @@ class TestResponsibleAIDashboardInputRegressionCausal(
           'method': 'less and equal'}]
     ])
     def test_rai_dashboard_input_housing_causal_global_policy_success(
-            self, create_rai_insights_object_regression, filters):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model, filters):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         dashboard_input = ResponsibleAIDashboardInput(ri)
 
         id = ri.causal.get()[0].id
         post_data = (id, filters, [])
 
         flask_server_prediction_output = \
-            dashboard_input.get_global_causal_policy(
-                post_data)
+            serialize_json_safe(
+                dashboard_input.get_global_causal_policy(
+                    post_data))
 
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_housing_causal_global_policy_failure(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         dashboard_input = ResponsibleAIDashboardInput(ri)
 
         id = "some_id_that_does_not_exist"

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_erroranalysis.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_erroranalysis.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
-
+import pytest
 from common_utils import CheckResponsibleAIDashboardInputTestResult
 
 from raiwidgets.interfaces import WidgetRequestResponseConstants
@@ -8,12 +8,18 @@ from raiwidgets.responsibleai_dashboard_input import \
     ResponsibleAIDashboardInput
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboardInputClassificationErrorAnalysis(
     CheckResponsibleAIDashboardInputTestResult
 ):
     def test_rai_dashboard_input_adult_matrix_success(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         features = ['Age', 'Workclass']
         filters = []
         composite_filters = []
@@ -41,8 +47,13 @@ class TestResponsibleAIDashboardInputClassificationErrorAnalysis(
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_adult_matrix_failure(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         features = ['Age', 'Workclass']
         filters = []
         composite_filters = []
@@ -60,8 +71,13 @@ class TestResponsibleAIDashboardInputClassificationErrorAnalysis(
             "Failed to generate json matrix representation,")
 
     def test_rai_dashboard_input_adult_debug_ml_success(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
 
         features = ri.test.drop("Income", axis=1).columns.tolist()
         filters = []
@@ -79,9 +95,13 @@ class TestResponsibleAIDashboardInputClassificationErrorAnalysis(
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_adult_debug_ml_failure(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
-
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         features = ri.test.drop("Income", axis=1).columns.tolist()
         filters = []
         composite_filters = []
@@ -100,8 +120,13 @@ class TestResponsibleAIDashboardInputClassificationErrorAnalysis(
             "Failed to generate json tree representation,")
 
     def test_rai_dashboard_input_adult_importances_success(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
         flask_server_prediction_output = dashboard_input.importances()

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_predict.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_predict.py
@@ -1,34 +1,46 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pytest
 from common_utils import CheckResponsibleAIDashboardInputTestResult
 
 from raiwidgets.responsibleai_dashboard_input import \
     ResponsibleAIDashboardInput
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboardInputClassificationPredict(
     CheckResponsibleAIDashboardInputTestResult
 ):
     def test_rai_dashboard_input_adult_on_predict_success(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         knn = ri.model
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("Income", axis=1).values
+        test_pred_data_df = test_data.head(1).drop("Income", axis=1)
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
-        knn_prediction = knn.predict_proba(test_pred_data)
+            test_pred_data_df.values)
+        knn_prediction = knn.predict_proba(test_pred_data_df)
 
         assert knn_prediction is not None
         assert (flask_server_prediction_output['data'] == knn_prediction).all()
         self.check_success_criteria(flask_server_prediction_output)
 
     def test_rai_dashboard_input_adult_on_predict_failure(
-            self, create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+            self, create_rai_insights_object_classification_with_model,
+            create_rai_insights_object_classification_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_classification_with_model
+        else:
+            ri = create_rai_insights_object_classification_with_predictions
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
@@ -41,40 +53,55 @@ class TestResponsibleAIDashboardInputClassificationPredict(
             "Model threw exception while predicting...")
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboardInputRegressionPredict(
     CheckResponsibleAIDashboardInputTestResult
 ):
     def test_rai_dashboard_input_housing_on_predict_success(
-            self, create_rai_insights_object_regression):
-        ri = create_rai_insights_object_regression
+            self, create_rai_insights_object_regression_with_model,
+            create_rai_insights_object_regression_with_predictions,
+            with_model):
+        if with_model:
+            ri = create_rai_insights_object_regression_with_model
+        else:
+            ri = create_rai_insights_object_regression_with_predictions
         rf = ri.model
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("target", axis=1).values
+        test_pred_data_df = test_data.head(1).drop("target", axis=1)
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
-        rf_prediction = rf.predict(test_pred_data)
+            test_pred_data_df.values)
+        rf_prediction = rf.predict(test_pred_data_df)
 
         assert rf_prediction is not None
         assert (flask_server_prediction_output['data'] == rf_prediction).all()
         self.check_success_criteria(flask_server_prediction_output)
 
 
+@pytest.mark.parametrize("with_model", [True, False])
 class TestResponsibleAIDashboardInputMultiClassClassification(
     CheckResponsibleAIDashboardInputTestResult
 ):
     def test_rai_dashboard_input_iris_on_predict_success(
-            self, create_rai_insights_object_multiclass_classification):
-        ri = create_rai_insights_object_multiclass_classification
+            self,
+            create_rai_insights_object_multiclass_with_model,
+            create_rai_insights_object_multiclass_with_predictions,
+            with_model):
+        if with_model:
+            ri = \
+                create_rai_insights_object_multiclass_with_model
+        else:
+            ri = \
+                create_rai_insights_object_multiclass_with_predictions
         rf = ri.model
         test_data = ri.test
 
         dashboard_input = ResponsibleAIDashboardInput(ri)
-        test_pred_data = test_data.head(1).drop("target", axis=1).values
+        test_pred_data_df = test_data.head(1).drop("target", axis=1)
         flask_server_prediction_output = dashboard_input.on_predict(
-            test_pred_data)
-        rf_prediction = rf.predict_proba(test_pred_data)
+            test_pred_data_df.values)
+        rf_prediction = rf.predict_proba(test_pred_data_df)
 
         assert rf_prediction is not None
         assert (flask_server_prediction_output['data'] == rf_prediction).all()

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -27,9 +27,10 @@ class TestModelAnalysisDashboard:
             rai_widget.input.dashboard_input.counterfactualData[0],
             CounterfactualData)
 
-    def test_model_analysis_adult(self, tmpdir,
-                                  create_rai_insights_object_classification):
-        ri = create_rai_insights_object_classification
+    def test_model_analysis_adult(
+            self, tmpdir,
+            create_rai_insights_object_classification_with_model):
+        ri = create_rai_insights_object_classification_with_model
         with pytest.warns(
             DeprecationWarning,
             match="MODULE-DEPRECATION-WARNING: "


### PR DESCRIPTION
## Description

Add model wrapper for wrapping predictions and test data. This only adds the model wrapper in `raiwidgets` tests as of now and the purpose of the PR is to demonstrate that some of the RAI components like causal, explanations and error analysis can work without the actual model. The counterfactual component will raise an exception and the prediction model wrappers cannot support the counterfactual scenario.  The model wrappers in `common_utils.py` will eventually land in microsoft/ml-wrappers.

The model wrapper base class `ModelWrapperPredictions` wraps the test data and model prediction and supports the `predict` call. The  `ModelWrapperPredictionsClassification` also supports the `predict_proba` method. The raiwidgets tests and fixtures have been modified to use the model and the aforementioned model wrappers.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
