### PR TITLE
Exempt only files from max-lines rule that are already in violation, but not new files

### DIFF
--- a/libs/model-assessment/.eslintrc.json
+++ b/libs/model-assessment/.eslintrc.json
@@ -7,7 +7,18 @@
       "rules": {}
     },
     {
-      "files": ["*.ts", "*.tsx"],
+      "files": [
+        "ModelAssessmentDashboard.tsx",
+        "ModelAssessmentDashboardState.ts",
+        "TabsView.tsx",
+        "StatsTableUtils.ts",
+        "ModelOverview.tsx",
+        "FeatureConfigurationFlyout.tsx",
+        "ChartConfigurationFlyout.tsx",
+        "ProcessPreBuiltCohortRegression.test.ts",
+        "ProcessPreBuiltCohortBinaryClassification.test.ts",
+        "CohortList.tsx"
+      ],
       "rules": {
         "max-lines": "warn"
       }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Exempt only files from max-lines rule that are already in violation, but not new files. The global rule says "error" for violations, so by setting "warn" for specific files that are already in violation we can exempt them. Blanket exemptions should be removed.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
