### PR TITLE
update to latest 16.x node version for tests

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,7 +9,7 @@ env:
   blob_container_for_js: latest
   blob_container_for_raiwidget: raiwidgets
   blob_path_for_pull_request: ${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref }}
-  node-version: 16.8
+  node-version: 16.x
   widgetDirectory: raiwidgets
   raiDirectory: responsibleai
   dashboardDirectory: dashboard

--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ui-build:
     env:
-      node-version: 16.8
+      node-version: 16.x
 
     runs-on: windows-latest
 
@@ -40,7 +40,7 @@ jobs:
     needs: ui-build
 
     env:
-      node-version: 16.8
+      node-version: 16.x
 
     strategy:
       fail-fast: false

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci-raiwidgets-pytest:
     env:
-      node-version: 16.8
+      node-version: 16.x
     strategy:
       matrix:
         packageDirectory: ["raiwidgets"]

--- a/.github/workflows/CI-typescript.yml
+++ b/.github/workflows/CI-typescript.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.8]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -1,7 +1,7 @@
 name: Release to PyPI
 
 env:
-  node-version: 16.8
+  node-version: 16.x
   widgetDirectory: raiwidgets
   raiDirectory: responsibleai
   typescriptBuildOutput: dist


### PR DESCRIPTION
## Description

We previously capped node version to 16.8 due to build failures.  This PR tries to update to latest again, as it was before.

I also tried to add 18.x as well, but I saw build failures so I took it out (related to rollup plugin which I think just needs to be upgraded, but when I upgraded I saw some other failures).  Now that 18.x has an LTS version released we should at some point look into adding it as well.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
