### PR TITLE
[Metadata] Fix counterfactual error on unable to update feature value

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualList.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualList.tsx
@@ -215,14 +215,16 @@ export class CounterfactualList extends React.Component<
     option?: IComboBoxOption
   ): void => {
     const id = key.toString();
-    const keyIndex =
-      this.props.data?.feature_names_including_target.indexOf(id);
+    const columnKey = this.getColumnKey(id);
+    if (!columnKey) {
+      return;
+    }
     if (option?.text) {
       const optionIndex = options.findIndex(
         (feature) => feature.key === option.text
       );
       this.props.setCustomRowPropertyComboBox(
-        `Data${keyIndex}`,
+        columnKey,
         optionIndex,
         option.text
       );
@@ -239,15 +241,23 @@ export class CounterfactualList extends React.Component<
   ): void => {
     const target = evt.target as Element;
     const id = target.id;
-    const keyIndex =
-      this.props.data?.feature_names_including_target.indexOf(id);
-    this.props.setCustomRowProperty(`Data${keyIndex}`, false, newValue);
+    const columnKey = this.getColumnKey(id);
+    if (!columnKey) {
+      return;
+    }
+    this.props.setCustomRowProperty(columnKey, false, newValue);
     this.setState((prevState) => {
       prevState.data[id] = newValue?.endsWith(".")
         ? newValue
         : toNumber(newValue);
       return { data: { ...prevState.data } };
     });
+  };
+
+  private getColumnKey = (featureKey: string): string | undefined => {
+    const metaDict = this.context.jointDataset.metaDict;
+    const metaDictKeys = Object.keys(metaDict);
+    return metaDictKeys.find((item) => metaDict[item].label === featureKey);
   };
 
   private toggleCallout = (): void => {


### PR DESCRIPTION
If dropped features are passed to RAIInsights, the feature index could be wrong, We need to use metadict to query for the feature key.

## Description
Before: Unable to update feature values in counterfactual list if dropped features are passed.

After: We are able to update feature values in counterfactual list if dropped features are passed.
![image](https://user-images.githubusercontent.com/91754176/206767167-a5f4fc2e-4fa9-42db-826e-98cc7875cd27.png)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
