### PR TITLE
fix loading older versions of RAIInsights due to _FEATURE_METADATA key error

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -884,7 +884,7 @@ class RAIInsights(RAIBaseInsights):
 
         inst.__dict__['_' + _FEATURE_COLUMNS] = meta[_FEATURE_COLUMNS]
         inst.__dict__['_' + _FEATURE_RANGES] = meta[_FEATURE_RANGES]
-        if meta[_FEATURE_METADATA] is None:
+        if _FEATURE_METADATA not in meta or meta[_FEATURE_METADATA] is None:
             inst.__dict__['_' + _FEATURE_METADATA] = None
         else:
             inst.__dict__['_' + _FEATURE_METADATA] = FeatureMetadata(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

While trying to fix another bug by loading an old RAIInsights, I found this backwards compatibility issue:

![image](https://user-images.githubusercontent.com/24683184/208156423-a16b4b5d-58a2-4a94-8c14-484539ca74b0.png)

There seems to be a key error on the new _FEATURE_METADATA field.

Fixing it by checking if key exists first when loading the RAIInsights allowed me to load an older version of RAIInsights.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
