### PR TITLE
Update requirements-linting.txt to pin isort

### DIFF
--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -9,4 +9,4 @@ flake8-docstrings==1.5.0
 flake8-logging-format==0.6.0
 flake8-pytest-style
 flake8-rst-docstrings==0.0.13
-isort
+isort==5.10.1


### PR DESCRIPTION
## Description

Looks like isort just a release 5.11.0 https://pypi.org/project/isort/#history and it broke the linting build with the following error:-

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/main.py", line 87, in sort_imports
    incorrectly_sorted = not api.check_file(file_name, config=config, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/api.py", line 345, in check_file
    **config_kwargs,
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/api.py", line 273, in check_stream
    color=config.color_output, error=config.format_error, success=config.format_success
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/format.py", line 153, in create_terminal_printer
    colorama.init(strip=False)
NameError: name 'colorama' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.15/x64/bin/isort", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/main.py", line [12](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3679273792/jobs/6223600749#step:6:13)25, in main
    for sort_attempt in attempt_iterator:
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/main.py", line 1219, in <genexpr>
    for file_name in file_names
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/main.py", line 1[14](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3679273792/jobs/6223600749#step:6:15), in sort_imports
    _print_hard_fail(config, offending_file=file_name)
  File "/opt/hostedtoolcache/Python/3.7.[15](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3679273792/jobs/6223600749#step:6:16)/x64/lib/python3.7/site-packages/isort/main.py", line 1[28](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3679273792/jobs/6223600749#step:6:29), in _print_hard_fail
    color=config.color_output, error=config.format_error, success=config.format_success
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/isort/format.py", line 153, in create_terminal_printer
    colorama.init(strip=False)
NameError: name 'colorama' is not defined
```

Pinning isort to 5.10.1 to unblock the linting gate.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
