### PR TITLE
Fix dependency plot showing Average of abs value

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -18,7 +18,7 @@ import {
   ModelAssessmentContext,
   defaultModelAssessmentContext,
   IModelAssessmentContext,
-  IsMulticlass
+  IsClassifier
 } from "@responsible-ai/core-ui";
 import { CounterfactualsTab } from "@responsible-ai/counterfactuals";
 import {
@@ -91,7 +91,7 @@ export class TabsView extends React.PureComponent<
       [WeightVectors.AbsAvg]: localization.Interpret.absoluteAverage
     };
     const weightVectorOptions = [];
-    if (IsMulticlass(props.modelMetadata.modelType)) {
+    if (IsClassifier(props.modelMetadata.modelType)) {
       weightVectorOptions.push(WeightVectors.AbsAvg);
     }
     props.modelMetadata.classNames.forEach((name, index) => {
@@ -112,7 +112,7 @@ export class TabsView extends React.PureComponent<
       mapShiftErrorAnalysisOption: ErrorAnalysisOptions.TreeMap,
       mapShiftVisible: false,
       selectedFeatures: props.dataset.feature_names,
-      selectedWeightVector: IsMulticlass(props.modelMetadata.modelType)
+      selectedWeightVector: IsClassifier(props.modelMetadata.modelType)
         ? WeightVectors.AbsAvg
         : 0,
       weightVectorLabels,


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
we initialize with 'Average of absolute value' and corresponding data is shown in plot but just the dropdown doesn't show the above option.
One of the way to fix is to show 'Average of absolute value' as one of the drop down option as below along with other options.
Reviewed by Mehrnoosh.

![depPlotAvgAbs](https://user-images.githubusercontent.com/33799331/194163229-62bf2871-0d12-47ed-a2ae-b498c6e24836.gif)

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
