### PR TITLE
fix outdated example link in Error Analysis README

### DIFF
--- a/docs/erroranalysis-dashboard-README.md
+++ b/docs/erroranalysis-dashboard-README.md
@@ -16,7 +16,7 @@ For instance, you can use Error Analysis to discover that the model has a higher
 - [Error analysis and interpretability of a census income prediction model](https://github.com/microsoft/responsible-ai-widgets/blob/master/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-interpretability-dashboard-census.ipynb)
 - [Error analysis and interpretability of a breast cancer prediction model](https://github.com/microsoft/responsible-ai-widgets/blob/master/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-interpretability-dashboard-breast-cancer.ipynb)
 - [Error analysis of a multi class classification model](https://github.com/microsoft/responsible-ai-widgets/blob/master/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-multiclass.ipynb)
-- [Error analysis of a boston housing price prediction model](https://github.com/microsoft/responsible-ai-widgets/blob/master/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-boston-housing.ipynb)
+- [Error analysis of a housing price prediction model](https://github.com/microsoft/responsible-ai-toolbox/blob/main/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-housing.ipynb)
 - [Error analysis of a critical temperature of superconductors prediction model](https://github.com/microsoft/responsible-ai-widgets/blob/master/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-superconductor.ipynb)
 
 <a name="interpretability dashboard"></a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the link to the housing price prediction example notebook in Error Analysis README to fix 404.
<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
