### PR TITLE
Add number of cohort samples inside generateMetrics()

### DIFF
--- a/libs/core-ui/src/lib/util/StatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtils.ts
@@ -43,6 +43,8 @@ export enum MulticlassClassificationMetrics {
   Accuracy = "accuracy"
 }
 
+export const TotalCohortSamples = "samples";
+
 const generateBinaryStats: (outcomes: number[]) => ILabeledStatistic[] = (
   outcomes: number[]
 ): ILabeledStatistic[] => {
@@ -60,6 +62,11 @@ const generateBinaryStats: (outcomes: number[]) => ILabeledStatistic[] = (
   ).length;
   const total = outcomes.length;
   return [
+    {
+      key: TotalCohortSamples,
+      label: localization.Interpret.Statistics.samples,
+      stat: total
+    },
     {
       key: BinaryClassificationMetrics.Accuracy,
       label: localization.Interpret.Statistics.accuracy,
@@ -124,6 +131,11 @@ const generateRegressionStats: (
   }, 0);
   return [
     {
+      key: TotalCohortSamples,
+      label: localization.Interpret.Statistics.samples,
+      stat: count
+    },
+    {
       key: RegressionMetrics.MeanAbsoluteError,
       label: localization.Interpret.Statistics.mae,
       stat: meanAbsoluteError
@@ -158,6 +170,11 @@ const generateMulticlassStats: (outcomes: number[]) => ILabeledStatistic[] = (
   const total = outcomes.length;
   return [
     {
+      key: TotalCohortSamples,
+      label: localization.Interpret.Statistics.samples,
+      stat: total
+    },
+    {
       key: MulticlassClassificationMetrics.Accuracy,
       label: localization.Interpret.Statistics.accuracy,
       stat: correctCount / total
@@ -186,6 +203,11 @@ const generateImageStats: (
   const macroF1 = 2 * ((macroP * macroR) / (macroP + macroR)) || 0;
 
   return [
+    {
+      key: TotalCohortSamples,
+      label: localization.Interpret.Statistics.samples,
+      stat: predYs.length
+    },
     {
       key: ImageClassificationMetrics.Accuracy,
       label: localization.Interpret.Statistics.accuracy,

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1162,7 +1162,8 @@
       "recall": "Recall: {0}",
       "selectionRate": "Selection rate: {0}",
       "mae": "Mean absolute error: {0}",
-      "f1Score": "F1 score: {0}"
+      "f1Score": "F1 score: {0}",
+      "samples": "Sample size: {0}"
     },
     "ValidationErrors": {
       "_inconsistentDimensions.comment": "Raise warning if arguments passed in have different sizes, listing dimensions of both mismatching pieces.",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -10,7 +10,8 @@ import {
   ILabeledStatistic,
   ImageClassificationMetrics,
   MulticlassClassificationMetrics,
-  RegressionMetrics
+  RegressionMetrics,
+  TotalCohortSamples
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { PointOptionsObject } from "highcharts";
@@ -34,18 +35,29 @@ export function generateCohortsStatsTable(
   fairnessStats: IFairnessStats[];
   items: PointOptionsObject[];
 } {
-  // The "count" metric has to be treated separately
-  // since it's not handled like other metrics, but
-  // is part of the ErrorCohort object.
-  const items: PointOptionsObject[] = cohorts.map(
-    (errorCohort, cohortIndex) => {
-      return {
-        colorValue: 0,
-        value: errorCohort.cohortStats.totalCohort,
-        x: 0,
-        // metric index for Count column
-        y: cohortIndex
-      };
+  const items: PointOptionsObject[] = labeledStatistics.map(
+    (labeledStatistic, cohortIndex) => {
+      const cohortStats = labeledStatistic.find(
+        (cohortStats: ILabeledStatistic) =>
+          cohortStats.key === TotalCohortSamples
+      );
+      if (cohortStats) {
+        return {
+          colorValue: 0,
+          value: cohortStats.stat,
+          x: 0,
+          // metric index for Count column
+          y: cohortIndex
+        };
+      } else {
+        return {
+          colorValue: 0,
+          value: 0,
+          x: 0,
+          // metric index for Count column
+          y: cohortIndex
+        };
+      }
     }
   );
   let countMax = Number.MIN_SAFE_INTEGER;

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -49,15 +49,14 @@ export function generateCohortsStatsTable(
           // metric index for Count column
           y: cohortIndex
         };
-      } else {
-        return {
-          colorValue: 0,
-          value: 0,
-          x: 0,
-          // metric index for Count column
-          y: cohortIndex
-        };
       }
+      return {
+        colorValue: 0,
+        value: 0,
+        x: 0,
+        // metric index for Count column
+        y: cohortIndex
+      };
     }
   );
   let countMax = Number.MIN_SAFE_INTEGER;


### PR DESCRIPTION
## Description

Currently the number of samples are calculated inside `generateCohortsStatsTable()`. The number of cohort samples can be re-located in `generateMetrics()` so that all metrics are returned from  `generateMetrics()`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
