### PR TITLE
fix CI notebook build via updated yarn command flags

### DIFF
--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   ci-notebook:
+    env:
+      node-version: 16.x
     strategy:
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
@@ -23,11 +25,21 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.pythonVersion }}
 
-      - name: build typescript
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Install yarn
+        run: npm install yarn -g
+
+      - name: Install yarn dependencies
         run: |
           yarn config set network-timeout 300000
-          yarn install
-          yarn buildall
+          yarn install --frozen-lock-file
+
+      - name: Build Typescript
+        run: yarn buildall
 
       - if: ${{ matrix.operatingSystem != 'macos-latest' }}
         name: Install pytorch on non-MacOS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix CI notebook build via updated yarn command flags


The builds are currently failing due to errors in ci-notebook UI tests pipeline:
```
> nx run localization:build 
Error loading `tslib` helper library.
Package subpath './package.json' is not defined by "exports" in D:\a\responsible-ai-toolbox\responsible-ai-toolbox\node_modules\rollup-plugin-typescript2\node_modules\tslib\package.json

> nx run mlchartlib:build 
Error loading `tslib` helper library.
Package subpath './package.json' is not defined by "exports" in D:\a\responsible-ai-toolbox\responsible-ai-toolbox\node_modules\rollup-plugin-typescript2\node_modules\tslib\package.json
```
This PR attempts to fix this by using similar commands to other pipelines we have which don't seem to be failing.  I suspect the main argument that fixes this issue is ```--frozen-lock-file``` when calling yarn install.  Perhaps some npm dependency is upgraded and that causes the rollup-plugin-typescript2 error.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
