### PR TITLE
Gate call to probability distribution end point

### DIFF
--- a/libs/core-ui/src/lib/util/CalculateBoxPlot.test.tsx
+++ b/libs/core-ui/src/lib/util/CalculateBoxPlot.test.tsx
@@ -120,7 +120,8 @@ describe("calculateBoxPlotDataFromErrorCohort", () => {
         0,
         "",
         "0",
-        mockRequestBoxPlotDistribution
+        mockRequestBoxPlotDistribution,
+        true
       );
       expect(boxPlotData?.high).toEqual(expectedResult.high);
       expect(boxPlotData?.q3).toEqual(expectedResult.q3);

--- a/libs/core-ui/src/lib/util/calculateBoxData.ts
+++ b/libs/core-ui/src/lib/util/calculateBoxData.ts
@@ -16,9 +16,10 @@ export async function calculateBoxPlotDataFromErrorCohort(
   requestBoxPlotDistribution?: (
     request: any,
     abortSignal: AbortSignal
-  ) => Promise<IHighchartBoxData>
+  ) => Promise<IHighchartBoxData>,
+  ifEnableLargeData?: boolean
 ): Promise<IHighchartBoxData | undefined> {
-  if (requestBoxPlotDistribution) {
+  if (ifEnableLargeData && requestBoxPlotDistribution) {
     return await calculateBoxPlotDataFromSDK(
       errorCohort,
       requestBoxPlotDistribution,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ProbabilityDistributionBoxChart.tsx
@@ -10,7 +10,8 @@ import {
   ErrorCohort,
   ModelAssessmentContext,
   setOutlierDataIfChanged,
-  IBoxChartState
+  IBoxChartState,
+  ifEnableLargeData
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { PointOptionsObject } from "highcharts";
@@ -47,7 +48,8 @@ export class ProbabilityDistributionBoxChart extends React.Component<IProbabilit
             index,
             this.props.probabilityOption?.key || "",
             this.props.probabilityOption?.id,
-            this.context.requestBoxPlotDistribution
+            this.context.requestBoxPlotDistribution,
+            ifEnableLargeData(this.context.dataset)
           );
         }
       );

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/RegressionDistributionChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/RegressionDistributionChart.tsx
@@ -20,7 +20,8 @@ import {
   JointDataset,
   ModelAssessmentContext,
   setOutlierDataIfChanged,
-  IBoxChartState
+  IBoxChartState,
+  ifEnableLargeData
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { PointOptionsObject } from "highcharts";
@@ -102,7 +103,8 @@ export class RegressionDistributionChart extends React.Component<
             index,
             targetOption?.key.toString(),
             targetOption?.id,
-            this.context.requestBoxPlotDistribution
+            this.context.requestBoxPlotDistribution,
+            ifEnableLargeData(this.context.dataset)
           );
         }
       );


### PR DESCRIPTION

## Description

Since the newSDKEndPoints flights was removed under the PR https://github.com/microsoft/responsible-ai-toolbox/pull/1532/files, we need to gate the call to probability distribution end point under the flag `IfEnableLargeData`. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
