### PR TITLE
Disable partial dependence plots for large data scenarios

### DIFF
--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -281,102 +281,105 @@ export class GlobalExplanationTab extends React.PureComponent<
             </MissingParametersPlaceholder>
           </Stack.Item>
         )}
-        {this.context.jointDataset.hasDataset && (
-          <>
-            <Stack.Item className={classNames.chartCallout}>
-              <LabelWithCallout
-                label={localization.Interpret.Charts.howToRead}
-                calloutTitle={
-                  localization.Interpret.GlobalTab.dependencePlotTitle
-                }
-                type="button"
-                telemetryHook={this.props.telemetryHook}
-                calloutEventName={
-                  TelemetryEventName.FeatureImportancesHowToReadChartCalloutClick
-                }
-              >
-                <Text>
-                  {localization.Interpret.GlobalTab.dependencePlotHelperText}
-                </Text>
-              </LabelWithCallout>
-            </Stack.Item>
-            <Stack.Item>
-              <Stack
-                horizontal
-                className={classNames.dependencePlotChartContainer}
-              >
-                <Stack.Item className={classNames.chartLeftPart}>
-                  <div
-                    id="DependencePlot"
-                    className={classNames.secondaryChartAndLegend}
-                    ref={this.depPlot}
-                  >
-                    <FeatureImportanceDependence
-                      chartProps={this.state.dependenceProps}
-                      cohortIndex={this.state.selectedCohortIndex}
-                      cohort={
-                        this.props.cohorts[this.state.selectedCohortIndex]
-                      }
-                      jointDataset={this.context.jointDataset}
-                      logarithmicScaling={this.state.logarithmicScaling}
-                      metadata={this.context.modelMetadata}
-                      selectedWeight={this.props.selectedWeightVector}
-                      selectedWeightLabel={
-                        this.props.weightLabels[this.props.selectedWeightVector]
-                      }
-                    />
-                  </div>
-                </Stack.Item>
-                <Stack.Item className={classNames.legendAndSort}>
-                  {featureOptions && (
-                    <ComboBox
-                      id="DependencePlotFeatureSelection"
-                      label={
-                        localization.Interpret.GlobalTab.viewDependencePlotFor
-                      }
-                      options={featureOptions}
-                      allowFreeform={false}
-                      autoComplete="on"
-                      placeholder={
-                        localization.Interpret.GlobalTab
-                          .dependencePlotFeatureSelectPlaceholder
-                      }
-                      selectedKey={this.state.dependenceProps?.xAxis.property}
-                      onChange={this.onXSet}
-                      calloutProps={FluentUIStyles.calloutProps}
-                    />
-                  )}
-                  {cohortOptions && (
-                    <Dropdown
-                      label={
-                        localization.Interpret.GlobalTab.datasetCohortSelector
-                      }
-                      options={cohortOptions}
-                      selectedKey={this.state.selectedCohortIndex}
-                      onChange={this.setSelectedCohort}
-                    />
-                  )}
-                  {featureOptions &&
-                    (selectedMeta?.featureRange?.rangeType ===
-                      RangeTypes.Integer ||
-                      selectedMeta?.featureRange?.rangeType ===
-                        RangeTypes.Numeric) && (
-                      <Toggle
-                        key="logarithmic-scaling-toggle"
-                        label={
-                          localization.Interpret.AxisConfigDialog
-                            .logarithmicScaling
+        {!ifEnableLargeData(this.context.dataset) &&
+          this.context.jointDataset.hasDataset && (
+            <>
+              <Stack.Item className={classNames.chartCallout}>
+                <LabelWithCallout
+                  label={localization.Interpret.Charts.howToRead}
+                  calloutTitle={
+                    localization.Interpret.GlobalTab.dependencePlotTitle
+                  }
+                  type="button"
+                  telemetryHook={this.props.telemetryHook}
+                  calloutEventName={
+                    TelemetryEventName.FeatureImportancesHowToReadChartCalloutClick
+                  }
+                >
+                  <Text>
+                    {localization.Interpret.GlobalTab.dependencePlotHelperText}
+                  </Text>
+                </LabelWithCallout>
+              </Stack.Item>
+              <Stack.Item>
+                <Stack
+                  horizontal
+                  className={classNames.dependencePlotChartContainer}
+                >
+                  <Stack.Item className={classNames.chartLeftPart}>
+                    <div
+                      id="DependencePlot"
+                      className={classNames.secondaryChartAndLegend}
+                      ref={this.depPlot}
+                    >
+                      <FeatureImportanceDependence
+                        chartProps={this.state.dependenceProps}
+                        cohortIndex={this.state.selectedCohortIndex}
+                        cohort={
+                          this.props.cohorts[this.state.selectedCohortIndex]
                         }
-                        inlineLabel
-                        checked={this.state.logarithmicScaling}
-                        onChange={this.setLogarithmicScaling}
+                        jointDataset={this.context.jointDataset}
+                        logarithmicScaling={this.state.logarithmicScaling}
+                        metadata={this.context.modelMetadata}
+                        selectedWeight={this.props.selectedWeightVector}
+                        selectedWeightLabel={
+                          this.props.weightLabels[
+                            this.props.selectedWeightVector
+                          ]
+                        }
+                      />
+                    </div>
+                  </Stack.Item>
+                  <Stack.Item className={classNames.legendAndSort}>
+                    {featureOptions && (
+                      <ComboBox
+                        id="DependencePlotFeatureSelection"
+                        label={
+                          localization.Interpret.GlobalTab.viewDependencePlotFor
+                        }
+                        options={featureOptions}
+                        allowFreeform={false}
+                        autoComplete="on"
+                        placeholder={
+                          localization.Interpret.GlobalTab
+                            .dependencePlotFeatureSelectPlaceholder
+                        }
+                        selectedKey={this.state.dependenceProps?.xAxis.property}
+                        onChange={this.onXSet}
+                        calloutProps={FluentUIStyles.calloutProps}
                       />
                     )}
-                </Stack.Item>
-              </Stack>
-            </Stack.Item>
-          </>
-        )}
+                    {cohortOptions && (
+                      <Dropdown
+                        label={
+                          localization.Interpret.GlobalTab.datasetCohortSelector
+                        }
+                        options={cohortOptions}
+                        selectedKey={this.state.selectedCohortIndex}
+                        onChange={this.setSelectedCohort}
+                      />
+                    )}
+                    {featureOptions &&
+                      (selectedMeta?.featureRange?.rangeType ===
+                        RangeTypes.Integer ||
+                        selectedMeta?.featureRange?.rangeType ===
+                          RangeTypes.Numeric) && (
+                        <Toggle
+                          key="logarithmic-scaling-toggle"
+                          label={
+                            localization.Interpret.AxisConfigDialog
+                              .logarithmicScaling
+                          }
+                          inlineLabel
+                          checked={this.state.logarithmicScaling}
+                          onChange={this.setLogarithmicScaling}
+                        />
+                      )}
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+            </>
+          )}
       </Stack>
     );
   }


### PR DESCRIPTION
## Description

It is not possible to visualize all scatter plot points in partial dependence plot. Hence, disabling it for large data.

Before:-
![image](https://user-images.githubusercontent.com/47334368/206777249-afb14c01-ffc7-4b96-a930-4778792e380b.png)

After:-
![image](https://user-images.githubusercontent.com/47334368/206777532-95031c9e-7b95-45c2-830d-f77aaae61ff1.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
