### PR TITLE
Remove warning for 'dropped_features are not in use currently.'

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -230,7 +230,6 @@ export class TreeViewRenderer extends React.PureComponent<
           bbY: -0.5 * (bb.height + labelPaddingY) - labelYOffset,
           id: `linkLabel${d.id}`,
           style: {
-            display: d.data.nodeState.onSelectedPath ? undefined : "none",
             transform: `translate(${labelX}px, ${labelY}px)`
           },
           text: d.data.condition

--- a/responsibleai/responsibleai/feature_metadata.py
+++ b/responsibleai/responsibleai/feature_metadata.py
@@ -36,8 +36,6 @@ class FeatureMetadata:
             warnings.warn('datetime_features are not in use currently.')
         if self.categorical_features is not None:
             warnings.warn('categorical_features are not in use currently.')
-        if self.dropped_features is not None:
-            warnings.warn('dropped_features are not in use currently.')
 
     def validate_feature_metadata_with_user_features(
             self, user_features: Optional[List[str]] = None):

--- a/responsibleai/tests/test_feature_metadata.py
+++ b/responsibleai/tests/test_feature_metadata.py
@@ -86,10 +86,7 @@ class TestFeatureMetadata:
         assert feature_metadata_dict == expected_feature_metadata_dict
 
     def test_feature_metadata_with_dropped_features(self):
-        with pytest.warns(
-                UserWarning,
-                match='dropped_features are not in use currently.'):
-            feature_metadata = FeatureMetadata(dropped_features=['d1', 'd2'])
+        feature_metadata = FeatureMetadata(dropped_features=['d1', 'd2'])
         assert feature_metadata.identity_feature_name is None
         assert feature_metadata.datetime_features is None
         assert feature_metadata.categorical_features is None


### PR DESCRIPTION
This PR removes warning for 'dropped_features are not in use currently.', since we already support dropped_features.

## Description
PR to remove a warning 'dropped_features are not in use currently.'

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
