### PR TITLE
skip CI-Python gates when pull requests are unrelated

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -12,7 +12,6 @@ on:
       - "raiutils/**"
       - "responsibleai/**"
 
-
 jobs:
   ci-python:
     strategy:

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - "erroranalysis/**"
+      - "rai_core_flask/**"
+      - "rai_test_utils/**"
+      - "raiutils/**"
+      - "responsibleai/**"
+
 
 jobs:
   ci-python:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The goal here is to reduce the number of gates that are run for a PR without reducing the ability to detect regressions. If we change only UI code, for example, there's no need to run Python tests (except for notebooks and raiwidgets).

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
