### PR TITLE
Add `SystemErrorException` class to `raiutils`

### DIFF
--- a/raiutils/raiutils/exceptions.py
+++ b/raiutils/raiutils/exceptions.py
@@ -2,6 +2,16 @@
 # Licensed under the MIT License.
 
 
+class SystemErrorException(Exception):
+    """Exception raised when there is an system error condition
+    which is outside the control of the user.
+
+    :param exception_message: A message describing the error.
+    :type exception_message: str
+    """
+    _error_code = "System Error"
+
+
 class UserErrorException(Exception):
     """Exception raised when the user has made an error like
     configuration error.

--- a/raiutils/tests/test_exceptions.py
+++ b/raiutils/tests/test_exceptions.py
@@ -1,7 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-from raiutils.exceptions import (UserConfigValidationException,
+from raiutils.exceptions import (SystemErrorException,
+                                 UserConfigValidationException,
                                  UserErrorException)
 
 TEST_MESSAGE = "Test message"
@@ -24,3 +25,9 @@ class TestExceptions:
         self._verify_exception_hierarchy(
             uee, UserErrorException(),
             'User Error', TEST_MESSAGE)
+
+    def test_system_exceptions(self):
+        se = SystemErrorException(TEST_MESSAGE)
+        self._verify_exception_hierarchy(
+            se, SystemErrorException(),
+            'System Error', TEST_MESSAGE)


### PR DESCRIPTION
## Description

Add `SystemErrorException` class to `raiutils` as it will serve as the base class for System Errors.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
