### PR TITLE
Pin datasets version in nlp-feature-extractors to resolve the huggingface-hub dependency conflict

### DIFF
--- a/nlp_feature_extractors/requirements.txt
+++ b/nlp_feature_extractors/requirements.txt
@@ -1,4 +1,4 @@
-datasets
+datasets>=2.9.0
 negspacy>=1.0.0
 numpy>=1.17.2
 sentencepiece


### PR DESCRIPTION
This PR is to pin datasets>=2.9.0
https://pypi.org/project/datasets/#history

## Description

We are seeing dependency vulnerability on responsible text image due to protobuf version pin in nlp-feature-extractors 0.0.3. And we want to upgrade nlp-feature-extractors to latest version, so that it doesn't have protobuf as dependency. But there is a dependency conflict for huggingface-hub where transformers requires huggingface-hub<1.0,>=0.11.0, and datasets in nlp-features-extractors requires huggingface-hub<0.1.0. Upgrading datasets to v2.9.0 can fix the dependency conflicts.

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
