### PR TITLE
Fix robot page exception on data explorer

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
@@ -198,7 +198,7 @@ export class SidePanel extends React.Component<
           colorAxis.property
         );
         const includedIndexes = _.uniq(
-          this.props.cohorts[this.props.selectedCohortIndex].unwrap(
+          this.props.cohorts[this.props.selectedCohortIndex]?.unwrap(
             colorAxis.property
           )
         );


### PR DESCRIPTION
There was an ICM for robot page exception on data explorer. We have seen similar issue before on undefined this.props.cohorts[this.props.selectedCohortIndex].

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
