### PR TITLE
Update workflow ymls to pin pip-tools to below 6.12.2

### DIFF
--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools
+          pip install --upgrade "pip-tools<6.12.2"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools
+          pip install --upgrade "pip-tools<6.12.2"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -11,7 +11,7 @@ on:
       - "rai_test_utils/**"
       - "raiutils/**"
       - "responsibleai/**"
-      - ".github/workflows"
+      - ".github/workflows/CI-python.yml"
 
 jobs:
   ci-python:

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -11,6 +11,7 @@ on:
       - "rai_test_utils/**"
       - "raiutils/**"
       - "responsibleai/**"
+      - ".github/workflows"
 
 jobs:
   ci-python:

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools<6.12.2
+          pip install --upgrade "pip-tools<6.12.2"
 
       - name: Pip compile
         run: |

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools
+          pip install --upgrade pip-tools<6.12.2
 
       - name: Pip compile
         run: |

--- a/.github/workflows/CI-rai_core_flask-pytest.yml
+++ b/.github/workflows/CI-rai_core_flask-pytest.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - "rai_core_flask/**"
+      - ".github/workflows/CI-rai_core_flask-pytest.yml"
 
 jobs:
   ci-python:
@@ -44,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools
+          pip install --upgrade "pip-tools<6.12.2"
 
       - name: Pip compile
         run: |

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade pip-tools
+          pip install --upgrade "pip-tools<6.12.2"
 
       - name: Install dependencies
         shell: bash -l {0}


### PR DESCRIPTION

## Description

Looks like pip-tools (6.12.2) had a release today which broke our builds. Looks like it maybe because of the issue https://github.com/jazzband/pip-tools/issues/1804 where you can provide some special paths for requirements and cannot merge two sets of requirements. This PR upper bounds pip-tools in all the yml workflow files where we install pip-tools. 

Also, looks like a change in CI-python.yml won't run the python tests due to directory policy. Also, adding another rule when the python tests should run.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
