### PR TITLE
Update release workflows to include forecasting npm package

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -191,6 +191,7 @@ jobs:
         package:
           [
             core-ui,
+            forecasting,
             mlchartlib,
             dataset-explorer,
             causality,

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -227,6 +227,7 @@ jobs:
         package:
           [
             core-ui,
+            forecasting,
             mlchartlib,
             dataset-explorer,
             causality,


### PR DESCRIPTION
When updating to latest npm package, I hit an issue where forecasting was not found. This package is currently not in our release workflows. This PR add forecasting npm package to release workflow

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
