### PR TITLE
Show branching decisions on hover over on unselected tree nodes

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewPath.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewPath.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from "react";
+
+export interface ITreeViewLink {
+  d: string;
+  id: string;
+  key: string;
+  style: React.CSSProperties | undefined;
+}
+
+export interface ITreeViewPathProps {
+  link: ITreeViewLink;
+  onMouseOver: (linkId: string) => void;
+  onMouseOut: () => void;
+}
+
+export class TreeViewPath extends React.Component<ITreeViewPathProps> {
+  public render(): React.ReactNode {
+    const { link } = this.props;
+
+    return (
+      <path
+        key={link.key}
+        id={link.key}
+        d={link.d}
+        pointerEvents="all"
+        style={link.style}
+        onMouseOver={this.onMouseOver}
+        onMouseOut={this.onMouseOut}
+      />
+    );
+  }
+
+  private onMouseOver = (): void => {
+    this.props.onMouseOver(this.props.link.id);
+  };
+
+  private onMouseOut = (): void => {
+    this.props.onMouseOut();
+  };
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewPath.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewPath.tsx
@@ -23,7 +23,7 @@ export class TreeViewPath extends React.Component<ITreeViewPathProps> {
     return (
       <path
         key={link.key}
-        id={link.key}
+        id={link.id}
         d={link.d}
         pointerEvents="all"
         style={link.style}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -44,6 +44,7 @@ import { FilterProps } from "../../FilterProps";
 import { TreeLegend } from "../TreeLegend/TreeLegend";
 
 import { TreeViewNode } from "./TreeViewNode";
+import { ITreeViewLink, TreeViewPath } from "./TreeViewPath";
 import { ITreeViewRendererProps } from "./TreeViewProps";
 import {
   ITreeViewRendererStyles,
@@ -190,7 +191,7 @@ export class TreeViewRenderer extends React.PureComponent<
     // or not we highlight it.  We use the d3 linkVertical which is a curved
     // spline to draw the link.  The thickness of the links depends on the
     // ratio of data going through the path versus overall data in the tree.
-    const links = rootDescendants
+    const links: ITreeViewLink[] = rootDescendants
       .slice(1)
       .map((d: HierarchyPointNode<ITreeNode>) => {
         const thick = 1 + Math.floor(30 * (d.data.size / this.state.rootSize));
@@ -201,8 +202,10 @@ export class TreeViewRenderer extends React.PureComponent<
         const linkVerticalD = linkVertical({ source: d.parent, target: d });
         return {
           d: linkVerticalD || "",
-          id: id + getRandomId(),
+          id,
+          key: id + getRandomId(),
           style: {
+            cursor: "pointer",
             fill: theme.semanticColors.bodyBackground,
             stroke: lineColor,
             strokeWidth: thick
@@ -230,6 +233,10 @@ export class TreeViewRenderer extends React.PureComponent<
           bbY: -0.5 * (bb.height + labelPaddingY) - labelYOffset,
           id: `linkLabel${d.id}`,
           style: {
+            display:
+              d.data.nodeState.onSelectedPath || this.state.hoverPathId === d.id
+                ? undefined
+                : "none",
             transform: `translate(${labelX}px, ${labelY}px)`
           },
           text: d.data.condition
@@ -326,11 +333,11 @@ export class TreeViewRenderer extends React.PureComponent<
               <g className={containerStyles} tabIndex={0}>
                 <g>
                   {links.map((link) => (
-                    <path
-                      key={link.id}
-                      id={link.id}
-                      d={link.d}
-                      style={link.style}
+                    <TreeViewPath
+                      key={link.key}
+                      link={link}
+                      onMouseOver={this.onMouseOver}
+                      onMouseOut={this.onMouseOut}
                     />
                   ))}
                 </g>
@@ -352,7 +359,7 @@ export class TreeViewRenderer extends React.PureComponent<
                     <g
                       key={linkLabel.id}
                       style={linkLabel.style}
-                      pointerEvents="none"
+                      pointerEvents="all"
                     >
                       <rect
                         x={linkLabel.bbX}
@@ -383,6 +390,14 @@ export class TreeViewRenderer extends React.PureComponent<
       </Stack>
     );
   }
+
+  private onMouseOver = (linkId: string | undefined): void => {
+    this.setState({ hoverPathId: linkId });
+  };
+
+  private onMouseOut = (): void => {
+    this.setState({ hoverPathId: undefined });
+  };
 
   private calculateFilterProps(
     node: IErrorAnalysisTreeNode,
@@ -540,6 +555,7 @@ export class TreeViewRenderer extends React.PureComponent<
       }
 
       return {
+        hoverPathId: undefined,
         isErrorMetric,
         maxDepth,
         metric,
@@ -658,6 +674,7 @@ export class TreeViewRenderer extends React.PureComponent<
       // APPLY TO NODEDETAIL OBJECT TO UPDATE DISPLAY PANEL
       const nodeDetail = this.getNodeDetail(node);
       return {
+        hoverPathId: undefined,
         isErrorMetric: state.isErrorMetric,
         maxDepth: state.maxDepth,
         metric: state.metric,

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewState.ts
@@ -33,6 +33,7 @@ export interface ITreeViewRendererState {
   request?: AbortController;
   nodeDetail: INodeDetail;
   selectedNode: any;
+  hoverPathId: string | undefined;
   transform: any;
   treeNodes: any[];
   root?: HierarchyPointNode<ITreeNode>;
@@ -72,6 +73,7 @@ export function createInitialTreeViewState(
   errorAnalysisData: IErrorAnalysisData | undefined
 ): ITreeViewRendererState {
   return {
+    hoverPathId: undefined,
     isErrorMetric: true,
     maxDepth: errorAnalysisData?.maxDepth ?? 4,
     metric: errorAnalysisData?.metric ?? Metrics.ErrorRate,


### PR DESCRIPTION
This PR is a follow-up PR of https://github.com/microsoft/responsible-ai-toolbox/pull/1870.
In previous PR, it introduces a bug where branching decisions with long strings are overlapping.
![image](https://user-images.githubusercontent.com/91754176/210672520-fb6794ad-1090-460c-8575-6cf70777f6a2.png)

This PR is to only show branching decisions for unselected tree nodes on mouse hover over.

## Description
screenshot:
![image](https://user-images.githubusercontent.com/91754176/210672645-03c1dff6-e0e4-49ff-8670-bbee2f4ea8f1.png)

Gif:
![treeHoverOver](https://user-images.githubusercontent.com/91754176/210672886-f9f7573f-2b3f-4bea-ab4c-0f8b9566c8aa.gif)


## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
