### PR TITLE
Update CI-raiwidgets-pytest.yml to skip windows 3.8 tests

### DIFF
--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -22,6 +22,9 @@ jobs:
           - packageDirectory: "raiwidgets"
             operatingSystem: macos-latest
             pythonVersion: 3.9
+          - packageDirectory: "raiwidgets"
+            operatingSystem: windows-latest
+            pythonVersion: 3.8
 
     runs-on: ${{ matrix.operatingSystem }}
 


### PR DESCRIPTION
## Description

Looks like the windows test with python 3.8 are failing most of the time with segmentation faults in workflow https://github.com/microsoft/responsible-ai-toolbox/actions/workflows/CI-raiwidgets-pytest.yml. Hence, skipping these tests unless there is a solution in place.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
