### PR TITLE
Move sort operation of out `render()` in `CausalAggregateView`

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateView.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateView.tsx
@@ -30,7 +30,6 @@ export class CausalAggregateView extends React.PureComponent<ICausalAggregateVie
 
   public render(): React.ReactNode {
     const styles = CausalAggregateStyles();
-    this.props.globalEffects.sort((d1, d2) => d2.point - d1.point);
 
     return (
       <Stack

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAnalysisView.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAnalysisView.tsx
@@ -44,7 +44,9 @@ export class CausalAnalysisView extends React.PureComponent<
   public constructor(props: ICausalAnalysisViewProps) {
     super(props);
     this.state = {
-      currentGlobalCausalEffects: this.props.data.global_effects,
+      currentGlobalCausalEffects: this.props.data.global_effects.sort(
+        (d1, d2) => d2.point - d1.point
+      ),
       currentGlobalCausalPolicy: this.props.data.policies,
       currentLocalCausalEffects: this.props.data.local_effects
     };
@@ -116,10 +118,16 @@ export class CausalAnalysisView extends React.PureComponent<
         compositeFiltersRelabeled,
         new AbortController().signal
       );
-      this.setState({ currentGlobalCausalEffects: result.global_effects });
+      this.setState({
+        currentGlobalCausalEffects: result.global_effects.sort(
+          (d1, d2) => d2.point - d1.point
+        )
+      });
     } else {
       this.setState({
-        currentGlobalCausalEffects: this.props.data.global_effects
+        currentGlobalCausalEffects: this.props.data.global_effects.sort(
+          (d1, d2) => d2.point - d1.point
+        )
       });
     }
   };


### PR DESCRIPTION
## Description

@xuke444 mentioned that data operations such as sorting should not be done in render. Hence, moving the sort of the causal aggregate insights into parent component.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
