### PR TITLE
Fix robot page exception on undefined dataset

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -50,14 +50,14 @@ export function buildInitialModelAssessmentContext(
         .localFeatureImportance;
   }
   const jointDataset = new JointDataset({
-    dataset: props.dataset.features,
-    featureMetaData: props.dataset.feature_metadata,
+    dataset: props.dataset?.features,
+    featureMetaData: props.dataset?.feature_metadata,
     localExplanations,
     metadata: modelMetadata,
-    predictedProbabilities: props.dataset.probability_y,
-    predictedY: props.dataset.predicted_y,
-    targetColumn: props.dataset.target_column,
-    trueY: props.dataset.true_y
+    predictedProbabilities: props.dataset?.probability_y,
+    predictedY: props.dataset?.predicted_y,
+    targetColumn: props.dataset?.target_column,
+    trueY: props.dataset?.true_y
   });
   const globalProps = buildGlobalProperties(
     props.modelExplanationData?.[0]?.precomputedExplanations
@@ -130,21 +130,21 @@ function getModelTypeFromProps(
   classNames: string[] | undefined
 ): ModelTypes {
   let modelType: ModelTypes = ModelTypes.Multiclass;
-  if (props.dataset.task_type === DatasetTaskType.Regression) {
+  if (props.dataset?.task_type === DatasetTaskType.Regression) {
     modelType = ModelTypes.Regression;
-  } else if (props.dataset.task_type === DatasetTaskType.Classification) {
+  } else if (props.dataset?.task_type === DatasetTaskType.Classification) {
     modelType = getModelTypeFromExplanation(
       props.modelExplanationData?.[0]?.precomputedExplanations,
-      props.dataset.probability_y
+      props.dataset?.probability_y
     );
   }
-  if (props.dataset.task_type === DatasetTaskType.ImageClassification) {
+  if (props.dataset?.task_type === DatasetTaskType.ImageClassification) {
     if (classNames && classNames.length === 2) {
       modelType = ModelTypes.ImageBinary;
     } else {
       modelType = ModelTypes.ImageMulticlass;
     }
-  } else if (props.dataset.task_type === DatasetTaskType.TextClassification) {
+  } else if (props.dataset?.task_type === DatasetTaskType.TextClassification) {
     if (classNames) {
       if (classNames.length === 2) {
         modelType = ModelTypes.TextBinary;
@@ -154,15 +154,15 @@ function getModelTypeFromProps(
     } else {
       getModelTypeFromTextExplanation(
         props.modelExplanationData?.[0]?.precomputedExplanations,
-        props.dataset.probability_y
+        props.dataset?.probability_y
       );
     }
   } else if (
-    props.dataset.task_type === DatasetTaskType.MultilabelImageClassification
+    props.dataset?.task_type === DatasetTaskType.MultilabelImageClassification
   ) {
     modelType = ModelTypes.ImageMultilabel;
   } else if (
-    props.dataset.task_type === DatasetTaskType.MultilabelTextClassification
+    props.dataset?.task_type === DatasetTaskType.MultilabelTextClassification
   ) {
     modelType = ModelTypes.TextMultilabel;
   }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -172,9 +172,9 @@ function getModelTypeFromProps(
 function buildModelMetadata(
   props: IModelAssessmentDashboardProps
 ): IExplanationModelMetadata {
-  let classNames = props.dataset.class_names;
+  let classNames = props.dataset?.class_names;
   const modelType = getModelTypeFromProps(props, classNames);
-  let featureNames = props.dataset.feature_names;
+  let featureNames = props.dataset?.feature_names;
   let featureNamesAbridged: string[];
   const maxLength = 18;
   if (featureNames !== undefined) {
@@ -186,7 +186,7 @@ function buildModelMetadata(
     });
   } else {
     let featureLength = 0;
-    if (props.dataset.features && props.dataset.features[0] !== undefined) {
+    if (props.dataset?.features && props.dataset.features[0] !== undefined) {
       featureLength = props.dataset.features[0].length;
     } else if (
       props.modelExplanationData?.[0]?.precomputedExplanations &&
@@ -233,7 +233,7 @@ function buildModelMetadata(
   if (modelType !== ModelTypes.ImageMulticlass) {
     const classLength = getClassLength(
       props.modelExplanationData?.[0]?.precomputedExplanations,
-      props.dataset.probability_y
+      props.dataset?.probability_y
     );
     if (!classNames || classNames.length !== classLength) {
       classNames = buildIndexedNames(
@@ -248,17 +248,17 @@ function buildModelMetadata(
   }
   const featureIsCategorical = ModelMetadata.buildIsCategorical(
     featureNames.length,
-    props.dataset.features
+    props.dataset?.features
   ).map(
     (v, i) =>
       v ||
-      props.dataset.categorical_features.includes(
-        props.dataset.feature_names[i]
+      props.dataset?.categorical_features.includes(
+        props.dataset?.feature_names[i]
       )
   );
   const featureRanges =
     ModelMetadata.buildFeatureRanges(
-      props.dataset.features,
+      props.dataset?.features,
       featureIsCategorical
     ) || [];
   return {


### PR DESCRIPTION
This PR is to fix the robot page exception that customer hit in `buildModelMetadata` function.

For better user experience, we should find a way to check all the props, and return meaningful error messages when certain property is undefined. Maybe we can achieve that directly inside AML studio UI code.

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
