### PR TITLE
Fix focus indicator is not visible on all four sides for “Tree map” and "heat map" tabs.

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -17,12 +17,19 @@ export interface IErrorAnalysisStyles {
   errorAnalysisWrapper: IStyle;
   separator: IStyle;
   tabs: IStyle;
+  pivotLabelWrapper: IStyle;
 }
 
 export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles> =
   () => {
     const theme = getTheme();
     return mergeStyleSets<IErrorAnalysisStyles>({
+      pivotLabelWrapper: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "start",
+        padding: "0px 15px 15px"
+      },
       cohortInfo: {
         overflow: "auto",
         width: "40%",
@@ -37,7 +44,6 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
       errorAnalysisView: flexLgDown,
       errorAnalysisWrapper: {
         marginTop: "10px",
-        paddingLeft: "15px",
         selectors: {
           "@media screen and (max-width: 479px)": {
             flexWrap: "wrap"
@@ -45,7 +51,12 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
         }
       },
       featureList: {
-        padding: "16px 0 10px 0"
+        padding: "16px 0 10px 0",
+        selectors: {
+          "@media screen and (max-width: 479px)": {
+            paddingLeft: "15px"
+          }
+        }
       },
       separator: hideLgDown,
       tabs: {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -23,12 +23,6 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
   () => {
     const theme = getTheme();
     return mergeStyleSets<IErrorAnalysisStyles>({
-      pivotLabelWrapper: {
-        display: "flex",
-        flexDirection: "row",
-        justifyContent: "start",
-        padding: "0px 15px 15px"
-      },
       cohortInfo: {
         overflow: "auto",
         width: "40%",
@@ -56,6 +50,12 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
             paddingLeft: "15px"
           }
         }
+      },
+      pivotLabelWrapper: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "start",
+        padding: "0px 15px 15px"
       },
       separator: hideLgDown
     });

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysis.styles.ts
@@ -16,7 +16,6 @@ export interface IErrorAnalysisStyles {
   featureList: IStyle;
   errorAnalysisWrapper: IStyle;
   separator: IStyle;
-  tabs: IStyle;
   pivotLabelWrapper: IStyle;
 }
 
@@ -58,17 +57,6 @@ export const errorAnalysisStyles: () => IProcessedStyleSet<IErrorAnalysisStyles>
           }
         }
       },
-      separator: hideLgDown,
-      tabs: {
-        selectors: {
-          "[role='tablist'].ms-Pivot": {
-            display: "flex",
-            flexWrap: "wrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap"
-          }
-        }
-      }
+      separator: hideLgDown
     });
   };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisViewTab.tsx
@@ -79,8 +79,7 @@ export class ErrorAnalysisViewTab extends React.Component<
               <Pivot
                 onLinkClick={this.handleTabClick}
                 selectedKey={this.props.selectedKey}
-                overflowBehavior="menu"
-                className={classNames.tabs}
+                styles={{ root: classNames.pivotLabelWrapper }}
               >
                 <PivotItem
                   itemKey={ErrorAnalysisOptions.TreeMap}


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
This issue is regressed due to some other changes.

## Description

In normal screen
![image](https://user-images.githubusercontent.com/33799331/217116293-8af81b1c-abb5-477e-b66e-1fbe830a1379.png)

In 320*256 screen
![image](https://user-images.githubusercontent.com/33799331/217116365-ec752239-63dc-427b-a03c-aa31587d50ae.png)


<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
