### PR TITLE
Remove `setstate()` out of render function in `RegressionDistributionChart.tsx`

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/RegressionDistributionChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/RegressionDistributionChart.tsx
@@ -131,7 +131,6 @@ export class RegressionDistributionChart extends React.Component<
     }
 
     if (this.state.targetOption === undefined) {
-      this.setState({ targetOption: targetOptions[0] });
       return React.Fragment;
     }
 


### PR DESCRIPTION
## Description

Remove `setstate()` out of render function in `RegressionDistributionChart.tsx`

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
