### PR TITLE
Remove unnecessary props from DatasetExplorer `SidePanel` class

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/DatasetExplorerTab.tsx
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/DatasetExplorerTab.tsx
@@ -243,13 +243,8 @@ export class DatasetExplorerTab extends React.Component<
             <Stack.Item className={classNames.sidePanel}>
               <SidePanel
                 chartProps={this.state.chartProps}
-                cohorts={this.context.errorCohorts.map(
-                  (errorCohort) => errorCohort.cohort
-                )}
-                jointDataset={this.context.jointDataset}
                 selectedCohortIndex={this.state.selectedCohortIndex}
                 onChartPropChange={this.onChartPropsChange}
-                dataset={this.context.dataset}
               />
             </Stack.Item>
           </Stack>

--- a/libs/dataset-explorer/src/lib/ChartView/LargeDataView/LargeDatasetExplorerTab.tsx
+++ b/libs/dataset-explorer/src/lib/ChartView/LargeDataView/LargeDatasetExplorerTab.tsx
@@ -162,13 +162,8 @@ export class LargeDatasetExplorerTab extends React.Component<
             <Stack.Item className={classNames.sidePanel}>
               <SidePanel
                 chartProps={this.state.chartProps}
-                cohorts={this.context.errorCohorts.map(
-                  (errorCohort) => errorCohort.cohort
-                )}
-                jointDataset={this.context.jointDataset}
                 selectedCohortIndex={this.state.selectedCohortIndex}
                 onChartPropChange={this.onChartPropsChange}
-                dataset={this.context.dataset}
                 disabled={this.state.isBubbleChartDataLoading}
                 isBubbleChartRendered={this.state.isBubbleChartRendered}
                 setIsRevertButtonClicked={this.setIsRevertButtonClicked}


### PR DESCRIPTION
## Description

Looks like `cohorts`, `jointDataset` and `dataset` props can be inferred from `this.context`. Hence, removing these from being passed around a props for `SidePanel`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
