### PR TITLE
fix small data erroring out on mutual info score for error analysis guidance

### DIFF
--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -472,10 +472,17 @@ class BaseAnalyzer(ABC):
             error.
         :rtype: list[float]
         """
+        # if only one row, replicate it to avoid exception
+        if input_data.shape[0] == 1:
+            input_data = np.concatenate((input_data, input_data))
+            diff = np.concatenate((diff, diff))
+        n_neighbors = min(3, input_data.shape[0] - 1)
         if self._model_task == ModelTask.CLASSIFICATION:
-            return mutual_info_classif(input_data, diff).tolist()
+            return mutual_info_classif(
+                input_data, diff, n_neighbors=n_neighbors).tolist()
         else:
-            return mutual_info_regression(input_data, diff).tolist()
+            return mutual_info_regression(
+                input_data, diff, n_neighbors=n_neighbors).tolist()
 
     def compute_root_stats(self):
         """Compute the root all data statistics.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

With a recent update in scikit-learn some tests started failing that used 3 rows of data when calculating mutual information score for the feature guidance score in the error analysis features list.

Since the dashboard is useful even when evaluating for a few instances, this PR resolved the exceptions by still calculating the score, either by replicate the row for n=1 or setting a lower number of nearest neighbors for KNN used by mutual information.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
