### PR TITLE
Derive fairness metrics from metric stats instead of cohort stats

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -63,15 +63,19 @@ export function generateCohortsStatsTable(
   let countMin = Number.MAX_SAFE_INTEGER;
   let countMinCohortName = "";
   let countMaxCohortName = "";
-  cohorts.forEach((errorCohort) => {
-    const cohortCount = errorCohort.cohortStats.totalCohort;
-    if (cohortCount > countMax) {
-      countMax = cohortCount;
-      countMaxCohortName = errorCohort.cohort.name;
-    }
-    if (cohortCount < countMin) {
-      countMin = cohortCount;
-      countMinCohortName = errorCohort.cohort.name;
+  cohorts.forEach((errorCohort, cohortIndex) => {
+    const labeledStat = labeledStatistics[cohortIndex].find(
+      (labeledStat) => labeledStat.key === TotalCohortSamples
+    );
+    if (labeledStat) {
+      if (labeledStat.stat > countMax) {
+        countMax = labeledStat.stat;
+        countMaxCohortName = errorCohort.cohort.name;
+      }
+      if (labeledStat.stat < countMin) {
+        countMin = labeledStat.stat;
+        countMinCohortName = errorCohort.cohort.name;
+      }
     }
   });
   const fairnessStats: IFairnessStats[] = [


### PR DESCRIPTION
## Description

It seems I missed deriving the fairness metric for number of samples from metric stats as a part of the PR https://github.com/microsoft/responsible-ai-toolbox/pull/1849. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
