### PR TITLE
fix install command for speech to text example

### DIFF
--- a/notebooks/cognitive-services-examples/speech-to-text/README.md
+++ b/notebooks/cognitive-services-examples/speech-to-text/README.md
@@ -9,7 +9,7 @@ This quickstart and example
 
 ## Prerequisites
   - [Install Anaconda](https://docs.anaconda.com/anaconda/install/)
-  - In Anaconda run: pip install azure-cognitiveservices-speech-speech to install Speech SDK
+  - In Anaconda run: conda install azure-cognitiveservices-speech-speech to install Speech SDK
       
 ## Procedures 
 * Run Speech API


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix install command for speech to text example.  Command should use conda instead of pip.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
