### PR TITLE
Move cohort re-labelling logic to Cohort.ts

### DIFF
--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -248,4 +248,47 @@ export class Cohort {
     }
     return filteredData;
   }
+
+  public static getLabeledFilters(
+    filters: IFilter[],
+    jointDataset: JointDataset
+  ): IFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = filters
+      .filter((item) => item)
+      .map((filter: IFilter): IFilter => {
+        const label = jointDataset.metaDict[filter.column].label;
+        return {
+          arg: filter.arg,
+          column: label,
+          method: filter.method
+        };
+      });
+    return filtersRelabeled;
+  }
+
+  public static getLabeledCompositeFilters(
+    compositeFilters: ICompositeFilter[],
+    jointDataset: JointDataset
+  ): ICompositeFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = compositeFilters.map(
+      (compositeFilter: ICompositeFilter): ICompositeFilter => {
+        if (compositeFilter.method) {
+          return Cohort.getLabeledFilters(
+            [compositeFilter as IFilter],
+            jointDataset
+          )[0] as ICompositeFilter;
+        }
+        return {
+          compositeFilters: Cohort.getLabeledCompositeFilters(
+            compositeFilter.compositeFilters,
+            jointDataset
+          ),
+          operation: compositeFilter.operation
+        } as ICompositeFilter;
+      }
+    );
+    return filtersRelabeled;
+  }
 }

--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -40,6 +40,49 @@ export class Cohort {
     this.filteredData = this.applyFilters();
   }
 
+  public static getLabeledFilters(
+    filters: IFilter[],
+    jointDataset: JointDataset
+  ): IFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = filters
+      .filter((item) => item)
+      .map((filter: IFilter): IFilter => {
+        const label = jointDataset.metaDict[filter.column].label;
+        return {
+          arg: filter.arg,
+          column: label,
+          method: filter.method
+        };
+      });
+    return filtersRelabeled;
+  }
+
+  public static getLabeledCompositeFilters(
+    compositeFilters: ICompositeFilter[],
+    jointDataset: JointDataset
+  ): ICompositeFilter[] {
+    // return the filters relabeled from Data# to original label
+    const filtersRelabeled = compositeFilters.map(
+      (compositeFilter: ICompositeFilter): ICompositeFilter => {
+        if (compositeFilter.method) {
+          return Cohort.getLabeledFilters(
+            [compositeFilter as IFilter],
+            jointDataset
+          )[0] as ICompositeFilter;
+        }
+        return {
+          compositeFilters: Cohort.getLabeledCompositeFilters(
+            compositeFilter.compositeFilters,
+            jointDataset
+          ),
+          operation: compositeFilter.operation
+        } as ICompositeFilter;
+      }
+    );
+    return filtersRelabeled;
+  }
+
   public updateFilter(filter: IFilter, index?: number): void {
     if (index === undefined) {
       index = this.filters.length;
@@ -247,48 +290,5 @@ export class Cohort {
       filteredData = [...filteredData];
     }
     return filteredData;
-  }
-
-  public static getLabeledFilters(
-    filters: IFilter[],
-    jointDataset: JointDataset
-  ): IFilter[] {
-    // return the filters relabeled from Data# to original label
-    const filtersRelabeled = filters
-      .filter((item) => item)
-      .map((filter: IFilter): IFilter => {
-        const label = jointDataset.metaDict[filter.column].label;
-        return {
-          arg: filter.arg,
-          column: label,
-          method: filter.method
-        };
-      });
-    return filtersRelabeled;
-  }
-
-  public static getLabeledCompositeFilters(
-    compositeFilters: ICompositeFilter[],
-    jointDataset: JointDataset
-  ): ICompositeFilter[] {
-    // return the filters relabeled from Data# to original label
-    const filtersRelabeled = compositeFilters.map(
-      (compositeFilter: ICompositeFilter): ICompositeFilter => {
-        if (compositeFilter.method) {
-          return Cohort.getLabeledFilters(
-            [compositeFilter as IFilter],
-            jointDataset
-          )[0] as ICompositeFilter;
-        }
-        return {
-          compositeFilters: Cohort.getLabeledCompositeFilters(
-            compositeFilter.compositeFilters,
-            jointDataset
-          ),
-          operation: compositeFilter.operation
-        } as ICompositeFilter;
-      }
-    );
-    return filtersRelabeled;
   }
 }

--- a/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
+++ b/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
@@ -57,49 +57,6 @@ export class ErrorCohort {
     return filtersRelabeled;
   }
 
-  public static getLabeledFilters(
-    filters: IFilter[],
-    jointDataset: JointDataset
-  ): IFilter[] {
-    // return the filters relabeled from Data# to original label
-    const filtersRelabeled = filters
-      .filter((item) => item)
-      .map((filter: IFilter): IFilter => {
-        const label = jointDataset.metaDict[filter.column].label;
-        return {
-          arg: filter.arg,
-          column: label,
-          method: filter.method
-        };
-      });
-    return filtersRelabeled;
-  }
-
-  public static getLabeledCompositeFilters(
-    compositeFilters: ICompositeFilter[],
-    jointDataset: JointDataset
-  ): ICompositeFilter[] {
-    // return the filters relabeled from Data# to original label
-    const filtersRelabeled = compositeFilters.map(
-      (compositeFilter: ICompositeFilter): ICompositeFilter => {
-        if (compositeFilter.method) {
-          return ErrorCohort.getLabeledFilters(
-            [compositeFilter as IFilter],
-            jointDataset
-          )[0] as ICompositeFilter;
-        }
-        return {
-          compositeFilters: ErrorCohort.getLabeledCompositeFilters(
-            compositeFilter.compositeFilters,
-            jointDataset
-          ),
-          operation: compositeFilter.operation
-        } as ICompositeFilter;
-      }
-    );
-    return filtersRelabeled;
-  }
-
   public filtersToString(): string[] {
     const cohortFilters = getBasicFilterString(
       this.cohort.filters,

--- a/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
+++ b/libs/core-ui/src/lib/Cohort/ErrorCohort.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IFilter, ICompositeFilter } from "../Interfaces/IFilter";
+import { IFilter } from "../Interfaces/IFilter";
 import { getBasicFilterString } from "../util/getBasicFilterString";
 import { getCompositeFilterString } from "../util/getCompositeFilterString";
 import { JointDataset } from "../util/JointDataset";

--- a/libs/core-ui/src/lib/util/calculateBoxData.ts
+++ b/libs/core-ui/src/lib/util/calculateBoxData.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { Cohort } from "../Cohort/Cohort";
 import { ErrorCohort } from "../Cohort/ErrorCohort";
-import { Cohort } from "../Cohort/Cohort"
 import { IHighchartBoxData } from "../Interfaces/IHighchartBoxData";
 
 export async function calculateBoxPlotDataFromErrorCohort(

--- a/libs/core-ui/src/lib/util/calculateBoxData.ts
+++ b/libs/core-ui/src/lib/util/calculateBoxData.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { ErrorCohort } from "../Cohort/ErrorCohort";
+import { Cohort } from "../Cohort/Cohort"
 import { IHighchartBoxData } from "../Interfaces/IHighchartBoxData";
 
 export async function calculateBoxPlotDataFromErrorCohort(
@@ -37,12 +38,12 @@ export async function calculateBoxPlotDataFromSDK(
   ) => Promise<IHighchartBoxData>,
   queryClass?: string
 ): Promise<IHighchartBoxData> {
-  const filtersRelabeled = ErrorCohort.getLabeledFilters(
+  const filtersRelabeled = Cohort.getLabeledFilters(
     errorCohort.cohort.filters,
     errorCohort.jointDataset
   );
 
-  const compositeFiltersRelabeled = ErrorCohort.getLabeledCompositeFilters(
+  const compositeFiltersRelabeled = Cohort.getLabeledCompositeFilters(
     errorCohort.cohort.compositeFilters,
     errorCohort.jointDataset
   );

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixAreaUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixAreaUtils.ts
@@ -7,6 +7,7 @@ import {
   FilterMethods,
   JointDataset,
   ErrorCohort,
+  Cohort,
   Metrics,
   MetricCohortStats,
   IErrorAnalysisMatrix,
@@ -47,11 +48,11 @@ export async function fetchMatrix(
   ) {
     return undefined;
   }
-  const filtersRelabeled = ErrorCohort.getLabeledFilters(
+  const filtersRelabeled = Cohort.getLabeledFilters(
     baseCohort.cohort.filters,
     baseCohort.jointDataset
   );
-  const compositeFiltersRelabeled = ErrorCohort.getLabeledCompositeFilters(
+  const compositeFiltersRelabeled = Cohort.getLabeledCompositeFilters(
     baseCohort.cohort.compositeFilters,
     baseCohort.jointDataset
   );

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -14,7 +14,7 @@ import {
   IFilter,
   FilterMethods,
   CohortSource,
-  ErrorCohort,
+  Cohort,
   ErrorCohortStats,
   getRandomId,
   Metrics,
@@ -708,11 +708,11 @@ export class TreeViewRenderer extends React.PureComponent<
       }
       return;
     }
-    const filtersRelabeled = ErrorCohort.getLabeledFilters(
+    const filtersRelabeled = Cohort.getLabeledFilters(
       this.props.baseCohort.cohort.filters,
       this.props.baseCohort.jointDataset
     );
-    const compositeFiltersRelabeled = ErrorCohort.getLabeledCompositeFilters(
+    const compositeFiltersRelabeled = Cohort.getLabeledCompositeFilters(
       this.props.baseCohort.cohort.compositeFilters,
       this.props.baseCohort.jointDataset
     );


### PR DESCRIPTION
## Description

It looks like the functions `getBasicFilterString` and `getCompositeFilterString` operated on Cohort filters. So moving these functions into Cohort.ts as for explanations we use Cohort (not ErrorCohort) and the cohort labelling logic come handy if these functions are defined in Cohort.ts.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
