### PR TITLE
Raise exception instead of logging warnings when model cannot be loaded

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_base_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_base_insights.py
@@ -254,25 +254,24 @@ class RAIBaseInsights(ABC):
         top_dir = Path(path)
         serializer_path = top_dir / _SERIALIZER
         model_load_err = ('ERROR-LOADING-USER-MODEL: '
-                          'There was an error loading the user model. '
-                          'Some of RAI dashboard features may not work.')
+                          'There was an error loading the user model.')
         if serializer_path.exists():
             try:
                 with open(serializer_path, 'rb') as file:
                     serializer = pickle.load(file)
                 inst.__dict__['_' + _SERIALIZER] = serializer
                 inst.__dict__[_MODEL] = serializer.load(top_dir)
-            except Exception:
+            except Exception as e:
                 warnings.warn(model_load_err)
-                inst.__dict__[_MODEL] = None
+                raise e
         else:
             inst.__dict__['_' + _SERIALIZER] = None
             try:
                 with open(top_dir / _MODEL_PKL, 'rb') as file:
                     inst.__dict__[_MODEL] = pickle.load(file)
-            except Exception:
+            except Exception as e:
                 warnings.warn(model_load_err)
-                inst.__dict__[_MODEL] = None
+                raise e
 
     @staticmethod
     def _load_managers(inst, path, manager_map):

--- a/responsibleai/tests/rai_insights/test_rai_insights_save_and_load_scenarios.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_save_and_load_scenarios.py
@@ -200,13 +200,8 @@ class TestRAIInsightsSaveAndLoadScenarios(object):
             # while loading the model.
             model_pkl_path = Path(tmpdir) / "rai_insights" / "model.pkl"
             os.remove(model_pkl_path)
-            with pytest.warns(
-                UserWarning,
-                match='ERROR-LOADING-USER-MODEL: '
-                      'There was an error loading the user model. '
-                      'Some of RAI dashboard features may not work.'):
-                without_model_rai_insights = RAIInsights.load(save_path)
-                assert without_model_rai_insights.model is None
+            with pytest.raises(Exception):
+                RAIInsights.load(save_path)
 
     @pytest.mark.parametrize('manager_type', [ManagerNames.CAUSAL,
                                               ManagerNames.ERROR_ANALYSIS,


### PR DESCRIPTION
## Description

Looks like not raising this exception causes the downstream components to fail anyways. Hence, raising the exception instead of just logging a warning.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
