### PR TITLE
upgrade setup-python github action from v2 to v4 and pin to older ubuntu image for python 3.6 to fix build error

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -33,7 +33,7 @@ jobs:
 
       #setup environment
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Use Node.js ${{ env.node-version }}

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -18,12 +18,21 @@ jobs:
             "raiutils",
             "rai_test_utils"
           ]
-        operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
+        operatingSystem:
+          [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
         pythonVersion: ["3.6", "3.7", "3.8", "3.9"]
         exclude:
           - packageDirectory: "rai_core_flask"
             operatingSystem: macos-latest
             pythonVersion: "3.9"
+          - operatingSystem: ubuntu-20.04
+            pythonVersion: "3.7"
+          - operatingSystem: ubuntu-20.04
+            pythonVersion: "3.8"
+          - operatingSystem: ubuntu-20.04
+            pythonVersion: "3.9"
+          - operatingSystem: ubuntu-latest
+            pythonVersion: "3.6"
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -31,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.pythonVersion }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.pythonVersion }}
 

--- a/.github/workflows/GitHubPages.yml
+++ b/.github/workflows/GitHubPages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/release-erroranalysis.yml
+++ b/.github/workflows/release-erroranalysis.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/release-flask.yml
+++ b/.github/workflows/release-flask.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/release-nlp-feature-extractors.yml
+++ b/.github/workflows/release-nlp-feature-extractors.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/release-rai-test-utils.yml
+++ b/.github/workflows/release-rai-test-utils.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/release-raiutils.yml
+++ b/.github/workflows/release-raiutils.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are seeing build errors on main related to the setup-python github action for python 3.6.
This PR tries to:

1.) Upgrade setup-python github action from v2 to latest version v4
2.) Based on issues, error seems to occur when using python 3.6 with new latest-ubuntu OS tag.  Hence, pinning to older ubuntu for python 3.6 in test matrix resolves this.

Related issue:
https://github.com/actions/setup-python/issues/544
https://github.com/actions/setup-python/issues/543

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
