### PR TITLE
Fix model wrapper to identify model type, remove task type from error analysis

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -249,8 +249,7 @@ class RAIInsights(RAIBaseInsights):
             self.model, self.test, self.target_column,
             self._classes,
             self.categorical_features,
-            dropped_features,
-            task_type=self.task_type)
+            dropped_features)
 
         self._explainer_manager = ExplainerManager(
             self.model, self.get_train_data(), self.get_test_data(),


### PR DESCRIPTION
This PR fixes an issue that blocks curated image release and other RAI repo releases. 

## Description

The issue is, the model wrapper created in PR https://github.com/microsoft/responsible-ai-toolbox/pull/1824 has both predict function and predict_proba function. In error analysis, we check if the model has predict_proba function to identify if it is a classification model or regression model. In the case model is wrapped, it will always identify the model as classification model. 

The fix is, we check if the model is classification model or regression model, and wrap the model in a separate function. So regression model won't have predict_proba function after wrapping. In this case, we don't need to specifically pass task_type into error_analysis_manager. So this PR also removes task_type from error_analysis_manager

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
