### PR TITLE
Update e2e visit() function to not refresh the page if provided name doesn't exist in RAINotebookNames

### DIFF
--- a/libs/e2e/src/util/visit.ts
+++ b/libs/e2e/src/util/visit.ts
@@ -10,7 +10,7 @@ export function visit(
 ): void {
   let fileName: string;
   const hosts = Cypress.env().hosts;
-  if (!name) {
+  if (!name || !RAINotebookNames[name]) {
     return;
   }
   if (!hosts || !name) {


### PR DESCRIPTION
This PR updates e2e visit() function to not refresh the page if provided name doesn't exist in RAINotebookNames.

## Description
We don't want to refresh the page in AzureML to test for interactive dashboard features.

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
