### PR TITLE
update rai-core-flask by closing WSGIServer on separate thread to fix segfault errors and get the rai-core-flask release builds working again

### DIFF
--- a/rai_core_flask/rai_core_flask/flask_helper.py
+++ b/rai_core_flask/rai_core_flask/flask_helper.py
@@ -62,6 +62,12 @@ class FlaskHelper(object):
         self._thread = threading.Thread(target=self.run, daemon=True)
         self._thread.start()
 
+        # Closes server on program exit, including freeing all sockets
+        def closeserver():
+            self.stop()
+
+        atexit.register(closeserver)
+
     @staticmethod
     def _is_local_port_available(ip, port, raise_error=True):
         """Check whether the specified local port is available.
@@ -100,15 +106,8 @@ class FlaskHelper(object):
         logger.setLevel(logging.ERROR)
         self.server = WSGIServer((ip, self.port), self.app, log=logger)
         self.app.config["server"] = self.server
-        # self.app.config["CACHE_TYPE"] = "null"
         self.server.serve_forever()
 
-        # Closes server on program exit, including freeing all sockets
-        def closeserver():
-            self.stop()
-
-        atexit.register(closeserver)
-
     def stop(self):
-        if(self.server.started):
+        if (self.server.started):
             self.server.stop()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update: instead of pinning, I found that closing WSGIServer on a separate thread seems to fix the segfaults, and doing the pinning is not necessary.  See related stackoverflow about graceful shutdown of WSGIServer:

https://stackoverflow.com/questions/18277048/gevent-pywsgi-graceful-shutdown

=====

rai-core-flask package release seems to be failing on errors in tests from some segfaults: https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3699568450

It seems the latest versions of greenlet v2.0 and gevent are less stable and fail with segfaults.  Pinning here to <2.0 and corresponding gevent version until newer packages are released that are more stable.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
