### PR TITLE
Remove redundant call to serialize_json_safe() in raiwidgets causal tests

### DIFF
--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_causal.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard_input_causal.py
@@ -4,7 +4,6 @@
 import pytest
 from common_utils import CheckResponsibleAIDashboardInputTestResult
 
-from raiutils.data_processing import serialize_json_safe
 from raiwidgets.responsibleai_dashboard_input import \
     ResponsibleAIDashboardInput
 
@@ -85,9 +84,8 @@ class TestResponsibleAIDashboardInputRegressionCausal(
         post_data = (id, filters, [])
 
         flask_server_prediction_output = \
-            serialize_json_safe(
-                dashboard_input.get_global_causal_effects(
-                    post_data))
+            dashboard_input.get_global_causal_effects(
+                post_data)
 
         self.check_success_criteria(flask_server_prediction_output)
 
@@ -132,9 +130,8 @@ class TestResponsibleAIDashboardInputRegressionCausal(
         post_data = (id, filters, [])
 
         flask_server_prediction_output = \
-            serialize_json_safe(
-                dashboard_input.get_global_causal_policy(
-                    post_data))
+            dashboard_input.get_global_causal_policy(
+                post_data)
 
         self.check_success_criteria(flask_server_prediction_output)
 


### PR DESCRIPTION
## Description

It looks like the serialize_json_safe() is already called in responsibleai_dashboard_input.py for causal end point output.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
