### PR TITLE
Add user feature name to box plot hover over

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
@@ -2,24 +2,37 @@
 // Licensed under the MIT License.
 
 import { getTheme } from "@fluentui/react";
-import { getBoxData, getPrimaryChartColor } from "@responsible-ai/core-ui";
+import {
+  getBoxData,
+  getPrimaryChartColor,
+  IGenericChartProps,
+  JointDataset
+} from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
 
-export function getDatasetBoxOption(plotlyProps: IPlotlyProperty): any {
+export function getDatasetBoxOption(
+  jointData: JointDataset,
+  plotlyProps: IPlotlyProperty,
+  chartProps?: IGenericChartProps
+): any {
   const boxData = plotlyProps.data.map((d: any) => getBoxData(d.x, d.y).box);
   const outlier = plotlyProps.data.map(
     (d: any) => getBoxData(d.x, d.y).outlier
   );
   const theme = getTheme();
   const boxGroupData: any = [];
+  let userFeatureName =
+    localization.ModelAssessment.ModelOverview.BoxPlot.boxPlotSeriesLabel;
+  if (chartProps?.yAxis.property) {
+    userFeatureName = jointData.metaDict[chartProps?.yAxis.property].label;
+  }
   boxData.forEach((data: any) => {
     boxGroupData.push({
       color: data.color,
       data,
       fillColor: theme.semanticColors.inputBackgroundChecked,
-      name: localization.ModelAssessment.ModelOverview.BoxPlot
-        .boxPlotSeriesLabel
+      name: userFeatureName
     });
   });
   outlier.forEach((data: any) => {

--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetOption.ts
@@ -28,5 +28,5 @@ export function getDatasetOption(
   ) {
     return getDatasetBarOption(jointData, plotlyProps, chartProps);
   }
-  return getDatasetBoxOption(plotlyProps);
+  return getDatasetBoxOption(jointData, plotlyProps, chartProps);
 }


### PR DESCRIPTION
## Description

Currently box plot hover over shows just the "Box Plot" string. Replacing the "Box Plot" string with user feature name on y-axis which is more intuitive. 

Before:-
![image](https://user-images.githubusercontent.com/47334368/204447589-3bf5f0fa-2b3e-427a-b92d-bd97deab7695.png)


After:-
![image](https://user-images.githubusercontent.com/47334368/204447474-cddea9ae-15d4-43d6-b404-6871d8db8a75.png)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
