### PR TITLE
[Large counterfactuals & explanations] Do not call local counterfactuals/explanations on unselecting the point

### DIFF
--- a/libs/counterfactuals/src/lib/CounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChart.tsx
@@ -50,7 +50,7 @@ export interface ICounterfactualChartProps {
   ) => void;
   telemetryHook?: (message: ITelemetryEvent) => void;
   togglePanel: () => void;
-  toggleSelectionOfPoint: (index?: number) => void;
+  toggleSelectionOfPoint: (index?: number) => number[];
 }
 
 export interface ICounterfactualChartState {

--- a/libs/counterfactuals/src/lib/CounterfactualChartLegend.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChartLegend.tsx
@@ -49,7 +49,7 @@ export interface ICounterfactualChartLegendProps {
   telemetryHook?: (message: ITelemetryEvent) => void;
   toggleCustomActivation: (index: number) => void;
   togglePanel: () => void;
-  toggleSelectionOfPoint: (index?: number) => void;
+  toggleSelectionOfPoint: (index?: number) => number[];
   setIsRevertButtonClicked: (status: boolean) => void;
 }
 
@@ -154,10 +154,11 @@ export class CounterfactualChartLegend extends React.PureComponent<ICounterfactu
     if (typeof item?.key === "string") {
       const index = Number.parseInt(item.key);
       this.props.setTemporaryPointToCopyOfDatasetPoint(index, item.data.index);
-      this.props.toggleSelectionOfPoint(index);
+      const newSelections = this.props.toggleSelectionOfPoint(index);
       if (
         ifEnableLargeData(this.context.dataset) &&
-        this.props.setCounterfactualData
+        this.props.setCounterfactualData &&
+        newSelections.length > 0
       ) {
         this.props.setCounterfactualData(item.data.index);
       }

--- a/libs/counterfactuals/src/lib/CounterfactualChartWithLegend.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualChartWithLegend.tsx
@@ -155,9 +155,9 @@ export class CounterfactualChartWithLegend extends React.PureComponent<
     );
   }
 
-  private toggleSelectionOfPoint = (index?: number): void => {
+  private toggleSelectionOfPoint = (index?: number): number[] => {
     if (index === undefined) {
-      return;
+      return [];
     }
     const indexOf = this.props.selectedPointsIndexes.indexOf(index);
     let newSelections = [...this.props.selectedPointsIndexes];
@@ -181,6 +181,7 @@ export class CounterfactualChartWithLegend extends React.PureComponent<
       pointIsActive
     });
     this.props.onSelectedPointsIndexesUpdated(newSelections);
+    return newSelections;
   };
 
   private toggleCustomActivation = (index: number): void => {

--- a/libs/counterfactuals/src/lib/largeCounterfactualsView/LargeCounterfactualChart.tsx
+++ b/libs/counterfactuals/src/lib/largeCounterfactualsView/LargeCounterfactualChart.tsx
@@ -359,8 +359,10 @@ export class LargeCounterfactualChart extends React.PureComponent<
     const absoluteIndex = data.customData[JointDataset.AbsoluteIndexLabel];
     index &&
       this.props.setTemporaryPointToCopyOfDatasetPoint(index, absoluteIndex);
-    this.props.setCounterfactualData(absoluteIndex);
-    this.props.toggleSelectionOfPoint(index);
+    const newSelections = this.props.toggleSelectionOfPoint(index);
+    if (newSelections.length > 0) {
+      this.props.setCounterfactualData(absoluteIndex);
+    }
     this.props.telemetryHook?.({
       level: TelemetryLevels.ButtonClick,
       type: TelemetryEventName.CounterfactualNewDatapointSelectedFromChart

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LargeIndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LargeIndividualFeatureImportanceView.tsx
@@ -249,7 +249,7 @@ export class LargeIndividualFeatureImportanceView extends React.Component<
     );
   };
 
-  private toggleSelectionOfPoint = (index?: number): number[] | undefined => {
+  private toggleSelectionOfPoint = (index?: number): number[] => {
     const newSelections = getNewSelections(
       this.state.selectedPointsIndexes,
       index
@@ -259,7 +259,7 @@ export class LargeIndividualFeatureImportanceView extends React.Component<
         selectedPointsIndexes: newSelections
       });
     }
-    return newSelections;
+    return newSelections ?? [];
   };
 
   private setLocalExplanationsData = async (

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LargeIndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LargeIndividualFeatureImportanceView.tsx
@@ -249,7 +249,7 @@ export class LargeIndividualFeatureImportanceView extends React.Component<
     );
   };
 
-  private toggleSelectionOfPoint = (index?: number): void => {
+  private toggleSelectionOfPoint = (index?: number): number[] | undefined => {
     const newSelections = getNewSelections(
       this.state.selectedPointsIndexes,
       index
@@ -259,6 +259,7 @@ export class LargeIndividualFeatureImportanceView extends React.Component<
         selectedPointsIndexes: newSelections
       });
     }
+    return newSelections;
   };
 
   private setLocalExplanationsData = async (

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/largeIndividualFeatureImportanceViewUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/largeIndividualFeatureImportanceViewUtils.ts
@@ -131,15 +131,15 @@ export function getNewSelections(
 export async function selectPointFromChartLargeData(
   data: IScatterPoint,
   setLocalExplanationsData: (absoluteIndex: number) => Promise<void>,
-  toggleSelectionOfPoint: (index?: number) => void,
+  toggleSelectionOfPoint: (index?: number) => number[] | undefined,
   telemetryHook?: ((message: ITelemetryEvent) => void) | undefined
 ): Promise<void> {
   const index = data.customData[JointDataset.IndexLabel];
   const absoluteIndex = data.customData[JointDataset.AbsoluteIndexLabel];
-  if (absoluteIndex) {
+  const newSelections = toggleSelectionOfPoint(index);
+  if (absoluteIndex && newSelections && newSelections?.length > 0) {
     setLocalExplanationsData(absoluteIndex);
   }
-  toggleSelectionOfPoint(index);
   telemetryHook?.({
     level: TelemetryLevels.ButtonClick,
     type: TelemetryEventName.FeatureImportancesNewDatapointSelectedFromChart

--- a/rai_test_utils/rai_test_utils/version.py
+++ b/rai_test_utils/rai_test_utils/version.py
@@ -3,6 +3,6 @@
 
 name = 'rai_test_utils'
 _major = '0'
-_minor = '0'
+_minor = '1'
 _patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
Signed-off-by: vinutha karanth <vinutha.karanth@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Do not call local counterfactuals on unselecting the point

## Description
Fix is to call local counterfactuals/explanations api only when there is selection index.

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
