### PR TITLE
Fix issue - Filter column is localized when calling backend 

### DIFF
--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -7,6 +7,7 @@ import {
   ICompositeFilter,
   Operations
 } from "../Interfaces/IFilter";
+import { getColumnName } from "../util/CohortUtils";
 import { compare } from "../util/compare";
 import { JointDataset } from "../util/JointDataset";
 import { ModelExplanationUtils } from "../util/ModelExplanationUtils";
@@ -49,7 +50,11 @@ export class Cohort {
     const filtersRelabeled = filters
       .filter((item) => item)
       .map((filter: IFilter): IFilter => {
-        const label = jointDataset.metaDict[filter.column].label;
+        const columnName = getColumnName(filter.column);
+        const label =
+          columnName.length > 0
+            ? columnName
+            : jointDataset.metaDict[filter.column].label;
         return {
           arg: filter.arg,
           column: label,

--- a/libs/core-ui/src/lib/util/CohortUtils.ts
+++ b/libs/core-ui/src/lib/util/CohortUtils.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { JointDataset } from "./JointDataset";
+
+enum ColumnNames {
+  Index = "Index",
+  PredictedY = "Predicted Y",
+  TrueY = "True Y",
+  ClassificationError = "Classification outcome",
+  RegressionError = "Regression error"
+}
+
+export function getColumnName(filterColumn: string): string {
+  switch (filterColumn) {
+    case JointDataset.IndexLabel:
+      return ColumnNames.Index;
+    case JointDataset.PredictedYLabel:
+      return ColumnNames.PredictedY;
+    case JointDataset.TrueYLabel:
+      return ColumnNames.TrueY;
+    case JointDataset.ClassificationError:
+      return ColumnNames.ClassificationError;
+    case JointDataset.RegressionError:
+      return ColumnNames.RegressionError;
+    default:
+      return "";
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->
Before fix 
For filter column we are sending the localized string to backend
![image](https://user-images.githubusercontent.com/76190371/219172417-16cfb81e-46d6-4dda-8e32-382af4140a80.png)

After fix
![image](https://user-images.githubusercontent.com/76190371/219172920-614a90be-6c76-4107-a518-add0fb84433e.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
