### PR TITLE
improve installation instructions for onboarding to RAI toolbox repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ All pull requests need to abide by the following criteria to be accepted:
 First ensure you have
 [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 installed (which in turn may require installing `node`).
+
+This repository is tested with node 14.x, 15.x and 16.x, so using the latest 16.x version is recommended.
+
 Using npm you can install `yarn` as follows:
 
 ```
@@ -128,8 +131,21 @@ cypress window will open locally - select test file to run the tests
 2. `cd responsible-ai-toolbox` (It is recommended to create a new virtual environment and install the dependencies)
 3. `yarn install`
 4. `yarn buildall` or `yarn build widget`
-5. `pip install -e responsibleai` to install responsibleai locally.
-6. `pip install -e raiwidgets` to install raiwidgets locally.
+5. `pip install -e raiwidgets` to install raiwidgets locally.
+6. `pip install -e responsibleai` to install responsibleai locally.
+
+   If there are changes to other python packages, you will want to install them locally as well:
+
+   `pip install -e raiutils`
+
+   `pip install -e erroranalysis`
+
+   `pip install -e rai_core_flask`
+
+   `pip install -e nlp_feature_extractors` if using the RAI Text Dashboard locally.
+
+   If there are no changes to them, then raiwidgets install will pick up the latest versions released on pypi.
+
 7. `pip install jupyter`
 8. `cd notebooks\responsibleaidashboard`
 9. To execute tests run `yarn e2e-widget`. Sometimes it is preferable to watch the execution and select only individual test cases. This is possible by running the notebook manually and using `yarn e2e-widget -w --host {host} -n {notebook}` where host is where RAI widget runs on (printed in notebook output) and notebook is the name of the notebook you are running. Eg: `yarn e2e-widget -w --host 5000 -n responsibleaidashboard-census-classification-model-debugging`
@@ -166,14 +182,17 @@ For any new change, which involves changing any of the python SDK components and
 3. You should commit all your current set of changes for SDK and UX using `git commit`.
 4. Clean all untracked files using `git clean -fdx`
 5. Run `yarn install` and `yarn buildall` to build the UX changes.
-6. Run `pip install -e responsibleai` to install responsibleai locally.
-7. Run `pip install -e raiwidgets` to install raiwidgets locally.
+6. Run `pip install -e raiwidgets` to install raiwidgets locally.
+7. Run `pip install -e responsibleai` to install responsibleai locally.
 8. Run `pip install -e erroranalysis` to install erroranalysis locally.
 9. Run `pip install -e rai_core_flask` to install rai_core_flask locally.
-10. Install `jupyter` using `pip install jupyter`
-11. Open any notebook using python SDK and any widget from `responsible-ai-toolbox` and test your changes.
+10. Run `pip install -e raiutils` to install raiutils locally.
+11. Run `pip install -e nlp_feature_extractors` to install nlp_feature_extractors locally if using the RAI Text Dashboard.
+12. Run `pip install -e rai_test_utils` to install rai_test_utils locally.
+13. Install `jupyter` using `pip install jupyter`
+14. Open any notebook using python SDK and any widget from `responsible-ai-toolbox` and test your changes.
 
-The steps from 3 to 11 need to be repeated if you incrementally change UI or SDK.
+The steps from 3 to 14 need to be repeated if you incrementally change UI or SDK.
 
 ### Debugging
 


### PR DESCRIPTION

## Description

Improve installation instructions for onboarding to RAI toolbox repository.
Specifically, mention that only node v16.x is tested, as I have seen some developers try to onboard with v18.x and it failed.
Also, add instructions about some missing new pypi packages (raiutils, erroranalysis, etc) that are required for running locally.
Changed order of raiwidgets and responsibleai install since otherwise it can cause the version on pypi to get installed instead.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
