### PR TITLE
fix isnan exception in erroranalysis for newer versions of pandas and numpy when calling qcut

### DIFF
--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '3'
-_patch = '11'
+_patch = '12'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -332,6 +332,19 @@ class TestMatrixFilter(object):
                                      y_test, feature_names, model_task,
                                      matrix_features=matrix_features)
 
+    def test_matrix_filter_titanic_object_dtype_quantile(self):
+        (X_train, X_test, y_train, y_test, numeric,
+            categorical) = create_simple_titanic_data()
+        feature_names = categorical + numeric
+        matrix_features = [numeric[0], numeric[1]]
+        clf = create_titanic_pipeline(X_train, y_train)
+        categorical_features = categorical
+        run_error_analyzer(clf, X_test, y_test, feature_names,
+                           categorical_features,
+                           matrix_features=matrix_features,
+                           quantile_binning=True,
+                           model_task=ModelTask.CLASSIFICATION)
+
 
 def run_error_analyzer_on_models(X_train,
                                  y_train,


### PR DESCRIPTION
## Description

Fix isnan exception in erroranalysis for newer versions of pandas and numpy when calling qcut.

When going to heatmap, in some environments with python 3.8 installed and latest versions of pandas and numpy, erroranalysis matrix_filter method would fail with error:

\\responsibleai\\responsible-ai-widgets\\erroranalysis\\erroranalysis\\_internal\\matrix_filter.py\", line 365, in bin_data\n    bindf = pd.qcut(feat_col, bins, precision=PRECISION, duplicates=DROP)\n  \\.conda\\envs\\big_data\\lib\\site-packages\\pandas\\core\\reshape\\tile.py\", line 375, in qcut\n    x_np = x_np[~np.isnan(x_np)]\nTypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''\n"

The solution was to change to more specific dtypes using convert_dtypes() for pandas dataframe after making a copy, since the copy was changing all types to object dtype.

Since qcut was failing on object dtype column when creating the dataframe copy, changing to more specify number type via convert_dtypes() fixed the error.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
