### PR TITLE
Add better error message if causal treatment features contain dropped features

### DIFF
--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -155,9 +155,10 @@ class CausalManager(BaseManager):
         :type random_state: int or RandomState or None
         """
         for feature in treatment_features:
-            if feature in set(self._dropped_features):
+            if self._dropped_features and \
+                    feature in set(self._dropped_features):
                 message = ("'{}' in treatment_features has been dropped "
-                            f"during training the model").format(feature)
+                           "during training the model").format(feature)
                 raise UserConfigValidationException(message)
         difference_set = set(treatment_features) - set(self._train.columns)
         if len(difference_set) > 0:

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -50,9 +50,10 @@ class CausalManager(BaseManager):
         :type task_type: str
         :param categorical_features: All categorical feature names.
         :type categorical_features: list
-        :param dropped_features: List of features that were dropped by the
-                                 the user during training of their model.
-        :type dropped_features: Optional[List[str]]
+        :param feature_metadata: Feature metadata for the train/test
+                                 dataset to identify different kinds
+                                 of features in the dataset.
+        :type feature_metadata: FeatureMetadata
         """
         self._train = train
         self._test = test

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -58,7 +58,9 @@ class CausalManager(BaseManager):
         self._target_column = target_column
         self._task_type = task_type
 
-        self._categorical_features = categorical_features or []
+        self._categorical_features = categorical_features
+        if categorical_features is None:
+            self._categorical_features = []
         self._dropped_features = dropped_features or []
 
         self._results = []

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -19,6 +19,7 @@ from responsibleai._tools.causal.causal_result import CausalResult
 from responsibleai._tools.shared.state_directory_management import \
     DirectoryManager
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.feature_metadata import FeatureMetadata
 from responsibleai.managers.base_manager import BaseManager
 from responsibleai.rai_insights.constants import ModelTask
 
@@ -33,7 +34,7 @@ class CausalManager(BaseManager):
         target_column: str,
         task_type: str,
         categorical_features: Optional[List[str]],
-        dropped_features: Optional[List[str]] = None
+        feature_metadata: Optional[FeatureMetadata] = None
     ):
         """Construct a CausalManager for generating causal analyses
             from a dataset.
@@ -61,7 +62,7 @@ class CausalManager(BaseManager):
         self._categorical_features = categorical_features
         if categorical_features is None:
             self._categorical_features = []
-        self._dropped_features = dropped_features or []
+        self._feature_metadata = feature_metadata
 
         self._results = []
 
@@ -156,8 +157,9 @@ class CausalManager(BaseManager):
         :type random_state: int or RandomState or None
         """
         for feature in treatment_features:
-            if self._dropped_features and \
-                    feature in set(self._dropped_features):
+            if self._feature_metadata and \
+                    self._feature_metadata.dropped_features and \
+                    feature in set(self._feature_metadata.dropped_features):
                 message = ("'{}' in treatment_features has been dropped "
                            "during training the model").format(feature)
                 raise UserConfigValidationException(message)
@@ -505,9 +507,6 @@ class CausalManager(BaseManager):
         inst.__dict__['_task_type'] = rai_insights.task_type
         inst.__dict__['_categorical_features'] = \
             rai_insights.categorical_features
-        inst.__dict__['_dropped_features'] = None
-        if rai_insights._feature_metadata:
-            inst.__dict__['_dropped_features'] = \
-                rai_insights._feature_metadata.dropped_features
+        inst.__dict__['_feature_metadata'] = rai_insights._feature_metadata
 
         return inst

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -58,12 +58,8 @@ class CausalManager(BaseManager):
         self._target_column = target_column
         self._task_type = task_type
 
-        self._categorical_features = categorical_features
-        if categorical_features is None:
-            self._categorical_features = []
-        self._dropped_features = dropped_features
-        if dropped_features is None:
-            self._dropped_features = []
+        self._categorical_features = categorical_features or []
+        self._dropped_features = dropped_features or []
 
         self._results = []
 

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -62,6 +62,9 @@ class CausalManager(BaseManager):
         if categorical_features is None:
             self._categorical_features = []
         self._dropped_features = dropped_features
+        if dropped_features is None:
+            self._dropped_features = []
+
         self._results = []
 
     def add(

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -503,7 +503,9 @@ class CausalManager(BaseManager):
         inst.__dict__['_task_type'] = rai_insights.task_type
         inst.__dict__['_categorical_features'] = \
             rai_insights.categorical_features
-        inst.__dict__['_dropped_features'] = \
-            rai_insights._feature_metadata.dropped_features
+        inst.__dict__['_dropped_features'] = None
+        if rai_insights._feature_metadata:
+            inst.__dict__['_dropped_features'] = \
+                rai_insights._feature_metadata.dropped_features
 
         return inst

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -507,5 +507,7 @@ class CausalManager(BaseManager):
         inst.__dict__['_task_type'] = rai_insights.task_type
         inst.__dict__['_categorical_features'] = \
             rai_insights.categorical_features
+        inst.__dict__['_dropped_features'] = \
+            rai_insights._feature_metadata.dropped_features
 
         return inst

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -233,7 +233,7 @@ class RAIInsights(RAIBaseInsights):
             dropped_features = None
         self._causal_manager = CausalManager(
             self.get_train_data(), self.get_test_data(), self.target_column,
-            self.task_type, self.categorical_features)
+            self.task_type, self.categorical_features, dropped_features)
 
         self._counterfactual_manager = CounterfactualManager(
             model=self.model, train=self.get_train_data(),

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -233,7 +233,7 @@ class RAIInsights(RAIBaseInsights):
             dropped_features = None
         self._causal_manager = CausalManager(
             self.get_train_data(), self.get_test_data(), self.target_column,
-            self.task_type, self.categorical_features, dropped_features)
+            self.task_type, self.categorical_features, self._feature_metadata)
 
         self._counterfactual_manager = CounterfactualManager(
             model=self.model, train=self.get_train_data(),

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -15,6 +15,7 @@ from tests.common_utils import (create_binary_classification_dataset,
 
 from responsibleai import RAIInsights
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai.feature_metadata import FeatureMetadata
 
 TARGET = 'target'
 
@@ -514,6 +515,28 @@ class TestCausalUserConfigValidations:
                    "do not exist in train data: \\['not_a_feature'\\]")
         with pytest.raises(UserConfigValidationException, match=message):
             rai_insights.causal.add(treatment_features=['not_a_feature'])
+
+    def test_treatment_features_having_dropped_features(self):
+        X_train, y_train, X_test, y_test, _ = \
+            create_binary_classification_dataset()
+        train_data = X_train.copy()
+        X_train_dropped = train_data.drop(['col1'], axis=1)
+        model = create_lightgbm_classifier(X_train_dropped, y_train)
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+        feature_metadata = FeatureMetadata(dropped_features=['col1'])
+        rai_insights = RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column=TARGET,
+            task_type='classification',
+            feature_metadata=feature_metadata)
+
+        message = ("'col1' in treatment_features has been dropped "
+                   "during training the model")
+        with pytest.raises(UserConfigValidationException, match=message):
+            rai_insights.causal.add(treatment_features=['col1'])
 
     def test_heterogeneity_features_list_not_having_train_features(self):
         X_train, y_train, X_test, y_test, _ = \


### PR DESCRIPTION
This PR adds better error message if causal treatment features contain dropped features:
(responsibleai.exceptions.UserConfigValidationException: '{dropped_feature_name}' in treatment_features has been dropped during training the model)

## Description

We added dropped_features where users can choose to drop certain features from the model. In the case when user adds causal component, while treatment features contain dropped features, we need to have a better error message saying "'{dropped_feature_name}' in treatment_features has been dropped during training the model"

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
