### PR TITLE
add multilabel text example and fix correct and incorrect groups in data analysis

### DIFF
--- a/apps/dashboard/src/app/textApplications.ts
+++ b/apps/dashboard/src/app/textApplications.ts
@@ -7,6 +7,7 @@ import {
   blbooksgenre,
   blbooksgenreModelExplanationData
 } from "../model-assessment-text/__mock_data__/blbooksgenre";
+import { covid19events } from "../model-assessment-text/__mock_data__/covidevents";
 import {
   emotion,
   emotionModelExplanationData
@@ -44,6 +45,10 @@ export const textApplications: ITextApplications = <const>{
         classDimension: 3,
         dataset: blbooksgenre,
         modelExplanationData: [blbooksgenreModelExplanationData]
+      } as IModelAssessmentDataSet,
+      covid19events: {
+        classDimension: 3,
+        dataset: covid19events
       } as IModelAssessmentDataSet,
       emotion: {
         classDimension: 3,

--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -10,6 +10,23 @@ export interface ITableState {
   columns: IColumn[];
 }
 
+export function areRowPredTrueLabelsEqual(
+  row: { [key: string]: number },
+  jointDataset: JointDataset
+): boolean {
+  if (jointDataset.numLabels === 1) {
+    return row[JointDataset.PredictedYLabel] === row[JointDataset.TrueYLabel];
+  }
+  for (let i = 0; i < jointDataset.numLabels; i++) {
+    const predLabel = row[JointDataset.PredictedYLabel + i.toString()];
+    const trueLabel = row[JointDataset.TrueYLabel + i.toString()];
+    if (predLabel !== trueLabel) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function constructRows(
   cohortData: Array<{ [key: string]: number }>,
   jointDataset: JointDataset,

--- a/libs/dataset-explorer/src/lib/TableView/TableView.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableView.tsx
@@ -17,6 +17,7 @@ import {
   Text
 } from "@fluentui/react";
 import {
+  areRowPredTrueLabelsEqual,
   constructCols,
   constructRows,
   defaultModelAssessmentContext,
@@ -227,14 +228,12 @@ export class TableView extends React.Component<
     } else {
       this.props.selectedCohort.cohort.sortByGroup(
         JointDataset.IndexLabel,
-        (row) =>
-          row[JointDataset.TrueYLabel] === row[JointDataset.PredictedYLabel]
+        (row) => areRowPredTrueLabelsEqual(row, this.props.jointDataset)
       );
       // find first incorrect item
       const firstIncorrectItemIndex =
         this.props.selectedCohort.cohort.filteredData.findIndex(
-          (row) =>
-            row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
+          (row) => !areRowPredTrueLabelsEqual(row, this.props.jointDataset)
         );
       const noIncorrectItem = firstIncorrectItemIndex === -1;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

1.) Add covid19 events multilabel text example to test app (seems it was missing from the textApplication.ts somehow)
2.) Fix the correct/incorrect groupings in data analysis for multilabel text and vision scenarios

![image](https://user-images.githubusercontent.com/24683184/207173870-80e248a0-852c-42d0-93e2-43a8554c90e0.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
