### PR TITLE
Handle state change in `TreatmentView.tsx`

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentView.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentView.tsx
@@ -22,6 +22,7 @@ export interface ITreatmentViewProps {
 }
 export interface ITreatmentViewState {
   selectedPolicy?: ICausalPolicy;
+  selectedIndex: number;
 }
 
 export class TreatmentView extends React.Component<
@@ -31,6 +32,7 @@ export class TreatmentView extends React.Component<
   public constructor(props: ITreatmentViewProps) {
     super(props);
     this.state = {
+      selectedIndex: 0,
       selectedPolicy: props.data?.[0]
     };
   }
@@ -71,9 +73,28 @@ export class TreatmentView extends React.Component<
     );
   }
 
+  public componentDidUpdate(prevProps: ITreatmentViewProps): void {
+    if (
+      prevProps.data &&
+      this.props.data &&
+      prevProps.data[0].local_policies &&
+      this.props.data[0].local_policies
+    ) {
+      if (
+        prevProps.data[0].local_policies.length !==
+        this.props.data[0].local_policies.length
+      ) {
+        this.setState({
+          selectedPolicy: this.props.data[this.state.selectedIndex]
+        });
+      }
+    }
+  }
+
   private onSelect = (index: number): void => {
     if (this.props.data) {
       this.setState({
+        selectedIndex: index,
         selectedPolicy: this.props.data[index]
       });
     }


### PR DESCRIPTION
## Description

Now that causal component can update if the global cohort changes, there was a bug in `TreatmentView.tsx` where new treatment policy for a new global cohort wouldn't update the Treatment chart. The fix is to check if the global cohort changed and if it did change the causal TreatView with the new data.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
