### PR TITLE
add missing true and predicted labels to axis config for dataset explorer in multilabel text and vision scenarios

### DIFF
--- a/libs/core-ui/src/lib/components/AxisConfigChoiceGroup.tsx
+++ b/libs/core-ui/src/lib/components/AxisConfigChoiceGroup.tsx
@@ -50,7 +50,11 @@ function getLeftItems(removeCount?: boolean): string[] {
 export class AxisConfigChoiceGroup extends React.PureComponent<IAxisConfigChoiceGroupProps> {
   private readonly leftItems = getLeftItems(this.props.removeCount).reduce(
     (
-      previousValue: Array<{ key: string; title: string; ariaLabel?: string }>,
+      previousValue: Array<{
+        key: string;
+        title: string;
+        ariaLabel?: string;
+      }>,
       key
     ) => {
       const metaVal = this.props.jointDataset.metaDict[key];
@@ -83,6 +87,26 @@ export class AxisConfigChoiceGroup extends React.PureComponent<IAxisConfigChoice
         previousValue.push({
           key,
           title: localization.Interpret.Columns.predictedProbabilities
+        });
+        return previousValue;
+      }
+      if (
+        key === JointDataset.PredictedYLabel &&
+        this.props.jointDataset.numLabels > 1
+      ) {
+        previousValue.push({
+          key,
+          title: localization.Interpret.Columns.predictedLabels
+        });
+        return previousValue;
+      }
+      if (
+        key === JointDataset.TrueYLabel &&
+        this.props.jointDataset.numLabels > 1
+      ) {
+        previousValue.push({
+          key,
+          title: localization.Interpret.Columns.trueLabels
         });
         return previousValue;
       }
@@ -155,7 +179,10 @@ export class AxisConfigChoiceGroup extends React.PureComponent<IAxisConfigChoice
     }
     if (
       property === JointDataset.DataLabelRoot ||
-      property === JointDataset.ProbabilityYRoot
+      property === JointDataset.ProbabilityYRoot ||
+      (this.props.jointDataset.numLabels > 1 &&
+        (property === JointDataset.TrueYLabel ||
+          property === JointDataset.PredictedYLabel))
     ) {
       property += "0";
     }

--- a/libs/core-ui/src/lib/components/AxisConfigDialog.tsx
+++ b/libs/core-ui/src/lib/components/AxisConfigDialog.tsx
@@ -12,7 +12,6 @@ import {
   DefaultButton
 } from "@fluentui/react";
 import { localization } from "@responsible-ai/localization";
-import _ from "lodash";
 import React from "react";
 
 import { cohortKey } from "../cohortKey";
@@ -28,34 +27,12 @@ import { TelemetryEventName } from "../util/TelemetryEventName";
 
 import { AxisConfigBinOptions } from "./AxisConfigBinOptions";
 import { AxisConfigChoiceGroup } from "./AxisConfigChoiceGroup";
+import { IAxisConfigDialogProps } from "./AxisConfigDialogProps";
 import {
-  extractSelectionKey,
-  getBinCountForProperty,
-  getClassArray,
-  getDataArray
-} from "./AxisConfigDialogUtils";
-
-export interface IAxisConfigDialogProps {
-  orderedGroupTitles: ColumnCategories[];
-  selectedColumn: ISelectorConfig;
-  canBin: boolean;
-  mustBin: boolean;
-  canDither: boolean;
-  allowTreatAsCategorical: boolean;
-  allowLogarithmicScaling?: boolean;
-  hideDroppedFeatures?: boolean;
-  removeCount?: boolean;
-  onAccept: (newConfig: ISelectorConfig) => void;
-  onCancel: () => void;
-}
-
-export interface IAxisConfigDialogState {
-  selectedColumn: ISelectorConfig;
-  binCount?: number;
-  selectedFilterGroup?: string;
-  dataArray: IComboBoxOption[];
-  classArray: IComboBoxOption[];
-}
+  buildAxisConfigDialogState,
+  IAxisConfigDialogState
+} from "./AxisConfigDialogState";
+import { getBinCountForProperty } from "./AxisConfigDialogUtils";
 
 export class AxisConfigDialog extends React.PureComponent<
   IAxisConfigDialogProps,
@@ -73,27 +50,14 @@ export class AxisConfigDialog extends React.PureComponent<
     const droppedFeatureSet = new Set(
       this.context.jointDataset.datasetMetaData?.featureMetaData?.dropped_features
     );
-    this.setState({
-      binCount: getBinCountForProperty(
-        this.context.jointDataset.metaDict[this.props.selectedColumn.property],
-        this.props.canBin,
-        AxisConfigDialog.DEFAULT_BIN_COUNT
-      ),
-      classArray: getClassArray(
-        this.context.jointDataset.predictionClassCount,
-        this.context.jointDataset.metaDict
-      ),
-      dataArray: getDataArray(
-        droppedFeatureSet,
-        this.context.jointDataset.datasetFeatureCount,
-        this.context.jointDataset.metaDict,
-        this.props.hideDroppedFeatures
-      ),
-      selectedColumn: _.cloneDeep(this.props.selectedColumn),
-      selectedFilterGroup: extractSelectionKey(
-        this.props.selectedColumn.property
+    this.setState(
+      buildAxisConfigDialogState(
+        this.context.jointDataset,
+        this.props,
+        AxisConfigDialog.DEFAULT_BIN_COUNT,
+        droppedFeatureSet
       )
-    });
+    );
   }
 
   public render(): React.ReactNode {
@@ -106,7 +70,13 @@ export class AxisConfigDialog extends React.PureComponent<
     const isProbabilityColumn = this.state.selectedColumn.property.includes(
       JointDataset.ProbabilityYRoot
     );
-
+    const isMultilabel = this.context.jointDataset.numLabels > 1;
+    const isMultilablePredictedYColumn =
+      isMultilabel &&
+      this.state.selectedColumn.property.includes(JointDataset.PredictedYLabel);
+    const isMultilableTrueYColumn =
+      isMultilabel &&
+      this.state.selectedColumn.property.includes(JointDataset.TrueYLabel);
     return (
       <Panel
         id="AxisConfigPanel"
@@ -146,24 +116,19 @@ export class AxisConfigDialog extends React.PureComponent<
           {this.state.selectedColumn.property !== cohortKey &&
             this.state.selectedColumn.property !== ColumnCategories.None && (
               <Stack>
-                {isDataColumn && (
-                  <ComboBox
-                    options={this.state.dataArray}
-                    onChange={this.setSelectedProperty}
-                    label={
-                      localization.Interpret.AxisConfigDialog.selectFeature
-                    }
-                    selectedKey={this.state.selectedColumn.property}
-                  />
-                )}
-                {isProbabilityColumn && (
-                  <ComboBox
-                    options={this.state.classArray}
-                    onChange={this.setSelectedProperty}
-                    label={localization.Interpret.AxisConfigDialog.selectClass}
-                    selectedKey={this.state.selectedColumn.property}
-                  />
-                )}
+                {isDataColumn &&
+                  this.renderComboBox(
+                    this.state.dataArray,
+                    localization.Interpret.AxisConfigDialog.selectFeature
+                  )}
+                {isProbabilityColumn &&
+                  this.renderClassComboBox(this.state.classArray)}
+                {isMultilablePredictedYColumn &&
+                  this.renderClassComboBox(
+                    this.state.multilabelPredictedYArray
+                  )}
+                {isMultilableTrueYColumn &&
+                  this.renderClassComboBox(this.state.multilabelTrueYArray)}
                 <AxisConfigBinOptions
                   {...this.props}
                   jointDataset={this.context.jointDataset}
@@ -194,6 +159,27 @@ export class AxisConfigDialog extends React.PureComponent<
           {localization.Interpret.CohortEditor.cancel}
         </DefaultButton>
       </Stack>
+    );
+  };
+
+  private renderComboBox = (
+    options: IComboBoxOption[],
+    label: string
+  ): JSX.Element => {
+    return (
+      <ComboBox
+        options={options}
+        onChange={this.setSelectedProperty}
+        label={label}
+        selectedKey={this.state.selectedColumn.property}
+      />
+    );
+  };
+
+  private renderClassComboBox = (options: IComboBoxOption[]): JSX.Element => {
+    return this.renderComboBox(
+      options,
+      localization.Interpret.AxisConfigDialog.selectClass
     );
   };
 

--- a/libs/core-ui/src/lib/components/AxisConfigDialogProps.ts
+++ b/libs/core-ui/src/lib/components/AxisConfigDialogProps.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ISelectorConfig } from "../util/IGenericChartProps";
+import { ColumnCategories } from "../util/JointDatasetUtils";
+
+export interface IAxisConfigDialogProps {
+  orderedGroupTitles: ColumnCategories[];
+  selectedColumn: ISelectorConfig;
+  canBin: boolean;
+  mustBin: boolean;
+  canDither: boolean;
+  allowTreatAsCategorical: boolean;
+  allowLogarithmicScaling?: boolean;
+  hideDroppedFeatures?: boolean;
+  removeCount?: boolean;
+  onAccept: (newConfig: ISelectorConfig) => void;
+  onCancel: () => void;
+}

--- a/libs/core-ui/src/lib/components/AxisConfigDialogState.ts
+++ b/libs/core-ui/src/lib/components/AxisConfigDialogState.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IComboBoxOption } from "@fluentui/react";
+import _ from "lodash";
+
+import { ISelectorConfig } from "../util/IGenericChartProps";
+import { JointDataset } from "../util/JointDataset";
+
+import { IAxisConfigDialogProps } from "./AxisConfigDialogProps";
+import {
+  constructClassArray,
+  constructDataArray,
+  constructMultilabelArray,
+  extractSelectionKey,
+  getBinCountForProperty
+} from "./AxisConfigDialogUtils";
+
+export interface IAxisConfigDialogState {
+  selectedColumn: ISelectorConfig;
+  binCount?: number;
+  selectedFilterGroup?: string;
+  dataArray: IComboBoxOption[];
+  classArray: IComboBoxOption[];
+  multilabelPredictedYArray: IComboBoxOption[];
+  multilabelTrueYArray: IComboBoxOption[];
+}
+
+export function buildAxisConfigDialogState(
+  jointDataset: JointDataset,
+  props: IAxisConfigDialogProps,
+  defaultBinCount: number,
+  droppedFeatureSet: Set<string>
+): IAxisConfigDialogState {
+  return {
+    binCount: getBinCountForProperty(
+      jointDataset.metaDict[props.selectedColumn.property],
+      props.canBin,
+      defaultBinCount
+    ),
+    classArray: constructClassArray(jointDataset),
+    dataArray: constructDataArray(
+      jointDataset,
+      props.hideDroppedFeatures,
+      droppedFeatureSet
+    ),
+    multilabelPredictedYArray: constructMultilabelArray(
+      jointDataset,
+      JointDataset.PredictedYLabel
+    ),
+    multilabelTrueYArray: constructMultilabelArray(
+      jointDataset,
+      JointDataset.TrueYLabel
+    ),
+    selectedColumn: _.cloneDeep(props.selectedColumn),
+    selectedFilterGroup: extractSelectionKey(props.selectedColumn.property)
+  };
+}

--- a/libs/core-ui/src/lib/components/AxisConfigDialogUtils.ts
+++ b/libs/core-ui/src/lib/components/AxisConfigDialogUtils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { IComboBoxOption } from "@fluentui/react";
 import { localization } from "@responsible-ai/localization";
 
 import { JointDataset } from "../util/JointDataset";
@@ -82,38 +83,32 @@ export function getBinCountForProperty(
   return binCount;
 }
 
-export function getClassArray(
-  predictionClassCount: number,
-  metaDict: { [key: string]: IJointMeta }
-): Array<{
-  key: string;
-  text: string;
-}> {
-  return new Array(predictionClassCount).fill(0).map((_, index) => {
-    const key = JointDataset.ProbabilityYRoot + index.toString();
-    return {
-      key,
-      text: metaDict[key].abbridgedLabel
-    };
-  });
+export function constructClassArray(
+  jointDataset: JointDataset
+): IComboBoxOption[] {
+  return new Array(jointDataset.predictionClassCount)
+    .fill(0)
+    .map((_, index) => {
+      const key = JointDataset.ProbabilityYRoot + index.toString();
+      return {
+        key,
+        text: jointDataset.metaDict[key].abbridgedLabel
+      };
+    });
 }
 
-export function getDataArray(
-  droppedFeatureSet: Set<string>,
-  datasetFeatureCount: number,
-  metaDict: { [key: string]: IJointMeta },
-  hideDroppedFeatures?: boolean
-): Array<{
-  key: string;
-  text: string;
-}> {
-  return new Array(datasetFeatureCount)
+export function constructDataArray(
+  jointDataset: JointDataset,
+  hideDroppedFeatures: boolean | undefined,
+  droppedFeatureSet: Set<string>
+): IComboBoxOption[] {
+  return new Array(jointDataset.datasetFeatureCount)
     .fill(0)
     .map((_, index) => {
       const key = JointDataset.DataLabelRoot + index.toString();
       return {
         key,
-        text: metaDict[key].abbridgedLabel
+        text: jointDataset.metaDict[key].abbridgedLabel
       };
     })
     .filter((item) => {
@@ -122,4 +117,23 @@ export function getDataArray(
       }
       return true;
     });
+}
+
+export function constructMultilabelArray(
+  jointDataset: JointDataset,
+  label: string
+): IComboBoxOption[] {
+  const multilabelPredictedYArray = [];
+  if (jointDataset.numLabels > 1) {
+    multilabelPredictedYArray.push(
+      ...new Array(jointDataset.numLabels).fill(0).map((_, index) => {
+        const key = label + index.toString();
+        return {
+          key,
+          text: jointDataset.metaDict[key].abbridgedLabel
+        };
+      })
+    );
+  }
+  return multilabelPredictedYArray;
 }

--- a/libs/dataset-explorer/src/lib/ChartView/utils/generateDefaultChartAxes.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/utils/generateDefaultChartAxes.ts
@@ -14,13 +14,19 @@ export function generateDefaultChartAxes(
   if (!jointDataset.hasDataset) {
     return;
   }
+  let colorAxisProperty = JointDataset.IndexLabel;
+  if (jointDataset.hasPredictedY) {
+    if (jointDataset.numLabels > 1) {
+      colorAxisProperty = `${JointDataset.PredictedYLabel}0`;
+    } else {
+      colorAxisProperty = JointDataset.PredictedYLabel;
+    }
+  }
   const chartProps: IGenericChartProps = {
     chartType: ChartTypes.Histogram,
     colorAxis: {
       options: {},
-      property: jointDataset.hasPredictedY
-        ? JointDataset.PredictedYLabel
-        : JointDataset.IndexLabel
+      property: colorAxisProperty
     },
     xAxis: {
       options: {},

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -923,6 +923,8 @@
       "falsePositive": "False positive",
       "none": "Count",
       "predictedProbabilities": "Prediction probabilities",
+      "predictedLabels": "Predicted labels",
+      "trueLabels": "True labels",
       "regressionError": "Regression error",
       "trueNegative": "True negative",
       "truePositive": "True positive",


### PR DESCRIPTION

## Description

While testing multilabel text and vision, I found that the axis config dialog in the dataset explorer was missing the true and predicted labels as options.  This PR adds those options.  Since there can be many labels, I configured this as a dropdown similar to the probabilities config dropdown in a multiclass scenario.
Note as part of this PR I also refactored the AxisConfigDialog as it was quite large and with the new changes the file was going over 300 lines in length.

Screenshot of updated axis config dialog with dropdown for true and predicted labels:

![image](https://user-images.githubusercontent.com/24683184/218148809-3a055bf2-6711-4cea-b35e-33f54b09fb8a.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
