### PR TITLE
fix error in erroranalysis heatmap caused by max value over right side of max bin

### DIFF
--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -17,7 +17,7 @@ from erroranalysis._internal.matrix_filter import (CATEGORY1, CATEGORY2, COUNT,
                                                    INTERVAL_MAX, INTERVAL_MIN,
                                                    MATRIX, METRIC_NAME,
                                                    METRIC_VALUE, TN, TP,
-                                                   VALUES)
+                                                   VALUES, bin_data)
 from erroranalysis._internal.metrics import (get_ordered_classes,
                                              is_multi_agg_metric,
                                              metric_to_func)
@@ -344,6 +344,15 @@ class TestMatrixFilter(object):
                            matrix_features=matrix_features,
                            quantile_binning=True,
                            model_task=ModelTask.CLASSIFICATION)
+
+    def test_bin_data_max_over_left_bound(self):
+        max_val = 0.9479200000000001
+        # Test bin_data when max value is over right bound of last bin
+        df = pd.DataFrame({'a': [0.49928, 0.53104, 0.40528, 0.876,
+                                 0.912, max_val]})
+        feat1 = 'a'
+        binned_data = bin_data(df, feat1, 2)
+        assert binned_data.cat.categories[1].right == max_val
 
 
 def run_error_analyzer_on_models(X_train,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During internal testing, the erroranalysis heatmap (aka matrix filter) failed to generate on the parkinsons dataset due to error during binning when selecting the RPDE as a feature.

![image](https://user-images.githubusercontent.com/24683184/209236476-46d52b87-2ae4-4e71-beb8-9300436e4d4d.png)

During debugging, I found this can occur due to numerical precision issues where the actual max value actually appears to be slightly off to the right of the max bin value by a very small amount.  It appears this is by design and occurs in the pandas cut method. The solution is just to automatically detect this and slightly expand the right bound for the categorical intervals in pandas to the max value.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
