### PR TITLE
Forecasting: validate characters for name field in transformation creation dialog

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     "<rootDir>/apps/dashboard",
     "<rootDir>/libs/localization",
     "<rootDir>/libs/error-analysis",
+    "<rootDir>/libs/forecasting",
     "<rootDir>/apps/widget"
   ]
 };

--- a/libs/forecasting/.babelrc
+++ b/libs/forecasting/.babelrc
@@ -1,12 +1,4 @@
 {
-  "presets": [
-    [
-      "@nrwl/react/babel",
-      {
-        "runtime": "automatic",
-        "useBuiltIns": "usage"
-      }
-    ]
-  ],
+  "presets": ["@nrwl/react/babel"],
   "plugins": []
 }

--- a/libs/forecasting/.eslintrc.json
+++ b/libs/forecasting/.eslintrc.json
@@ -11,5 +11,6 @@
       "rules": {
         "max-lines": "warn"
       }
+    }
   ]
 }

--- a/libs/forecasting/.eslintrc.json
+++ b/libs/forecasting/.eslintrc.json
@@ -7,12 +7,9 @@
       "rules": {}
     },
     {
-      "files": ["*.ts", "*.tsx"],
-      "rules": {}
-    },
-    {
-      "files": ["*.js", "*.jsx"],
-      "rules": {}
-    }
+      "files": ["TransformationCreationDialog.tsx"],
+      "rules": {
+        "max-lines": "warn"
+      }
   ]
 }

--- a/libs/forecasting/babel-jest.config.json
+++ b/libs/forecasting/babel-jest.config.json
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ]
+}

--- a/libs/forecasting/jest.config.js
+++ b/libs/forecasting/jest.config.js
@@ -4,9 +4,12 @@
 module.exports = {
   coverageDirectory: "../../coverage/libs/forecasting",
   displayName: "forecasting",
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "html"],
   preset: "../../jest.preset.js",
   transform: {
-    "^.+\\.[tj]sx?$": "babel-jest"
+    "^.+\\.[tj]sx?$": [
+      "babel-jest",
+      { configFile: "./babel-jest.config.json", cwd: __dirname }
+    ]
   }
 };

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationCreationDialog.tsx
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationCreationDialog.tsx
@@ -24,6 +24,7 @@ import {
   Operation,
   Feature
 } from "../Interfaces/Transformation";
+import { isValidTransformationName } from "./isValidTransformationName";
 
 import { TransformationCreation } from "./TransformationCreation";
 
@@ -225,6 +226,11 @@ export class TransformationCreationDialog extends React.Component<
         value.length
       );
     }
+    if (!isValidTransformationName(value)) {
+      return localization.Forecasting.TransformationCreation
+        .scenarioNamingInvalidCharactersMessage;
+    }
+
     return undefined;
   };
 

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationCreationDialog.tsx
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationCreationDialog.tsx
@@ -24,8 +24,8 @@ import {
   Operation,
   Feature
 } from "../Interfaces/Transformation";
-import { isValidTransformationName } from "./isValidTransformationName";
 
+import { isValidTransformationName } from "./isValidTransformationName";
 import { TransformationCreation } from "./TransformationCreation";
 
 export interface ITransformationCreationDialogProps {

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.test.ts
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.test.ts
@@ -37,7 +37,9 @@ describe("test is valid transformation name", () => {
     expect(isValidTransformationName("-M")).toBe(false);
     expect(isValidTransformationName("*")).toBe(false);
     expect(isValidTransformationName("abcde*fg")).toBe(false);
-    expect(isValidTransformationName("This is a name, but it won't pass.")).toBe(false);
+    expect(
+      isValidTransformationName("This is a name, but it won't pass.")
+    ).toBe(false);
     expect(isValidTransformationName("ABCDE&FG")).toBe(false);
     expect(isValidTransformationName("a<b")).toBe(false);
     expect(isValidTransformationName("c>d")).toBe(false);
@@ -47,5 +49,5 @@ describe("test is valid transformation name", () => {
     expect(isValidTransformationName("k@l")).toBe(false);
     expect(isValidTransformationName("m/n")).toBe(false);
     expect(isValidTransformationName("o\\p")).toBe(false);
-  });  
+  });
 });

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.test.ts
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { isValidTransformationName } from "./isValidTransformationName";
+
+describe("test is valid transformation name", () => {
+  it("should identify correct names", () => {
+    expect(isValidTransformationName("g")).toBe(true);
+    expect(isValidTransformationName("1")).toBe(true);
+    expect(isValidTransformationName("M")).toBe(true);
+    expect(isValidTransformationName("good")).toBe(true);
+    expect(isValidTransformationName("1 transformation is good")).toBe(true);
+    expect(isValidTransformationName("Mild increase in 1 feature")).toBe(true);
+    expect(isValidTransformationName("g_add_1")).toBe(true);
+    expect(isValidTransformationName("6_sub_g")).toBe(true);
+    expect(isValidTransformationName("M_mul_5")).toBe(true);
+    expect(isValidTransformationName("g-2")).toBe(true);
+    expect(isValidTransformationName("1-0")).toBe(true);
+    expect(isValidTransformationName("M-9")).toBe(true);
+    expect(isValidTransformationName("g_a bc-7")).toBe(true);
+    expect(isValidTransformationName("1-r TP_q")).toBe(true);
+    expect(isValidTransformationName("M_345 p-y")).toBe(true);
+  });
+  it("should identify incorrect names", () => {
+    expect(isValidTransformationName("")).toBe(false);
+    expect(isValidTransformationName(" ")).toBe(false);
+    expect(isValidTransformationName(" g")).toBe(false);
+    expect(isValidTransformationName(" 1")).toBe(false);
+    expect(isValidTransformationName(" M")).toBe(false);
+    expect(isValidTransformationName("_")).toBe(false);
+    expect(isValidTransformationName("_g")).toBe(false);
+    expect(isValidTransformationName("_1")).toBe(false);
+    expect(isValidTransformationName("_M")).toBe(false);
+    expect(isValidTransformationName("-")).toBe(false);
+    expect(isValidTransformationName("-g")).toBe(false);
+    expect(isValidTransformationName("-1")).toBe(false);
+    expect(isValidTransformationName("-M")).toBe(false);
+    expect(isValidTransformationName("*")).toBe(false);
+    expect(isValidTransformationName("abcde*fg")).toBe(false);
+    expect(isValidTransformationName("This is a name, but it won't pass.")).toBe(false);
+    expect(isValidTransformationName("ABCDE&FG")).toBe(false);
+    expect(isValidTransformationName("a<b")).toBe(false);
+    expect(isValidTransformationName("c>d")).toBe(false);
+    expect(isValidTransformationName("e%f")).toBe(false);
+    expect(isValidTransformationName("g$h")).toBe(false);
+    expect(isValidTransformationName("i#j")).toBe(false);
+    expect(isValidTransformationName("k@l")).toBe(false);
+    expect(isValidTransformationName("m/n")).toBe(false);
+    expect(isValidTransformationName("o\\p")).toBe(false);
+  });  
+});

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.ts
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.ts
@@ -4,6 +4,6 @@
 export function isValidTransformationName(name: string): boolean {
   // explanation for the regex below:
   // ^[a-zA-Z0-9_]+ - start with alphanumeric character
-  // [a-zA-Z0-9_\-\s]*$ - continue with any number of alphanumeric characters, underscores, dashes, or spaces
+  // [a-zA-Z0-9_\\-\\s]*$ - continue with any number of alphanumeric characters, underscores, dashes, or spaces
   return new RegExp("^[a-zA-Z0-9]+[a-zA-Z0-9_\\-\\s]*$").test(name);
 }

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.ts
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/isValidTransformationName.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function isValidTransformationName(name: string): boolean {
+  // explanation for the regex below:
+  // ^[a-zA-Z0-9_]+ - start with alphanumeric character
+  // [a-zA-Z0-9_\-\s]*$ - continue with any number of alphanumeric characters, underscores, dashes, or spaces
+  return new RegExp("^[a-zA-Z0-9]+[a-zA-Z0-9_\\-\\s]*$").test(name);
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1878,6 +1878,7 @@
       "scenarioNamingInstructions": "Enter a name for your what-if scenario.",
       "scenarioNamingCollisionMessage": "This name exists already. Please enter a unique name.",
       "scenarioNamingLengthMessage": "The name must be between 1 and 50 characters. The actual length is {0}.",
+      "scenarioNamingInvalidCharactersMessage": "The name can only contain alphanumeric characters, whitespaces, dashes, or underscores, and needs to start with an alphanumeric character.",
       "valueErrorMessage": "For operation {0} please select a value between {1} and {2} other than {3}.",
       "invalidCombinationErrorMessage": "This is identical to an existing what-if scenario. Please change the feature, operation, or value.",
       "addTransformationButton": "Add Transformation",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds input validation for the name field in the transformation creation dialog. Length validation already exists, so this only adds character validation.

If you write a name and fully erase it:
![image](https://user-images.githubusercontent.com/10245648/221101344-3e48e792-80a0-40a9-97a4-442a1413d245.png)

If you enter invalid characters:
![image](https://user-images.githubusercontent.com/10245648/221101291-ecdf50c6-0d18-4fc3-bf04-5567fc2c8573.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
