### PR TITLE
Add new data APIs for compute_matrix() and compute_error_tree()

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -60,8 +60,8 @@ def compute_json_matrix(analyzer, features, filters, composite_filters):
     return compute_matrix(analyzer, features, filters, composite_filters)
 
 
-def compute_matrix(analyzer, features, filters, composite_filters,
-                   quantile_binning=False, num_bins=BIN_THRESHOLD):
+def compute_matrix_on_dataset(analyzer, features, dataset,
+                              quantile_binning=False, num_bins=BIN_THRESHOLD):
     """Compute a matrix of metrics for a given set of feature names.
 
     The filters and composite filters are used to filter the data
@@ -71,10 +71,14 @@ def compute_matrix(analyzer, features, filters, composite_filters,
     :type analyzer: BaseAnalyzer
     :param features: A list of one or two feature names to compute metrics for.
     :type features: list
-    :param filters: A list of filters to apply to the data.
-    :type filters: list
-    :param composite_filters: A list of composite filters to apply to the data.
-    :type composite_filters: list
+    :param dataset: The dataset on which matrix view needs to be computed.
+        The dataset should have the feature columns and the columns
+        'true_y' and 'index'. The 'true_y' column should have the true
+        target values corresponding to the test data. The 'index'
+        column should have the indices. If the analyzer is of type
+        PredictionsAnalyzer, then the dataset should include the column
+        'pred_y' which will hold the predictions.
+    :type dataset: pd.DataFrame
     :param quantile_binning: Whether to use quantile binning.
     :type quantile_binning: bool
     :param num_bins: The number of bins to use for quantile binning.
@@ -82,45 +86,6 @@ def compute_matrix(analyzer, features, filters, composite_filters,
     :return: A dictionary representation of the computed matrix which can be
         saved to JSON.
     :rtype: dict
-
-    :Example:
-
-    An example of running compute_matrix with a filter and a composite
-    filter:
-
-    >>> from erroranalysis._internal.error_analyzer import ModelAnalyzer
-    >>> from erroranalysis._internal.matrix_filter import (
-    ...     compute_matrix)
-    >>> from erroranalysis._internal.constants import ModelTask
-    >>> from sklearn.datasets import load_breast_cancer
-    >>> from sklearn.model_selection import train_test_split
-    >>> from sklearn import svm
-    >>> breast_cancer_data = load_breast_cancer()
-    >>> feature_names = breast_cancer_data.feature_names
-    >>> X_train, X_test, y_train, y_test = train_test_split(
-    ...     breast_cancer_data.data, breast_cancer_data.target,
-    ...     test_size=0.5, random_state=0)
-    >>> categorical_features = []
-    >>> clf = svm.SVC(gamma=0.001, C=100., probability=True,
-    ...               random_state=777)
-    >>> model = clf.fit(X_train, y_train)
-    >>> model_task = ModelTask.CLASSIFICATION
-    >>> analyzer = ModelAnalyzer(model, X_test, y_test, feature_names,
-    ...                          categorical_features, model_task=model_task)
-    >>> filters = [{'arg': [23.85], 'column': 'mean radius',
-    ...             'method': 'less and equal'}]
-    >>> composite_filters = [{'compositeFilters':
-    ...                      [{'compositeFilters':
-    ...                       [{'arg': [13.45, 22.27],
-    ...                         'column': 'mean radius',
-    ...                         'method': 'in the range of'},
-    ...                        {'arg': [10.88, 24.46],
-    ...                         'column': 'mean texture',
-    ...                         'method': 'in the range of'}],
-    ...                        'operation': 'and'}],
-    ...                      'operation': 'or'}]
-    >>> matrix = compute_matrix(analyzer, ['mean radius', 'mean texture'],
-    ...                         filters, composite_filters)
     """
     if num_bins <= 0:
         raise ValueError(
@@ -128,16 +93,14 @@ def compute_matrix(analyzer, features, filters, composite_filters,
     if features[0] is None and features[1] is None:
         raise ValueError(
             'One or two features must be specified to compute the heat map')
-    filtered_df = filter_from_cohort(analyzer,
-                                     filters,
-                                     composite_filters)
-    true_y = filtered_df[TRUE_Y]
+
+    true_y = dataset[TRUE_Y]
     dropped_cols = [TRUE_Y, ROW_INDEX]
     is_model_analyzer = hasattr(analyzer, 'model')
     if not is_model_analyzer:
-        pred_y = filtered_df[PRED_Y]
+        pred_y = dataset[PRED_Y]
         dropped_cols.append(PRED_Y)
-    input_data = filtered_df.drop(columns=dropped_cols)
+    input_data = dataset.drop(columns=dropped_cols)
     is_pandas = isinstance(analyzer.dataset, pd.DataFrame)
     metric = analyzer.metric
     if is_pandas:
@@ -320,6 +283,75 @@ def compute_matrix(analyzer, features, filters, composite_filters,
         matrix = matrix_1d(categories, val_err, counts,
                            counts_err, metric)
     return matrix
+
+
+def compute_matrix(analyzer, features, filters, composite_filters,
+                   quantile_binning=False, num_bins=BIN_THRESHOLD):
+    """Compute a matrix of metrics for a given set of feature names.
+
+    The filters and composite filters are used to filter the data
+    prior to computing the matrix.
+
+    :param analyzer: The error analyzer.
+    :type analyzer: BaseAnalyzer
+    :param features: A list of one or two feature names to compute metrics for.
+    :type features: list
+    :param filters: A list of filters to apply to the data.
+    :type filters: list
+    :param composite_filters: A list of composite filters to apply to the data.
+    :type composite_filters: list
+    :param quantile_binning: Whether to use quantile binning.
+    :type quantile_binning: bool
+    :param num_bins: The number of bins to use for quantile binning.
+    :type num_bins: int
+    :return: A dictionary representation of the computed matrix which can be
+        saved to JSON.
+    :rtype: dict
+
+    :Example:
+
+    An example of running compute_matrix with a filter and a composite
+    filter:
+
+    >>> from erroranalysis._internal.error_analyzer import ModelAnalyzer
+    >>> from erroranalysis._internal.matrix_filter import (
+    ...     compute_matrix)
+    >>> from erroranalysis._internal.constants import ModelTask
+    >>> from sklearn.datasets import load_breast_cancer
+    >>> from sklearn.model_selection import train_test_split
+    >>> from sklearn import svm
+    >>> breast_cancer_data = load_breast_cancer()
+    >>> feature_names = breast_cancer_data.feature_names
+    >>> X_train, X_test, y_train, y_test = train_test_split(
+    ...     breast_cancer_data.data, breast_cancer_data.target,
+    ...     test_size=0.5, random_state=0)
+    >>> categorical_features = []
+    >>> clf = svm.SVC(gamma=0.001, C=100., probability=True,
+    ...               random_state=777)
+    >>> model = clf.fit(X_train, y_train)
+    >>> model_task = ModelTask.CLASSIFICATION
+    >>> analyzer = ModelAnalyzer(model, X_test, y_test, feature_names,
+    ...                          categorical_features, model_task=model_task)
+    >>> filters = [{'arg': [23.85], 'column': 'mean radius',
+    ...             'method': 'less and equal'}]
+    >>> composite_filters = [{'compositeFilters':
+    ...                      [{'compositeFilters':
+    ...                       [{'arg': [13.45, 22.27],
+    ...                         'column': 'mean radius',
+    ...                         'method': 'in the range of'},
+    ...                        {'arg': [10.88, 24.46],
+    ...                         'column': 'mean texture',
+    ...                         'method': 'in the range of'}],
+    ...                        'operation': 'and'}],
+    ...                      'operation': 'or'}]
+    >>> matrix = compute_matrix(analyzer, ['mean radius', 'mean texture'],
+    ...                         filters, composite_filters)
+    """
+    filtered_df = filter_from_cohort(analyzer,
+                                     filters,
+                                     composite_filters)
+    return compute_matrix_on_dataset(analyzer, features, filtered_df,
+                                     quantile_binning, num_bins)
 
 
 def convert_dtypes(df):

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -96,6 +96,80 @@ def compute_json_error_tree(analyzer,
                               min_child_samples)
 
 
+def compute_error_tree_on_dataset(
+        analyzer,
+        features,
+        dataset,
+        max_depth=DEFAULT_MAX_DEPTH,
+        num_leaves=DEFAULT_NUM_LEAVES,
+        min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
+    """Computes the error tree for the given dataset.
+
+    :param analyzer: The error analyzer containing the categorical
+        features and categories for the full dataset.
+    :type analyzer: BaseAnalyzer
+    :param features: The features to train the surrogate model on.
+    :type features: numpy.ndarray or pandas.DataFrame
+    :param dataset: The dataset on which matrix view needs to be computed.
+        The dataset should have the feature columns and the columns
+        'true_y' and 'index'. The 'true_y' column should have the true
+        target values corresponding to the test data. The 'index'
+        column should have the indices. If the analyzer is of type
+        PredictionsAnalyzer, then the dataset should include the column
+        'pred_y' which will hold the predictions.
+    :type dataset: pd.DataFrame
+    :param max_depth: The maximum depth of the surrogate tree trained
+        on errors.
+    :type max_depth: int
+    :param num_leaves: The number of leaves of the surrogate tree
+        trained on errors.
+    :type num_leaves: int
+    :param min_child_samples: The minimal number of data required to
+        create one leaf.
+    :return: The tree representation as a list of nodes.
+    :rtype: list[dict[str, str]]
+    """
+    if max_depth is None:
+        max_depth = DEFAULT_MAX_DEPTH
+    if num_leaves is None:
+        num_leaves = DEFAULT_NUM_LEAVES
+    if min_child_samples is None:
+        min_child_samples = DEFAULT_MIN_CHILD_SAMPLES
+
+    if dataset.shape[0] == 0:
+        return create_empty_node(analyzer.metric)
+    is_model_analyzer = hasattr(analyzer, MODEL)
+    indexes = []
+    for feature in features:
+        indexes.append(analyzer.feature_names.index(feature))
+    dataset_sub_names = np.array(analyzer.feature_names)[np.array(indexes)]
+    dataset_sub_names = list(dataset_sub_names)
+    if not is_spark(dataset):
+        booster, dataset_indexed_df, cat_info = get_surrogate_booster_local(
+            dataset, analyzer, is_model_analyzer, indexes,
+            dataset_sub_names, max_depth, num_leaves, min_child_samples)
+        cat_ind_reindexed, categories_reindexed = cat_info
+    else:
+        booster, dataset_indexed_df = get_surrogate_booster_pyspark(
+            dataset, analyzer, max_depth, num_leaves, min_child_samples)
+        cat_ind_reindexed = []
+        categories_reindexed = []
+    dumped_model = booster.dump_model()
+    tree_structure = dumped_model["tree_info"][0]['tree_structure']
+    max_split_index = get_max_split_index(tree_structure) + 1
+    cache_subtree_features(tree_structure, dataset_sub_names)
+    tree = traverse(dataset_indexed_df,
+                    tree_structure,
+                    max_split_index,
+                    (categories_reindexed,
+                     cat_ind_reindexed),
+                    [],
+                    dataset_sub_names,
+                    metric=analyzer.metric,
+                    classes=analyzer.classes)
+    return tree
+
+
 def compute_error_tree(analyzer,
                        features,
                        filters,
@@ -165,47 +239,17 @@ def compute_error_tree(analyzer,
     ...                           filters, composite_filters)
     """
     # Fit a surrogate model on errors
-    if max_depth is None:
-        max_depth = DEFAULT_MAX_DEPTH
-    if num_leaves is None:
-        num_leaves = DEFAULT_NUM_LEAVES
-    if min_child_samples is None:
-        min_child_samples = DEFAULT_MIN_CHILD_SAMPLES
     filtered_df = filter_from_cohort(analyzer,
                                      filters,
                                      composite_filters)
-    if filtered_df.shape[0] == 0:
-        return create_empty_node(analyzer.metric)
-    is_model_analyzer = hasattr(analyzer, MODEL)
-    indexes = []
-    for feature in features:
-        indexes.append(analyzer.feature_names.index(feature))
-    dataset_sub_names = np.array(analyzer.feature_names)[np.array(indexes)]
-    dataset_sub_names = list(dataset_sub_names)
-    if not is_spark(filtered_df):
-        booster, filtered_indexed_df, cat_info = get_surrogate_booster_local(
-            filtered_df, analyzer, is_model_analyzer, indexes,
-            dataset_sub_names, max_depth, num_leaves, min_child_samples)
-        cat_ind_reindexed, categories_reindexed = cat_info
-    else:
-        booster, filtered_indexed_df = get_surrogate_booster_pyspark(
-            filtered_df, analyzer, max_depth, num_leaves, min_child_samples)
-        cat_ind_reindexed = []
-        categories_reindexed = []
-    dumped_model = booster.dump_model()
-    tree_structure = dumped_model["tree_info"][0]['tree_structure']
-    max_split_index = get_max_split_index(tree_structure) + 1
-    cache_subtree_features(tree_structure, dataset_sub_names)
-    tree = traverse(filtered_indexed_df,
-                    tree_structure,
-                    max_split_index,
-                    (categories_reindexed,
-                     cat_ind_reindexed),
-                    [],
-                    dataset_sub_names,
-                    metric=analyzer.metric,
-                    classes=analyzer.classes)
-    return tree
+    return compute_error_tree_on_dataset(
+        analyzer,
+        features,
+        filtered_df,
+        max_depth=DEFAULT_MAX_DEPTH,
+        num_leaves=DEFAULT_NUM_LEAVES,
+        min_child_samples=DEFAULT_MIN_CHILD_SAMPLES
+    )
 
 
 def get_surrogate_booster_local(filtered_df, analyzer, is_model_analyzer,

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -15,10 +15,14 @@ from erroranalysis._internal.constants import (MatrixParams, Metrics,
                                                metric_to_display_name)
 from erroranalysis._internal.matrix_filter import \
     compute_matrix as _compute_matrix
+from erroranalysis._internal.matrix_filter import \
+    compute_matrix_on_dataset as _compute_matrix_on_dataset
 from erroranalysis._internal.metrics import metric_to_func
 from erroranalysis._internal.process_categoricals import process_categoricals
 from erroranalysis._internal.surrogate_error_tree import \
     compute_error_tree as _compute_error_tree
+from erroranalysis._internal.surrogate_error_tree import \
+    compute_error_tree_on_dataset as _compute_error_tree_on_dataset
 from erroranalysis._internal.utils import generate_random_unique_indexes
 from erroranalysis._internal.version_checker import check_pandas_version
 from erroranalysis.report import ErrorReport
@@ -237,7 +241,7 @@ class BaseAnalyzer(ABC):
             to the dataset.
         :type composite_filters: list[str]
         :param quantile_binning: If true, use quantile binning for the
-            heatmap.  By default uses equal width binning.
+            heatmap. By default uses equal width binning.
         :type quantile_binning: bool
         :param num_bins: The number of bins per feature in the heatmap.
         :type num_bins: int
@@ -250,6 +254,40 @@ class BaseAnalyzer(ABC):
                                composite_filters,
                                quantile_binning=quantile_binning,
                                num_bins=num_bins)
+
+    def compute_matrix_on_dataset(
+            self,
+            features,
+            dataset,
+            quantile_binning=False,
+            num_bins=BIN_THRESHOLD):
+        """Computes the matrix filter (aka heatmap) json.
+
+        :param features: One or two feature names to compute the heatmap.
+        :type features: list
+        :param dataset: The dataset on which matrix view needs to be computed.
+            The dataset should have the feature columns and the columns
+            'true_y' and 'index'. The 'true_y' column should have the true
+            target values corresponding to the test data. The 'index'
+            column should have the indices. If the analyzer is of type
+            PredictionsAnalyzer, then the dataset should include the column
+            'pred_y' which will hold the predictions.
+        :type dataset: pd.DataFrame
+        :param quantile_binning: If true, use quantile binning for the
+            heatmap. By default uses equal width binning.
+        :type quantile_binning: bool
+        :param num_bins: The number of bins per feature in the heatmap.
+        :type num_bins: int
+        :return: The heatmap in json representation.
+        :rtype: dict
+        """
+        return _compute_matrix_on_dataset(
+            self,
+            features,
+            dataset,
+            quantile_binning,
+            num_bins
+        )
 
     def compute_error_tree(self,
                            features,
@@ -287,6 +325,46 @@ class BaseAnalyzer(ABC):
                                    max_depth=max_depth,
                                    num_leaves=num_leaves,
                                    min_child_samples=min_child_samples)
+
+    def compute_error_tree_on_dataset(
+            self,
+            features,
+            dataset,
+            max_depth=None,
+            num_leaves=None,
+            min_child_samples=None):
+        """Computes the tree view json.
+
+        :param features: The selected feature names to train the
+            surrogate model on.
+        :type features: list[str]
+        :param dataset: The dataset on which tree view needs to be computed.
+            The dataset should have the feature columns and the columns
+            'true_y' and 'index'. The 'true_y' column should have the true
+            target values corresponding to the test data. The 'index'
+            column should have the indices. If the analyzer is of type
+            PredictionsAnalyzer, then the dataset should include the column
+            'pred_y' which will hold the predictions.
+        :type dataset: pd.DataFrame
+        :param max_depth: The maximum depth of the surrogate tree trained
+            on errors.
+        :type max_depth: int
+        :param num_leaves: The number of leaves of the surrogate tree
+            trained on errors.
+        :type num_leaves: int
+        :param min_child_samples: The minimal number of data required to
+            create one leaf.
+        :type min_child_samples: int
+        :return: The tree view in json representation.
+        :rtype: dict
+        """
+        return _compute_error_tree_on_dataset(
+            self,
+            features,
+            dataset,
+            max_depth=max_depth,
+            num_leaves=num_leaves,
+            min_child_samples=min_child_samples)
 
     def create_error_report(self,
                             filter_features=None,

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -399,17 +399,20 @@ def run_error_analyzer(model,
         features = [feature_names[0], feature_names[1]]
     else:
         features = matrix_features
+
+    # Validate compute_matrix_on_dataset() output
     matrix = error_analyzer.compute_matrix(features,
                                            filters,
                                            composite_filters,
                                            quantile_binning=quantile_binning,
                                            num_bins=num_bins)
-    validation_data = X_test
+    validation_data = X_test.copy()
+    y_test_validation = y_test
     if filters is not None or composite_filters is not None:
         validation_data = filter_from_cohort(error_analyzer,
                                              filters,
                                              composite_filters)
-        y_test = validation_data[TRUE_Y]
+        y_test_validation = validation_data[TRUE_Y]
         validation_data = validation_data.drop(columns=[TRUE_Y, ROW_INDEX])
         if not isinstance(X_test, pd.DataFrame):
             validation_data = validation_data.values
@@ -419,8 +422,39 @@ def run_error_analyzer(model,
                                                metric,
                                                model,
                                                validation_data,
-                                               y_test)
+                                               y_test_validation)
     validate_matrix(matrix,
+                    expected_count,
+                    expected_error,
+                    features,
+                    metric=metric)
+
+    # Validate compute_matrix_on_dataset() output
+    dataset = X_test.copy()
+    if not isinstance(dataset, pd.DataFrame):
+        dataset = pd.DataFrame(data=dataset, columns=feature_names)
+    dataset[TRUE_Y] = y_test
+    dataset[ROW_INDEX] = np.arange(0, len(y_test))
+
+    new_matrix = error_analyzer.compute_matrix_on_dataset(
+        features, dataset,
+        quantile_binning=quantile_binning,
+        num_bins=num_bins)
+    expected_count = len(dataset)
+    metric = error_analyzer.metric
+
+    if not isinstance(X_test, pd.DataFrame):
+        dataset = dataset.drop(columns=[TRUE_Y, ROW_INDEX]).values
+    else:
+        dataset = dataset.drop(columns=[TRUE_Y, ROW_INDEX])
+
+    expected_error = get_expected_metric_error(
+        error_analyzer,
+        metric,
+        model,
+        dataset,
+        y_test)
+    validate_matrix(new_matrix,
                     expected_count,
                     expected_error,
                     features,

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -4,6 +4,7 @@
 import time
 from enum import Enum
 
+import numpy as np
 import pandas as pd
 import pytest
 from common_utils import (create_adult_census_data,
@@ -290,20 +291,54 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
                                              model_task=model_task)
     if tree_features is None:
         tree_features = feature_names
+
+    # Validate compute_error_tree() output
     tree = error_analyzer.compute_error_tree(
         tree_features, filters, composite_filters,
         max_depth=max_depth, num_leaves=num_leaves,
         min_child_samples=min_child_samples)
-    validation_data = X_test
+    validation_data = X_test.copy()
     if filters is not None or composite_filters is not None:
         validation_data = filter_from_cohort(error_analyzer,
                                              filters,
                                              composite_filters)
-        y_test = validation_data[TRUE_Y]
         validation_data = validation_data.drop(columns=[TRUE_Y, ROW_INDEX])
         if not isinstance(X_test, pd.DataFrame):
             validation_data = validation_data.values
-    validation_data_len = len(validation_data)
+    validate_error_tree(tree, len(validation_data), min_child_samples)
+
+    # Validate compute_error_tree_on_dataset() output
+    if len(validation_data) > 0:
+        dataset = X_test.copy()
+        if not isinstance(dataset, pd.DataFrame):
+            dataset = pd.DataFrame(data=dataset, columns=tree_features)
+        dataset[TRUE_Y] = y_test
+        dataset[ROW_INDEX] = np.arange(0, len(y_test))
+        if analyzer_type == AnalyzerType.PREDICTIONS:
+            dataset[PRED_Y] = model.predict(X_test)
+    else:
+        if isinstance(tree_features, np.ndarray):
+            tree_features_list = tree_features.tolist()
+        else:
+            tree_features_list = tree_features
+        if analyzer_type == AnalyzerType.PREDICTIONS:
+            dataset = pd.DataFrame(
+                data=[],
+                columns=tree_features_list + [TRUE_Y, ROW_INDEX, PRED_Y])
+        else:
+            dataset = pd.DataFrame(
+                data=[],
+                columns=tree_features_list + [TRUE_Y, ROW_INDEX])
+
+    new_tree = error_analyzer.compute_error_tree_on_dataset(
+        tree_features, dataset,
+        max_depth=max_depth, num_leaves=num_leaves,
+        min_child_samples=min_child_samples)
+
+    validate_error_tree(new_tree, len(dataset), min_child_samples)
+
+
+def validate_error_tree(tree, validation_data_len, min_child_samples):
     assert tree is not None
     assert len(tree) > 0
     assert ERROR in tree[0]


### PR DESCRIPTION
## Description

Introduced two new APIs `compute_matrix_on_dataset` and `compute_error_tree_on_dataset` to enable computation of error analysis insights on any external dataset and not just the test dataset available inside `RAIInsights`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
