### PR TITLE
Add RAI version number to oss serialize result

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_base_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_base_insights.py
@@ -17,7 +17,7 @@ from responsibleai._internal.constants import Metadata
 
 _DATA = 'data'
 _DTYPES = 'dtypes'
-_RAIVERSION = "raiversion"
+_RAIVERSION = "rai_version"
 _TRAIN = 'train'
 _TEST = 'test'
 _MODEL = Metadata.MODEL

--- a/responsibleai/responsibleai/rai_insights/rai_base_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_base_insights.py
@@ -12,10 +12,12 @@ from typing import Any, Optional
 
 import pandas as pd
 
+import responsibleai
 from responsibleai._internal.constants import Metadata
 
 _DATA = 'data'
 _DTYPES = 'dtypes'
+_RAIVERSION = "raiversion"
 _TRAIN = 'train'
 _TEST = 'test'
 _MODEL = Metadata.MODEL
@@ -154,6 +156,11 @@ class RAIBaseInsights(ABC):
                             json.dumps(dtypes))
         self._write_to_file(data_directory / (_TEST + _JSON_EXTENSION),
                             self.test.to_json(orient='split'))
+
+        self._write_to_file(Path(path) /
+                            (_RAIVERSION + _JSON_EXTENSION),
+                            json.dumps(
+                                {"responsibleai": responsibleai.__version__}))
 
     @abstractmethod
     def _save_metadata(self, path):

--- a/responsibleai/tests/rai_insights/test_rai_insights.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights.py
@@ -269,6 +269,7 @@ def run_rai_insights(model, train_data, test_data, target_column,
 
 def validate_common_state_directories(path, task_type):
     all_other_files = os.listdir(path)
+    assert "rai_version.json" in all_other_files
     assert "meta.json" in all_other_files
     assert "model.pkl" in all_other_files
 


### PR DESCRIPTION
This PR adds RAI version number to oss serialize result.

## Description
We will generate raiversion.json file:
![image](https://user-images.githubusercontent.com/91754176/201231604-eb81e9d9-d80e-4569-bcc5-ef0f8c41b7b0.png)
In the json file, it lists out the responsibleai package version number:
![image](https://user-images.githubusercontent.com/91754176/201231612-0aee2f36-78ba-4faa-8fd7-d43cbcf6a1b4.png)

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
