### PR TITLE
Always display tree branching decisions

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -230,7 +230,6 @@ export class TreeViewRenderer extends React.PureComponent<
           bbY: -0.5 * (bb.height + labelPaddingY) - labelYOffset,
           id: `linkLabel${d.id}`,
           style: {
-            display: d.data.nodeState.onSelectedPath ? undefined : "none",
             transform: `translate(${labelX}px, ${labelY}px)`
           },
           text: d.data.condition


### PR DESCRIPTION
For tree view,
Before:
It doesn't show the branching decisions, e.g., feature >= threshold value and feature < threshold value. This means that I'd have to click on each node manually to figure out what the tree is showing me which is not a great experience.
After:
We always display tree branching decisions no matter if the branch is the selected path or not.

## Description
Before:
![image](https://user-images.githubusercontent.com/91754176/210105602-c57e555e-19e2-4586-8758-a1e5e47b5975.png)

After:
![image](https://user-images.githubusercontent.com/91754176/210105564-6fa2286c-b184-45e4-88ab-2bc1a25e4038.png)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
