### PR TITLE
Turn off fail-fast for python tests

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   ci-python:
     strategy:
+      # keep running remaining matrix jobs even if one fails
+      # to avoid having to rerun all jobs several times
+      fail-fast: false
       matrix:
         packageDirectory:
           [

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -11,6 +11,9 @@ jobs:
     env:
       node-version: 16.x
     strategy:
+      # keep running remaining matrix jobs even if one fails
+      # to avoid having to rerun all jobs several times
+      fail-fast: false
       matrix:
         packageDirectory: ["raiwidgets"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We're seeing a lot of random segmentation faults these days which cancel all runs of the same matrix. Instead, turning off fail-fast will allow the successful runs to finish and then rerun *only* the failing ones.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
