### PR TITLE
Filter out undefined filters to resolve a robot page exception

### DIFF
--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -169,29 +169,31 @@ export class Cohort {
     row: { [key: string]: number },
     filters: IFilter[]
   ): boolean {
-    return filters.every((filter) => {
-      const rowVal = row[filter.column];
-      switch (filter.method) {
-        case FilterMethods.Equal:
-          return rowVal === filter.arg[0];
-        case FilterMethods.GreaterThan:
-          return rowVal > filter.arg[0];
-        case FilterMethods.GreaterThanEqualTo:
-          return rowVal >= filter.arg[0];
-        case FilterMethods.LessThan:
-          return rowVal < filter.arg[0];
-        case FilterMethods.LessThanEqualTo:
-          return rowVal <= filter.arg[0];
-        case FilterMethods.Includes:
-          return (filter.arg as number[]).includes(rowVal);
-        case FilterMethods.Excludes:
-          return !(filter.arg as number[]).includes(rowVal);
-        case FilterMethods.InTheRangeOf:
-          return rowVal >= filter.arg[0] && rowVal <= filter.arg[1];
-        default:
-          return false;
-      }
-    });
+    return filters
+      .filter((item) => item)
+      .every((filter) => {
+        const rowVal = row[filter.column];
+        switch (filter.method) {
+          case FilterMethods.Equal:
+            return rowVal === filter.arg[0];
+          case FilterMethods.GreaterThan:
+            return rowVal > filter.arg[0];
+          case FilterMethods.GreaterThanEqualTo:
+            return rowVal >= filter.arg[0];
+          case FilterMethods.LessThan:
+            return rowVal < filter.arg[0];
+          case FilterMethods.LessThanEqualTo:
+            return rowVal <= filter.arg[0];
+          case FilterMethods.Includes:
+            return (filter.arg as number[]).includes(rowVal);
+          case FilterMethods.Excludes:
+            return !(filter.arg as number[]).includes(rowVal);
+          case FilterMethods.InTheRangeOf:
+            return rowVal >= filter.arg[0] && rowVal <= filter.arg[1];
+          default:
+            return false;
+        }
+      });
   }
 
   private filterRecursively(

--- a/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
+++ b/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
@@ -43,15 +43,17 @@ export class ErrorCohort {
     features: string[]
   ): IFilter[] {
     // return the filters relabeled from original label to Data#
-    const filtersRelabeled = filters.map((filter: IFilter): IFilter => {
-      const index = features.indexOf(filter.column);
-      const key = JointDataset.DataLabelRoot + index.toString();
-      return {
-        arg: filter.arg,
-        column: key,
-        method: filter.method
-      };
-    });
+    const filtersRelabeled = filters
+      .filter((item) => item)
+      .map((filter: IFilter): IFilter => {
+        const index = features.indexOf(filter.column);
+        const key = JointDataset.DataLabelRoot + index.toString();
+        return {
+          arg: filter.arg,
+          column: key,
+          method: filter.method
+        };
+      });
     return filtersRelabeled;
   }
 
@@ -60,14 +62,16 @@ export class ErrorCohort {
     jointDataset: JointDataset
   ): IFilter[] {
     // return the filters relabeled from Data# to original label
-    const filtersRelabeled = filters.map((filter: IFilter): IFilter => {
-      const label = jointDataset.metaDict[filter.column].label;
-      return {
-        arg: filter.arg,
-        column: label,
-        method: filter.method
-      };
-    });
+    const filtersRelabeled = filters
+      .filter((item) => item)
+      .map((filter: IFilter): IFilter => {
+        const label = jointDataset.metaDict[filter.column].label;
+        return {
+          arg: filter.arg,
+          column: label,
+          method: filter.method
+        };
+      });
     return filtersRelabeled;
   }
 

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/FilterList.test.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/FilterList.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { shallow } from "enzyme";
+import React from "react";
+
+import { IExplanationModelMetadata } from "../../Interfaces/IExplanationContext";
+import { FilterMethods, IFilter } from "../../Interfaces/IFilter";
+import { JointDataset } from "../../util/JointDataset";
+import { ColumnCategories } from "../../util/JointDatasetUtils";
+
+import { FilterList } from "./FilterList";
+
+const featureIsCategorical = [
+  false,
+  false,
+  false,
+  true,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false
+];
+const modelMetadata = {
+  classNames: ["Class 0"],
+  featureIsCategorical,
+  featureNames: [],
+  featureNamesAbridged: [],
+  featureRanges: [],
+  modelType: "binary"
+} as IExplanationModelMetadata;
+const jointDataset = new JointDataset({
+  dataset: [],
+  metadata: modelMetadata
+});
+
+describe("FilterList", () => {
+  it("Should render", () => {
+    const filters = [
+      {
+        arg: [12.09],
+        column: "alcohol",
+        method: FilterMethods.LessThan
+      },
+      {
+        arg: [2.5],
+        column: "ash",
+        method: FilterMethods.GreaterThan
+      }
+    ];
+
+    jointDataset.metaDict.alcohol = {
+      abbridgedLabel: "l",
+      category: ColumnCategories.Dataset,
+      isCategorical: true,
+      label: "less than",
+      treatAsCategorical: true
+    };
+    jointDataset.metaDict.ash = {
+      abbridgedLabel: "g",
+      category: ColumnCategories.Dataset,
+      isCategorical: true,
+      label: "greater than",
+      treatAsCategorical: true
+    };
+
+    const wrapper = shallow(
+      <FilterList filters={filters} jointDataset={jointDataset} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("Should filter out undefined filter", () => {
+    const filters = [
+      {
+        arg: [12.09],
+        column: "alcohol",
+        method: FilterMethods.LessThan
+      },
+      {
+        arg: [2.5],
+        column: "ash",
+        method: FilterMethods.GreaterThan
+      },
+      undefined as unknown as IFilter
+    ];
+
+    jointDataset.metaDict.alcohol = {
+      abbridgedLabel: "l",
+      category: ColumnCategories.Dataset,
+      isCategorical: true,
+      label: "less than",
+      treatAsCategorical: true
+    };
+    jointDataset.metaDict.ash = {
+      abbridgedLabel: "g",
+      category: ColumnCategories.Dataset,
+      isCategorical: true,
+      label: "greater than",
+      treatAsCategorical: true
+    };
+
+    const wrapper = shallow(
+      <FilterList filters={filters} jointDataset={jointDataset} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/FilterList.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/FilterList.tsx
@@ -31,29 +31,31 @@ export class FilterList extends React.Component<IFilterListProps> {
       localization.Interpret.FilterOperations.inTheRangeOf
   };
   public render(): React.ReactNode {
-    return this.props.filters.map((filter, index) => {
-      return (
-        <div key={index}>
-          {this.setFilterLabel(filter)}
-          {this.props.editFilter && (
-            <IconButton
-              id={`editFilerBtn-${index}`}
-              iconProps={{ iconName: "Edit" }}
-              onClick={(): void => this.props.editFilter?.(index)}
-              ariaLabel={localization.Common.editButton}
-            />
-          )}
-          {this.props.removeFilter && (
-            <IconButton
-              id={`removeFilterBtn-${index}`}
-              iconProps={{ iconName: "Clear" }}
-              onClick={(): void => this.props.removeFilter?.(index)}
-              ariaLabel={localization.Common.close}
-            />
-          )}
-        </div>
-      );
-    });
+    return this.props.filters
+      .filter((item) => item)
+      .map((filter, index) => {
+        return (
+          <div key={index}>
+            {this.setFilterLabel(filter)}
+            {this.props.editFilter && (
+              <IconButton
+                id={`editFilerBtn-${index}`}
+                iconProps={{ iconName: "Edit" }}
+                onClick={(): void => this.props.editFilter?.(index)}
+                ariaLabel={localization.Common.editButton}
+              />
+            )}
+            {this.props.removeFilter && (
+              <IconButton
+                id={`removeFilterBtn-${index}`}
+                iconProps={{ iconName: "Clear" }}
+                onClick={(): void => this.props.removeFilter?.(index)}
+                ariaLabel={localization.Common.close}
+              />
+            )}
+          </div>
+        );
+      });
   }
 
   private setFilterLabel(filter: IFilter): React.ReactNode {

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/__snapshots__/FilterList.test.tsx.snap
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/__snapshots__/FilterList.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilterList Should filter out undefined filter 1`] = `
+Array [
+  <div
+    key="0"
+  >
+    <StyledTooltipHostBase
+      content="l  less than "
+      onTooltipToggle={[Function]}
+      overflowMode={1}
+    >
+      l  less than 
+    </StyledTooltipHostBase>
+  </div>,
+  <div
+    key="1"
+  >
+    <StyledTooltipHostBase
+      content="g  greater than "
+      onTooltipToggle={[Function]}
+      overflowMode={1}
+    >
+      g  greater than 
+    </StyledTooltipHostBase>
+  </div>,
+]
+`;
+
+exports[`FilterList Should render 1`] = `
+Array [
+  <div
+    key="0"
+  >
+    <StyledTooltipHostBase
+      content="l  less than "
+      onTooltipToggle={[Function]}
+      overflowMode={1}
+    >
+      l  less than 
+    </StyledTooltipHostBase>
+  </div>,
+  <div
+    key="1"
+  >
+    <StyledTooltipHostBase
+      content="g  greater than "
+      onTooltipToggle={[Function]}
+      overflowMode={1}
+    >
+      g  greater than 
+    </StyledTooltipHostBase>
+  </div>,
+]
+`;

--- a/libs/core-ui/src/lib/util/getBasicFilterString.ts
+++ b/libs/core-ui/src/lib/util/getBasicFilterString.ts
@@ -10,40 +10,42 @@ export function getBasicFilterString(
   filters: IFilter[],
   jointDataset: JointDataset
 ): string[] {
-  return filters.map((filter: IFilter): string => {
-    let method = "";
-    const metaDict = jointDataset.metaDict[filter.column];
-    const label = metaDict.label;
-    if (filter.method === FilterMethods.InTheRangeOf) {
-      const arg0 = filter.arg[0].toFixed(2);
-      const arg1 = filter.arg[1].toFixed(2);
-      return `${label} in (${arg0}, ${arg1}]`;
-    }
-    if (filter.method === FilterMethods.Includes) {
-      const args = getFilterBoundsArgs(metaDict, filter);
-      return `${label} in ${args}`;
-    }
-    if (filter.method === FilterMethods.Excludes) {
-      const args = getFilterBoundsArgs(metaDict, filter);
-      return `${label} not in ${args}`;
-    }
-    if (filter.method === FilterMethods.Equal) {
-      method = "==";
-      if (metaDict?.treatAsCategorical && metaDict.sortedCategoricalValues) {
-        const catArg = (metaDict.sortedCategoricalValues as string[])[
-          filter.arg[0]
-        ];
-        return `${label} ${method} ${catArg}`;
+  return filters
+    .filter((item) => item)
+    .map((filter: IFilter): string => {
+      let method = "";
+      const metaDict = jointDataset.metaDict[filter.column];
+      const label = metaDict.label;
+      if (filter.method === FilterMethods.InTheRangeOf) {
+        const arg0 = filter.arg[0].toFixed(2);
+        const arg1 = filter.arg[1].toFixed(2);
+        return `${label} in (${arg0}, ${arg1}]`;
       }
-    } else if (filter.method === FilterMethods.GreaterThan) {
-      method = ">";
-    } else if (filter.method === FilterMethods.GreaterThanEqualTo) {
-      method = ">=";
-    } else if (filter.method === FilterMethods.LessThan) {
-      method = "<";
-    } else if (filter.method === FilterMethods.LessThanEqualTo) {
-      method = "<=";
-    }
-    return `${label} ${method} ${filter.arg[0].toFixed(2)}`;
-  });
+      if (filter.method === FilterMethods.Includes) {
+        const args = getFilterBoundsArgs(metaDict, filter);
+        return `${label} in ${args}`;
+      }
+      if (filter.method === FilterMethods.Excludes) {
+        const args = getFilterBoundsArgs(metaDict, filter);
+        return `${label} not in ${args}`;
+      }
+      if (filter.method === FilterMethods.Equal) {
+        method = "==";
+        if (metaDict?.treatAsCategorical && metaDict.sortedCategoricalValues) {
+          const catArg = (metaDict.sortedCategoricalValues as string[])[
+            filter.arg[0]
+          ];
+          return `${label} ${method} ${catArg}`;
+        }
+      } else if (filter.method === FilterMethods.GreaterThan) {
+        method = ">";
+      } else if (filter.method === FilterMethods.GreaterThanEqualTo) {
+        method = ">=";
+      } else if (filter.method === FilterMethods.LessThan) {
+        method = "<";
+      } else if (filter.method === FilterMethods.LessThanEqualTo) {
+        method = "<=";
+      }
+      return `${label} ${method} ${filter.arg[0].toFixed(2)}`;
+    });
 }


### PR DESCRIPTION
There is a robot page exception due to `TypeError: Cannot read properties of undefined (reading 'column')
    at t.setFilterLabel (https://ml.azure.com/static/js/79.5338ded6.chunk.js:2:1874569)
    at https://ml.azure.com/static/js/79.5338ded6.chunk.js:2:1874007
    at Array.map (<anonymous>)`
This PR filters out cohort filters if the filter is undefined so we can make sure user won't hit robot page exception for this issue.

## Description
For this.props.filters
Before: [filterA, filterB, undefined]

After: [filterA, filterB]

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
