### PR TITLE
fix release github action for raiwidgets and responsibleai by making it same as in gated build

### DIFF
--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -132,7 +132,13 @@ jobs:
 
       - name: Run widget tests without flights
         shell: bash -l {0}
-        run: yarn e2e-widget -f ""
+        run: |
+          yarn e2e-widget -n "responsibleaidashboard-census-classification-model-debugging" -f ""
+          yarn e2e-widget -n "responsibleaidashboard-diabetes-regression-model-debugging" -f ""
+          yarn e2e-widget -n "responsibleaidashboard-housing-decision-making" -f ""
+          yarn e2e-widget -n "responsibleaidashboard-housing-classification-model-debugging" -f ""
+          yarn e2e-widget -n "responsibleaidashboard-diabetes-decision-making" -f ""
+          yarn e2e-widget -n "responsibleaidashboard-multiclass-dnn-model-debugging" -f ""
 
       - name: Upload e2e test screen shot
         if: always()


### PR DESCRIPTION

## Description

fix release github action for raiwidgets and responsibleai by making it same as in gated build

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
