### PR TITLE
Fix bubble chart render issue due to exception in `SidePanel`

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
@@ -13,6 +13,8 @@ import {
   JointDataset,
   Cohort,
   ChartTypes,
+  defaultModelAssessmentContext,
+  ModelAssessmentContext,
   IGenericChartProps,
   InteractiveLegend,
   FluentUIStyles,
@@ -50,6 +52,10 @@ export class SidePanel extends React.Component<
   ISidePanelProps,
   ISidePanelState
 > {
+  public static contextType = ModelAssessmentContext;
+  public context: React.ContextType<typeof ModelAssessmentContext> =
+    defaultModelAssessmentContext;
+
   private readonly chartOptions: IChoiceGroupOption[] = [
     {
       key: ChartTypes.Histogram,


### PR DESCRIPTION
## Description

It seems we are missing initialization of context with `SidePanel` within DatasetExplorer. The causes an exception when trying to access the `jointDataset` within the context. The fix is to add the initialization of context within the `SidePanel` class.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
