### PR TITLE
Use "lower whisker" and "upper whisker" instead of misleading "minimum" and "maximum" on boxplot tooltips

### DIFF
--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -90,6 +90,7 @@ export * from "./lib/Interfaces/IMetaData";
 export * from "./lib/Interfaces/TextExplanationInterfaces";
 export * from "./lib/Interfaces/VisionExplanationInterfaces";
 export * from "./lib/Highchart/BasicHighChart";
+export * from "./lib/Highchart/BoxChartTooltip";
 export * from "./lib/Highchart/ChartColors";
 export * from "./lib/Highchart/FeatureImportanceDependence";
 export * from "./lib/Highchart/FeatureImportanceBar";

--- a/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
+++ b/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import _ from "lodash";
+import { SeriesTooltipOptionsObject } from "highcharts";
 
 // Fix tooltip to use "lower whisker" and "upper whisker"
 // instead of "minimum" and "maximum"
-export const boxChartTooltipDefaultSetting: Highcharts.SeriesTooltipOptionsObject = {
+export const boxChartTooltipDefaultSetting: SeriesTooltipOptionsObject = {
   pointFormat:
     '<span style="color:{point.color}">●</span> <b>{series.name}</b><br/>Upper whisker: {point.high}<br/>Upper quartile: {point.q3}<br/>Median: {point.median}<br/>Lower quartile: {point.q1}<br/>Lower whisker: {point.low}<br/>'
 };

--- a/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
+++ b/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import _ from "lodash";
+
+// Fix tooltip to use "lower whisker" and "upper whisker"
+// instead of "minimum" and "maximum"
+export const boxChartTooltipDefaultSetting: Highcharts.SeriesTooltipOptionsObject = {
+  pointFormat:
+    '<span style="color:{point.color}">●</span> <b>{series.name}</b><br/>Upper whisker: {point.high}<br/>Upper quartile: {point.q3}<br/>Median: {point.median}<br/>Lower quartile: {point.q1}<br/>Lower whisker: {point.low}<br/>'
+};

--- a/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
+++ b/libs/core-ui/src/lib/Highchart/BoxChartTooltip.tsx
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { localization } from "@responsible-ai/localization";
 import { SeriesTooltipOptionsObject } from "highcharts";
 
 // Fix tooltip to use "lower whisker" and "upper whisker"
 // instead of "minimum" and "maximum"
 export const boxChartTooltipDefaultSetting: SeriesTooltipOptionsObject = {
   pointFormat:
-    '<span style="color:{point.color}">●</span> <b>{series.name}</b><br/>Upper whisker: {point.high}<br/>Upper quartile: {point.q3}<br/>Median: {point.median}<br/>Lower quartile: {point.q1}<br/>Lower whisker: {point.low}<br/>'
+    '<span style="color:{point.color}">●</span> <b>{series.name}</b><br/>' +
+    `${localization.ModelAssessment.ModelOverview.BoxPlot.upperWhisker}: {point.high}<br/>` +
+    `${localization.ModelAssessment.ModelOverview.BoxPlot.upperQuartile}: {point.q3}<br/>` +
+    `${localization.ModelAssessment.ModelOverview.BoxPlot.median}: {point.median}<br/>` +
+    `${localization.ModelAssessment.ModelOverview.BoxPlot.lowerQuartile}: {point.q1}<br/>` +
+    `${localization.ModelAssessment.ModelOverview.BoxPlot.lowerWhisker} {point.low}<br/>`
 };

--- a/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.tsx
+++ b/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.tsx
@@ -48,7 +48,7 @@ export class FeatureImportanceBar extends React.Component<
   public constructor(props: IFeatureBarProps) {
     super(props);
     this.state = {
-      highchartOption: this.getHightChartOption()
+      highchartOption: this.getHighchartOption()
     };
   }
 
@@ -60,7 +60,7 @@ export class FeatureImportanceBar extends React.Component<
       this.props.chartType !== prevProps.chartType
     ) {
       this.setState({
-        highchartOption: this.getHightChartOption()
+        highchartOption: this.getHighchartOption()
       });
     }
   }
@@ -95,7 +95,7 @@ export class FeatureImportanceBar extends React.Component<
     );
   }
 
-  private getHightChartOption(): IHighchartsConfig {
+  private getHighchartOption(): IHighchartsConfig {
     return this.props.chartType === ChartTypes.Bar
       ? getFeatureImportanceBarOptions(
           this.props.sortArray,

--- a/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
@@ -4,8 +4,8 @@
 import { ITheme } from "@fluentui/react";
 import { SeriesOptionsType } from "highcharts";
 import _ from "lodash";
-import { boxChartTooltipDefaultSetting } from "../Highchart/BoxChartTooltip";
 
+import { boxChartTooltipDefaultSetting } from "../Highchart/BoxChartTooltip";
 import { getChartColors } from "../Highchart/ChartColors";
 import { IGlobalSeries } from "../Highchart/FeatureImportanceBar";
 import { IHighchartsConfig } from "../Highchart/IHighchartsConfig";
@@ -52,8 +52,8 @@ export function getFeatureImportanceBoxOptions(
       color: data.color,
       data: boxData.box,
       name: data.name,
-      type: "boxplot",
-      tooltip: boxChartTooltipDefaultSetting
+      tooltip: boxChartTooltipDefaultSetting,
+      type: "boxplot"
     });
   });
   return {
@@ -88,6 +88,6 @@ export function getFeatureImportanceBoxOptions(
       title: {
         align: "high"
       }
-    },
+    }
   };
 }

--- a/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
@@ -4,6 +4,7 @@
 import { ITheme } from "@fluentui/react";
 import { SeriesOptionsType } from "highcharts";
 import _ from "lodash";
+import { boxChartTooltipDefaultSetting } from "../Highchart/BoxChartTooltip";
 
 import { getChartColors } from "../Highchart/ChartColors";
 import { IGlobalSeries } from "../Highchart/FeatureImportanceBar";
@@ -51,7 +52,8 @@ export function getFeatureImportanceBoxOptions(
       color: data.color,
       data: boxData.box,
       name: data.name,
-      type: "boxplot"
+      type: "boxplot",
+      tooltip: boxChartTooltipDefaultSetting
     });
   });
   return {
@@ -86,6 +88,6 @@ export function getFeatureImportanceBoxOptions(
       title: {
         align: "high"
       }
-    }
+    },
   };
 }

--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
@@ -59,6 +59,6 @@ export function getDatasetBoxOption(
       title: {
         align: "high"
       }
-    },
+    }
   };
 }

--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/getDatasetBoxOption.ts
@@ -6,7 +6,8 @@ import {
   getBoxData,
   getPrimaryChartColor,
   IGenericChartProps,
-  JointDataset
+  JointDataset,
+  boxChartTooltipDefaultSetting
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
@@ -32,7 +33,8 @@ export function getDatasetBoxOption(
       color: data.color,
       data,
       fillColor: theme.semanticColors.inputBackgroundChecked,
-      name: userFeatureName
+      name: userFeatureName,
+      tooltip: boxChartTooltipDefaultSetting
     });
   });
   outlier.forEach((data: any) => {
@@ -57,6 +59,6 @@ export function getDatasetBoxOption(
       title: {
         align: "high"
       }
-    }
+    },
   };
 }

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1749,7 +1749,12 @@
       "BoxPlot": {
         "outlierProbability": "probability",
         "outlierLabel": "Outliers",
-        "boxPlotSeriesLabel": "Box Plot"
+        "boxPlotSeriesLabel": "Box Plot",
+        "lowerWhisker": "Lower whisker",
+        "upperWhisker": "Upper whisker",
+        "median": "Median",
+        "lowerQuartile": "Lower quartile",
+        "upperQuartile": "Upper quartile"
       },
       "chartConfigApply": "Apply",
       "chartConfigCancel": "Cancel",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
@@ -4,6 +4,7 @@
 import { getTheme, IChoiceGroupOption } from "@fluentui/react";
 import {
   BasicHighChart,
+  boxChartTooltipDefaultSetting,
   calculateBoxPlotData,
   calculateBoxPlotDataFromErrorCohort,
   defaultModelAssessmentContext,
@@ -124,7 +125,8 @@ export class ProbabilityDistributionBoxChart extends React.Component<IProbabilit
               fillColor: theme.semanticColors.inputBackgroundChecked,
               name: localization.ModelAssessment.ModelOverview.BoxPlot
                 .boxPlotSeriesLabel,
-              type: "boxplot"
+              type: "boxplot",
+              tooltip: boxChartTooltipDefaultSetting
             },
             {
               data: isNewSdkEndpointsFlightOn

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
@@ -125,8 +125,8 @@ export class ProbabilityDistributionBoxChart extends React.Component<IProbabilit
               fillColor: theme.semanticColors.inputBackgroundChecked,
               name: localization.ModelAssessment.ModelOverview.BoxPlot
                 .boxPlotSeriesLabel,
-              type: "boxplot",
-              tooltip: boxChartTooltipDefaultSetting
+              tooltip: boxChartTooltipDefaultSetting,
+              type: "boxplot"
             },
             {
               data: isNewSdkEndpointsFlightOn


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After a fairly lengthy (but nevertheless interesting!) [discussion](https://teams.microsoft.com/l/message/19:b3d5603e893043e28afa391c588a3106@thread.tacv2/1650993784816?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=f76d15f8-67ce-419b-a134-8cf5ff88fe24&parentMessageId=1650993784816&teamName=TIRAI&channelName=RAI&createdTime=1650993784816&allowXTenantAccess=false) about boxplot tooltip labels back in April I got the task assigned to fix it. Rereading the thread today it seemed like "lower whisker" and "upper whisker" were preferred.

As this is the tooltip of the `series`, not the overall chart, I didn't find a way to make it just the default option, but rather added it to the three existing box plots in the dataset explorer, model overview, and feature importance components.

model overview
![image](https://user-images.githubusercontent.com/10245648/205209500-058fb0ee-a443-43e4-941d-b0cc6bf4c92c.png)

dataset explorer
![image](https://user-images.githubusercontent.com/10245648/205209539-0ab1eac7-0116-4fb2-9b7c-d1c330944777.png)

feature importance:
![image](https://user-images.githubusercontent.com/10245648/205209470-53427dc5-4076-4c88-8a44-3d797f7ab967.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
