### PR TITLE
Add better error message if all features are dropped from dataset

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -459,9 +459,11 @@ class RAIInsights(RAIBaseInsights):
                 # Pick one row from train and test data
                 small_train_data = train[0:1]
                 small_test_data = test[0:1]
+                has_dropped_features = False
                 if feature_metadata is not None:
                     if feature_metadata.dropped_features is not None and \
                             len(feature_metadata.dropped_features) != 0:
+                        has_dropped_features = True
                         small_train_data = small_train_data.drop(
                             columns=feature_metadata.dropped_features, axis=1)
                         small_test_data = small_test_data.drop(
@@ -473,10 +475,14 @@ class RAIInsights(RAIBaseInsights):
                     columns=[target_column], axis=1)
                 if len(small_train_data.columns) == 0 or \
                         len(small_test_data.columns) == 0:
-                    raise UserConfigValidationException(
-                        'There is no feature in the dataset,'
-                        ' or all features have been dropped from the dataset'
-                    )
+                    if has_dropped_features:
+                        raise UserConfigValidationException(
+                            "All features have been dropped from the dataset"
+                        )
+                    else:
+                        raise UserConfigValidationException(
+                            "There is no feature in the dataset"
+                        )
 
                 small_train_features_before = list(small_train_data.columns)
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -474,8 +474,8 @@ class RAIInsights(RAIBaseInsights):
                 if len(small_train_data.columns) == 0 or \
                         len(small_test_data.columns) == 0:
                     raise UserConfigValidationException(
-                        'There is no feature passed to the model,'
-                        ' or all features have been dropped'
+                        'There is no feature in the dataset,'
+                        ' or all features have been dropped from the dataset'
                     )
 
                 small_train_features_before = list(small_train_data.columns)

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -477,11 +477,14 @@ class RAIInsights(RAIBaseInsights):
                         len(small_test_data.columns) == 0:
                     if has_dropped_features:
                         raise UserConfigValidationException(
-                            "All features have been dropped from the dataset"
+                            'All features have been dropped from the dataset.'
+                            ' Please do not drop all the features'
                         )
                     else:
                         raise UserConfigValidationException(
-                            "There is no feature in the dataset"
+                            'There is no feature in the dataset. Please make '
+                            'sure that your dataset contains at least '
+                            'one feature'
                         )
 
                 small_train_features_before = list(small_train_data.columns)

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -471,6 +471,12 @@ class RAIInsights(RAIBaseInsights):
                     columns=[target_column], axis=1)
                 small_test_data = small_test_data.drop(
                     columns=[target_column], axis=1)
+                if len(small_train_data.columns) == 0 or \
+                        len(small_test_data.columns) == 0:
+                    raise UserConfigValidationException(
+                        'There is no feature passed to the model,'
+                        ' or all features have been dropped'
+                    )
 
                 small_train_features_before = list(small_train_data.columns)
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -478,13 +478,13 @@ class RAIInsights(RAIBaseInsights):
                     if has_dropped_features:
                         raise UserConfigValidationException(
                             'All features have been dropped from the dataset.'
-                            ' Please do not drop all the features'
+                            ' Please do not drop all the features.'
                         )
                     else:
                         raise UserConfigValidationException(
                             'There is no feature in the dataset. Please make '
                             'sure that your dataset contains at least '
-                            'one feature'
+                            'one feature.'
                         )
 
                 small_train_features_before = list(small_train_data.columns)

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -379,39 +379,6 @@ class TestRAIInsightsValidations:
         assert 'The train labels and distinct values in ' + \
             'target (train data) do not match' in str(ucve.value)
 
-        X_train[TARGET] = y_train
-        X_test[TARGET] = y_test
-
-        with pytest.raises(UserConfigValidationException) as ucve:
-            RAIInsights(
-                model=model,
-                train=X_train,
-                test=X_test,
-                target_column=TARGET,
-                task_type='classification',
-                classes=[0, 1],
-                feature_metadata=FeatureMetadata(
-                    dropped_features=X_train_feature_names))
-        assert 'All features have been dropped from the dataset. ' + \
-            'Please do not drop all the features' in str(ucve.value)
-
-        X_train = pd.DataFrame([], columns=[])
-        X_test = pd.DataFrame([], columns=[])
-        X_train[TARGET] = y_train
-        X_test[TARGET] = y_test
-
-        with pytest.raises(UserConfigValidationException) as ucve:
-            RAIInsights(
-                model=model,
-                train=X_train,
-                test=X_test,
-                target_column=TARGET,
-                task_type='classification',
-                classes=[0, 1])
-        assert 'There is no feature in the dataset. Please make ' + \
-            'sure that your dataset contains at least one feature' in \
-            str(ucve.value)
-
         y_train[0] = 2
         X_train[TARGET] = y_train
         X_test[TARGET] = y_test
@@ -456,6 +423,45 @@ class TestRAIInsightsValidations:
 
         assert 'The train labels and distinct values in target ' + \
             '(test data) do not match' in str(ucve.value)
+
+    def test_dataset_exception(self):
+        X_train, X_test, y_train, y_test, _, _ = \
+            create_cancer_data()
+        model = create_lightgbm_classifier(X_train, y_train)
+        X_train_feature_names = X_train.columns.tolist()
+
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification',
+                classes=[0, 1],
+                feature_metadata=FeatureMetadata(
+                    dropped_features=X_train_feature_names))
+        assert 'All features have been dropped from the dataset. ' + \
+            'Please do not drop all the features.' in str(ucve.value)
+
+        X_train = pd.DataFrame([], columns=[])
+        X_test = pd.DataFrame([], columns=[])
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification',
+                classes=[0, 1])
+        assert 'There is no feature in the dataset. Please make ' + \
+            'sure that your dataset contains at least one feature.' in \
+            str(ucve.value)
 
     def test_classes_passes(self):
         X_train, X_test, y_train, y_test, _, _ = \

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -363,6 +363,7 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
+        X_train_feature_names = X_train.columns.tolist()
 
         X_train[TARGET] = y_train
         X_test[TARGET] = y_test
@@ -389,39 +390,26 @@ class TestRAIInsightsValidations:
                 target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1],
-                feature_metadata=FeatureMetadata(dropped_features=[
-                    "mean radius",
-                    "mean texture",
-                    "mean perimeter",
-                    "mean area",
-                    "mean smoothness",
-                    "mean compactness",
-                    "mean concavity",
-                    "mean concave points",
-                    "mean symmetry",
-                    "mean fractal dimension",
-                    "radius error",
-                    "texture error",
-                    "perimeter error",
-                    "area error",
-                    "smoothness error",
-                    "compactness error",
-                    "concavity error",
-                    "concave points error",
-                    "symmetry error",
-                    "fractal dimension error",
-                    "worst radius",
-                    "worst texture",
-                    "worst perimeter",
-                    "worst area",
-                    "worst smoothness",
-                    "worst compactness",
-                    "worst concavity",
-                    "worst concave points",
-                    "worst symmetry",
-                    "worst fractal dimension",
-                ]))
-        assert 'All features have been dropped from the dataset' in \
+                feature_metadata=FeatureMetadata(
+                    dropped_features=X_train_feature_names))
+        assert 'All features have been dropped from the dataset. ' + \
+            'Please do not drop all the features' in str(ucve.value)
+
+        X_train = pd.DataFrame([], columns=[])
+        X_test = pd.DataFrame([], columns=[])
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification',
+                classes=[0, 1])
+        assert 'There is no feature in the dataset. Please make ' + \
+            'sure that your dataset contains at least one feature' in \
             str(ucve.value)
 
         y_train[0] = 2
@@ -436,6 +424,19 @@ class TestRAIInsightsValidations:
                 target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
+        assert 'The train labels and distinct values in target ' + \
+            '(train data) do not match' in str(ucve.value)
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification',
+                classes=[0, 1],
+                feature_metadata=FeatureMetadata(
+                    dropped_features=X_train_feature_names))
         assert 'The train labels and distinct values in target ' + \
             '(train data) do not match' in str(ucve.value)
 

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from lightgbm import LGBMClassifier
+from responsibleai.feature_metadata import FeatureMetadata
 from tests.common_utils import (create_binary_classification_dataset,
                                 create_cancer_data, create_housing_data,
                                 create_iris_data, create_lightgbm_classifier,
@@ -376,6 +377,52 @@ class TestRAIInsightsValidations:
                 classes=[0, 1, 2])
         assert 'The train labels and distinct values in ' + \
             'target (train data) do not match' in str(ucve.value)
+
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(UserConfigValidationException) as ucve:
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification',
+                classes=[0, 1],
+                feature_metadata=FeatureMetadata(dropped_features=[
+                    "mean radius",
+                    "mean texture",
+                    "mean perimeter",
+                    "mean area",
+                    "mean smoothness",
+                    "mean compactness",
+                    "mean concavity",
+                    "mean concave points",
+                    "mean symmetry",
+                    "mean fractal dimension",
+                    "radius error",
+                    "texture error",
+                    "perimeter error",
+                    "area error",
+                    "smoothness error",
+                    "compactness error",
+                    "concavity error",
+                    "concave points error",
+                    "symmetry error",
+                    "fractal dimension error",
+                    "worst radius",
+                    "worst texture",
+                    "worst perimeter",
+                    "worst area",
+                    "worst smoothness",
+                    "worst compactness",
+                    "worst concavity",
+                    "worst concave points",
+                    "worst symmetry",
+                    "worst fractal dimension",
+                ]))
+        assert 'All features have been dropped from the dataset' in \
+            str(ucve.value)
 
         y_train[0] = 2
         X_train[TARGET] = y_train

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from lightgbm import LGBMClassifier
-from responsibleai.feature_metadata import FeatureMetadata
 from tests.common_utils import (create_binary_classification_dataset,
                                 create_cancer_data, create_housing_data,
                                 create_iris_data, create_lightgbm_classifier,
@@ -16,6 +15,7 @@ from tests.common_utils import (create_binary_classification_dataset,
 
 from responsibleai import RAIInsights
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.feature_metadata import FeatureMetadata
 
 TARGET = 'target'
 

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -363,7 +363,6 @@ class TestRAIInsightsValidations:
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
-        X_train_feature_names = X_train.columns.tolist()
 
         X_train[TARGET] = y_train
         X_test[TARGET] = y_test
@@ -391,19 +390,6 @@ class TestRAIInsightsValidations:
                 target_column=TARGET,
                 task_type='classification',
                 classes=[0, 1])
-        assert 'The train labels and distinct values in target ' + \
-            '(train data) do not match' in str(ucve.value)
-
-        with pytest.raises(UserConfigValidationException) as ucve:
-            RAIInsights(
-                model=model,
-                train=X_train,
-                test=X_test,
-                target_column=TARGET,
-                task_type='classification',
-                classes=[0, 1],
-                feature_metadata=FeatureMetadata(
-                    dropped_features=X_train_feature_names))
         assert 'The train labels and distinct values in target ' + \
             '(train data) do not match' in str(ucve.value)
 


### PR DESCRIPTION
This PR adds better error message if all features are dropped. 
(responsibleai.exceptions.UserConfigValidationException: There is no feature in the dataset, or all features have been dropped from the dataset ) 

## Description
We added dropped_features where users can choose to drop certain features from the model. In the case when user drops all features from the dataset, we need to have detailed error message "There is no feature in the dataset, or all features have been dropped from the dataset"


## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
