### PR TITLE
[Highcharts] Enable csv download, xls download and view data table in highcharts

### DIFF
--- a/.eslintrc/.eslintrc.import.eslintrc
+++ b/.eslintrc/.eslintrc.import.eslintrc
@@ -10,6 +10,7 @@
           "regenerator-runtime/runtime.js",
           "highcharts/modules/accessibility",
           "highcharts/modules/exporting",
+          "highcharts/modules/export-data",
           "highcharts/highcharts-more",
           "highcharts/modules/heatmap",
           "highcharts/modules/pattern-fill",

--- a/libs/core-ui/src/lib/Highchart/HighchartReact.tsx
+++ b/libs/core-ui/src/lib/Highchart/HighchartReact.tsx
@@ -5,6 +5,7 @@ import { localization } from "@responsible-ai/localization";
 import * as Highcharts from "highcharts";
 import HighchartsMore from "highcharts/highcharts-more";
 import * as Accessibility from "highcharts/modules/accessibility";
+import * as ExportData from "highcharts/modules/export-data";
 import * as Exporting from "highcharts/modules/exporting";
 import * as React from "react";
 
@@ -15,6 +16,7 @@ import { HighchartsModuleNames } from "./HighchartTypes";
 // Other modules need to be loaded on demand using modules property of the chart component.
 Accessibility.default(Highcharts);
 Exporting.default(Highcharts);
+ExportData.default(Highcharts);
 // init module
 HighchartsMore(Highcharts);
 

--- a/libs/core-ui/src/lib/Highchart/HighchartReact.tsx
+++ b/libs/core-ui/src/lib/Highchart/HighchartReact.tsx
@@ -39,11 +39,15 @@ export function HighchartReact(
   const createChart = (): Highcharts.Chart | null | undefined => {
     Highcharts.setOptions({
       lang: {
+        downloadCSV: localization.ChartContextMenu.downloadCSV,
         downloadJPEG: localization.ChartContextMenu.downloadJPEG,
         downloadPDF: localization.ChartContextMenu.downloadPDF,
         downloadPNG: localization.ChartContextMenu.downloadPNG,
         downloadSVG: localization.ChartContextMenu.downloadSVG,
+        downloadXLS: localization.ChartContextMenu.downloadXLS,
+        hideData: localization.ChartContextMenu.hideData,
         printChart: localization.ChartContextMenu.printChart,
+        viewData: localization.ChartContextMenu.viewData,
         viewFullscreen: localization.ChartContextMenu.viewInFullScreen
       }
     });

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -8,12 +8,16 @@
     "editButton": "Edit"
   },
   "ChartContextMenu": {
+    "hideData": "Hide data table",
+    "viewData": "View data table",
     "viewInFullScreen": "View in full screen",
     "printChart": "Print chart",
+    "downloadCSV": "Download CSV",
     "downloadPNG": "Download PNG image",
     "downloadJPEG": "Download JPEG image",
     "downloadPDF": "Download PDF document",
-    "downloadSVG": "Download SVG vector image"
+    "downloadSVG": "Download SVG vector image",
+    "downloadXLS": "Download XLS"
   },
   "CausalAnalysis": {
     "AggregateView": {


### PR DESCRIPTION
This PR enable csv & xls download in hightcharts. This is requested from an OCV where user has the comment: "Would be really cool and helpful to add an option to download as data chart. The PDF and image options are nice, but I can't work with the data."

## Description
We add three more options in highcharts, so users can download csv/xls file and interact with data:
![image](https://user-images.githubusercontent.com/91754176/197072757-1830c93e-7ad5-42d2-9f19-c22ea9ab9970.png)

Download csv file:
![image](https://user-images.githubusercontent.com/91754176/197072868-c5681567-057b-48c6-b997-f9be26db2484.png)

Click on 'View data table' button:
![image](https://user-images.githubusercontent.com/91754176/197072947-5b5e9155-222e-4142-9964-9a3466b843c9.png)

localization:
![image](https://user-images.githubusercontent.com/91754176/197075835-0d1b0182-986f-4b49-9fb3-700b2f9f4902.png)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
