### PR TITLE
Dataset explorer: Propagate number of bins to SDK backend API

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
@@ -46,7 +46,11 @@ export async function getBarOrBoxChartConfig(
     jointDataset.metaDict[yAxisProperty].isCategorical ||
     jointDataset.metaDict[yAxisProperty]?.treatAsCategorical;
 
-  let numberOfBins = jointDataset?.binDict?.Index.length ?? 5;
+  let numberOfBins = 5;
+  if (jointDataset?.binDict?.Index) {
+    numberOfBins = jointDataset.binDict.Index.length;
+  }
+
   if (treatYAsCategorical) {
     const treatXAsCategorical =
       (jointDataset.metaDict[xAxisProperty].isCategorical ||

--- a/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
@@ -46,11 +46,7 @@ export async function getBarOrBoxChartConfig(
     jointDataset.metaDict[yAxisProperty].isCategorical ||
     jointDataset.metaDict[yAxisProperty]?.treatAsCategorical;
 
-  let numberOfBins = 5;
-  if (jointDataset?.binDict?.Index) {
-    numberOfBins = jointDataset.binDict.Index.length;
-  }
-
+  let numberOfBins = jointDataset?.binDict?.Index.length ?? 5;
   if (treatYAsCategorical) {
     const treatXAsCategorical =
       (jointDataset.metaDict[xAxisProperty].isCategorical ||

--- a/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/LargeDataView/getBarOrBoxChartConfig.ts
@@ -46,6 +46,11 @@ export async function getBarOrBoxChartConfig(
     jointDataset.metaDict[yAxisProperty].isCategorical ||
     jointDataset.metaDict[yAxisProperty]?.treatAsCategorical;
 
+  let numberOfBins = 5;
+  if (jointDataset?.binDict?.Index) {
+    numberOfBins = jointDataset.binDict.Index.length;
+  }
+
   if (treatYAsCategorical) {
     const treatXAsCategorical =
       (jointDataset.metaDict[xAxisProperty].isCategorical ||
@@ -59,7 +64,7 @@ export async function getBarOrBoxChartConfig(
       treatXAsCategorical,
       jointDataset.metaDict[yAxisProperty].label,
       treatYAsCategorical,
-      5,
+      numberOfBins,
       new AbortController().signal
     );
     const datasetBarConfigOverride = {
@@ -78,7 +83,7 @@ export async function getBarOrBoxChartConfig(
     compositeFiltersRelabeled,
     jointDataset.metaDict[xAxisProperty].label,
     jointDataset.metaDict[yAxisProperty].label,
-    5,
+    numberOfBins,
     new AbortController().signal
   );
 


### PR DESCRIPTION
## Description

Previously we sent a fixed number of bins (5) to SDK to compute bar/box plots. Now sending the configurable value from UI.
## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
