### PR TITLE
fix mean absolute error metric calculation in model overview panel

### DIFF
--- a/libs/core-ui/src/lib/util/StatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtils.ts
@@ -113,9 +113,10 @@ const generateRegressionStats: (
   errors: number[]
 ): ILabeledStatistic[] => {
   const count = trueYs.length;
-  const meanAbsoluteError = errors.reduce((prev, curr) => {
-    return Math.abs(prev) + Math.abs(curr);
-  }, 0);
+  const meanAbsoluteError =
+    errors.reduce((prev, curr) => {
+      return Math.abs(prev) + Math.abs(curr);
+    }, 0) / count;
   const residualSumOfSquares = errors.reduce((prev, curr) => {
     return prev + curr * curr;
   }, 0);

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesDecisionMaking.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesDecisionMaking.ts
@@ -44,7 +44,7 @@ export const DiabetesDecisionMaking = {
     initialCohorts: [
       {
         metrics: {
-          meanAbsoluteError: "3 859.27",
+          meanAbsoluteError: "43.363",
           meanPrediction: "154.102",
           meanSquaredError: "2 981.101"
         },
@@ -53,7 +53,7 @@ export const DiabetesDecisionMaking = {
       },
       {
         metrics: {
-          meanAbsoluteError: "1 961.23",
+          meanAbsoluteError: "51.611",
           meanPrediction: "196.629",
           meanSquaredError: "4 014.697"
         },
@@ -62,7 +62,7 @@ export const DiabetesDecisionMaking = {
       },
       {
         metrics: {
-          meanAbsoluteError: "983.52",
+          meanAbsoluteError: "49.176",
           meanPrediction: "142.495",
           meanSquaredError: "3 829.201"
         },
@@ -71,7 +71,7 @@ export const DiabetesDecisionMaking = {
       },
       {
         metrics: {
-          meanAbsoluteError: "2 084.21",
+          meanAbsoluteError: "40.867",
           meanPrediction: "115.086",
           meanSquaredError: "2 416.75"
         },
@@ -80,7 +80,7 @@ export const DiabetesDecisionMaking = {
       },
       {
         metrics: {
-          meanAbsoluteError: "3 744.86",
+          meanAbsoluteError: "43.044",
           meanPrediction: "155.306",
           meanSquaredError: "2 972.126"
         },
@@ -89,7 +89,7 @@ export const DiabetesDecisionMaking = {
       },
       {
         metrics: {
-          meanAbsoluteError: "3 597.63",
+          meanAbsoluteError: "57.105",
           meanPrediction: "157.301",
           meanSquaredError: "4 154.723"
         },
@@ -99,7 +99,7 @@ export const DiabetesDecisionMaking = {
     ],
     newCohort: {
       metrics: {
-        meanAbsoluteError: "3 858.02",
+        meanAbsoluteError: "43.841",
         meanPrediction: "153.958",
         meanSquaredError: "3 014.96"
       },

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesRegressionModelDebugging.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesRegressionModelDebugging.ts
@@ -47,7 +47,7 @@ export const DiabetesRegressionModelDebugging = {
     initialCohorts: [
       {
         metrics: {
-          meanAbsoluteError: "3 859.27",
+          meanAbsoluteError: "43.363",
           meanPrediction: "154.102",
           meanSquaredError: "2 981.101"
         },
@@ -57,7 +57,7 @@ export const DiabetesRegressionModelDebugging = {
     ],
     newCohort: {
       metrics: {
-        meanAbsoluteError: "3 858.02",
+        meanAbsoluteError: "43.841",
         meanPrediction: "153.958",
         meanSquaredError: "3 014.96"
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During customer session, I noticed the mean absolute error metric looked incorrect for their data.  Indeed, it seems we were not taking the "mean" of the data but just summing the error.  To fix the issue, I divided by the count to get the correct metric.

Before:
![image](https://user-images.githubusercontent.com/24683184/217339529-b06f6c82-9987-417c-b218-ae9e6a11f6f0.png)

After:
![image](https://user-images.githubusercontent.com/24683184/217339560-8aed884f-b567-429a-b5dd-0054a6859a37.png)

Note how mean absolute error and mean squared error look a lot more similar now.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
