### PR TITLE
fix error analysis cohort filter for string label values

### DIFF
--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -52,7 +52,8 @@ def filter_from_cohort(analyzer, filters, composite_filters,
         categories=analyzer.categories,
         true_y=analyzer.true_y,
         pred_y=pred_y,
-        model_task=analyzer.model_task)
+        model_task=analyzer.model_task,
+        classes=analyzer.classes)
 
     return filter_data_with_cohort.filter_data_from_cohort(
         filters=filters,
@@ -462,6 +463,9 @@ class FilterDataWithCohortFilters:
         is_categorical = False
         if categorical_features:
             is_categorical = colname in categorical_features
+        is_label = False
+        if colname == TRUE_Y or colname == PRED_Y:
+            is_label = True
         for arg in filter[ARG]:
             if is_categorical:
                 cat_idx = categorical_features.index(colname)
@@ -469,6 +473,12 @@ class FilterDataWithCohortFilters:
                     arg_val = "'{}'".format(str(categories[cat_idx][arg]))
                 else:
                     arg_val = "{}".format(str(categories[cat_idx][arg]))
+            elif is_label and self.classes is not None:
+                class_value = self.classes[arg]
+                format_str = "{}"
+                if isinstance(class_value, str):
+                    format_str = "'{}'"
+                arg_val = format_str.format(str(self.classes[arg]))
             else:
                 arg_val = arg
             bounds.append("`{}`{}{}".format(colname, operator, arg_val))

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '10'
+_patch = '11'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_cohort_filter.py
+++ b/erroranalysis/tests/test_cohort_filter.py
@@ -64,13 +64,22 @@ class TestCohortFilter(object):
                            model_task,
                            filters=filters)
 
-    def test_cohort_filter_true_y(self):
-        X_train, X_test, y_train, y_test, feature_names = create_iris_pandas()
+    @pytest.mark.parametrize('use_str_labels', [True, False])
+    def test_cohort_filter_true_y(self, use_str_labels):
+        X_train, X_test, y_train, y_test, feature_names = create_iris_pandas(
+            use_str_labels)
+        classes = None
+        if use_str_labels:
+            classes = create_iris_data()[5]
         filters = [{'arg': [2],
                     'column': 'True Y',
                     'method': 'includes'}]
         validation_data = create_validation_data(X_test, y_test)
-        validation_data = validation_data.loc[y_test == 2]
+        if use_str_labels:
+            validation_filter = y_test == classes[2]
+        else:
+            validation_filter = y_test == 2
+        validation_data = validation_data.loc[validation_filter]
         model_task = ModelTask.CLASSIFICATION
         model = create_sklearn_svm_classifier(X_train, y_train)
         categorical_features = []
@@ -81,7 +90,8 @@ class TestCohortFilter(object):
                            feature_names,
                            categorical_features,
                            model_task,
-                           filters=filters)
+                           filters=filters,
+                           classes=classes)
 
     def test_cohort_filter_less(self):
         X_train, X_test, y_train, y_test, feature_names = create_iris_pandas()
@@ -346,11 +356,16 @@ class TestCohortFilter(object):
                            filters=filters)
 
 
-def create_iris_pandas():
-    X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+def create_iris_pandas(use_str_labels=False):
+    X_train, X_test, y_train, y_test, feature_names, classes = \
+        create_iris_data()
 
     X_train = pd.DataFrame(X_train, columns=feature_names)
     X_test = pd.DataFrame(X_test, columns=feature_names)
+
+    if use_str_labels:
+        y_train = np.array([classes[y] for y in y_train])
+        y_test = np.array([classes[y] for y in y_test])
 
     return X_train, X_test, y_train, y_test, feature_names
 
@@ -373,13 +388,15 @@ def run_error_analyzer(validation_data,
                        model_task,
                        filters=None,
                        composite_filters=None,
-                       is_empty_validation_data=False):
+                       is_empty_validation_data=False,
+                       classes=None):
     error_analyzer = ModelAnalyzer(model,
                                    X_test,
                                    y_test,
                                    feature_names,
                                    categorical_features,
-                                   model_task=model_task)
+                                   model_task=model_task,
+                                   classes=classes)
     filtered_data = filter_from_cohort(error_analyzer,
                                        filters,
                                        composite_filters)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the cohort filter to support string label values.  Otherwise, when creating a filter based on "True Y" or "Predicted Y", and changing the base cohort, error analysis can fail to filter the data correctly because the filter from UI is in terms of indexes while the data itself has string values.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
