### PR TITLE
improve erroranalysis error message when invalid features passed to matrix and tree methods

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -17,6 +17,7 @@ from erroranalysis._internal.constants import (DIFF, PRED_Y, ROW_INDEX, TRUE_Y,
 from erroranalysis._internal.metrics import (get_ordered_classes,
                                              is_multi_agg_metric,
                                              metric_to_func)
+from raiutils.exceptions import UserConfigValidationException
 
 BIN_THRESHOLD = MatrixParams.BIN_THRESHOLD
 CATEGORY1 = 'category1'
@@ -124,6 +125,10 @@ def compute_matrix_on_dataset(analyzer, features, dataset,
     for feature in features:
         if feature is None:
             continue
+        if feature not in analyzer.feature_names:
+            msg = 'Feature {} not found in dataset. Existing features: {}'
+            raise UserConfigValidationException(
+                msg.format(feature, analyzer.feature_names))
         indexes.append(analyzer.feature_names.index(feature))
     if is_pandas:
         input_data = input_data.to_numpy()

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -23,6 +23,7 @@ from erroranalysis._internal.constants import (DIFF, LEAF_INDEX, METHOD,
 from erroranalysis._internal.metrics import get_ordered_classes, metric_to_func
 from erroranalysis._internal.process_categoricals import process_categoricals
 from erroranalysis._internal.utils import is_spark
+from raiutils.exceptions import UserConfigValidationException
 
 # imports required for pyspark support
 try:
@@ -142,6 +143,10 @@ def compute_error_tree_on_dataset(
     is_model_analyzer = hasattr(analyzer, MODEL)
     indexes = []
     for feature in features:
+        if feature not in analyzer.feature_names:
+            msg = 'Feature {} not found in dataset. Existing features: {}'
+            raise UserConfigValidationException(
+                msg.format(feature, analyzer.feature_names))
         indexes.append(analyzer.feature_names.index(feature))
     dataset_sub_names = np.array(analyzer.feature_names)[np.array(indexes)]
     dataset_sub_names = list(dataset_sub_names)

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -29,6 +29,7 @@ from rai_test_utils.models.model_utils import (create_models_classification,
                                                create_models_regression)
 from rai_test_utils.models.sklearn import (create_kneighbors_classifier,
                                            create_titanic_pipeline)
+from raiutils.exceptions import UserConfigValidationException
 
 TOLERANCE = 1e-5
 BIN_THRESHOLD = MatrixParams.BIN_THRESHOLD
@@ -353,6 +354,17 @@ class TestMatrixFilter(object):
         feat1 = 'a'
         binned_data = bin_data(df, feat1, 2)
         assert binned_data.cat.categories[1].right == max_val
+
+    def test_matrix_filter_with_invalid_feature_names(self):
+        X_train, X_test, y_train, y_test, feature_names = create_housing_data()
+
+        # Test with invalid feature names
+        model_task = ModelTask.REGRESSION
+        err = "not found in dataset. Existing features"
+        with pytest.raises(UserConfigValidationException, match=err):
+            run_error_analyzer_on_models(X_train, y_train, X_test,
+                                         y_test, feature_names, model_task,
+                                         matrix_features=['invalid_feature'])
 
 
 def run_error_analyzer_on_models(X_train,

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -30,6 +30,7 @@ from rai_test_utils.models.model_utils import create_models_classification
 from rai_test_utils.models.sklearn import (
     create_kneighbors_classifier, create_sklearn_random_forest_regressor,
     create_titanic_pipeline)
+from raiutils.exceptions import UserConfigValidationException
 
 SIZE = 'size'
 PARENTID = 'parentId'
@@ -267,6 +268,16 @@ class TestSurrogateErrorTree(object):
                                model_task=ModelTask.CLASSIFICATION)
         assert ('Column string_index of type string is incorrectly treated '
                 'as numeric with threshold value') in str(ve.value)
+
+    def test_surrogate_error_tree_with_invalid_feature_names(self):
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+
+        model = create_kneighbors_classifier(X_train, y_train)
+        err = "not found in dataset. Existing features"
+        with pytest.raises(UserConfigValidationException, match=err):
+            run_error_analyzer(model, X_test, y_test, feature_names,
+                               AnalyzerType.MODEL,
+                               tree_features=['invalid_feature'])
 
 
 def run_error_analyzer(model, X_test, y_test, feature_names,


### PR DESCRIPTION
## Description

Invalid features could be passed to the matrix and tree methods, which could raise a cryptic error message.  This PR improves the error message by stating what the invalid features are and what valid ones can be chosen.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
