### PR TITLE
Update requirements.txt in `raiwidgets` and `responsibleai` to pin numpy upper bound

### DIFF
--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17.2
+numpy>=1.17.2,<1.24.0
 pandas>=0.25.1
 scipy>=1.4.1
 rai-core-flask==0.4.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -4,7 +4,7 @@ jsonschema
 erroranalysis>=0.3.13
 interpret-community>=0.27.0
 lightgbm>=2.0.11
-numpy>=1.17.2
+numpy>=1.17.2,<1.24.0
 numba<0.54.0
 pandas>=0.25.1
 scikit-learn>=0.22.1,<1.1 # See PR 1429 about upper bound


### PR DESCRIPTION
## Description

It looks like `numpy` has a new release https://pypi.org/project/numpy/#history which break `numba`. We are seeing the following error traces in our gates:-

```
un pytest --durations=10 --junitxml=junit/test-results.xml --cov=raiwidgets --cov-report=xml --cov-report=html
ImportError while loading conftest '/home/runner/work/responsible-ai-toolbox/responsible-ai-toolbox/raiwidgets/tests/conftest.py'.
tests/conftest.py:7: in <module>
    import shap
/usr/share/miniconda/envs/test/lib/python3.[9](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3743058848/jobs/6354773611#step:14:10)/site-packages/shap/__init__.py:[12](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/3743058848/jobs/6354773611#step:14:13): in <module>
    from ._explanation import Explanation, Cohorts
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/shap/_explanation.py:12: in <module>
    from .utils._general import OpChain
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/shap/utils/__init__.py:1: in <module>
    from ._clustering import hclust_ordering, partition_tree, partition_tree_shuffle, delta_minimization_order, hclust
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/shap/utils/_clustering.py:4: in <module>
    from numba import jit
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/numba/__init__.py:43: in <module>
    from numba.np.ufunc import (vectorize, guvectorize, threading_layer,
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/numba/np/ufunc/__init__.py:3: in <module>
    from numba.np.ufunc.decorators import Vectorize, GUVectorize, vectorize, guvectorize
/usr/share/miniconda/envs/test/lib/python3.9/site-packages/numba/np/ufunc/decorators.py:3: in <module>
    from numba.np.ufunc import _internal
E   SystemError: initialization of _internal failed without raising an exception
```

According to the github issue https://github.com/numba/numba/issues/8615 it seems we need to pin numpy below 1.24.0. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
