### PR TITLE
Forecasting: turn off Error Analysis

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -205,7 +205,8 @@ export class TabsView extends React.PureComponent<
                 </>
               )}
               {t.key === GlobalTabKeys.ErrorAnalysisTab &&
-                this.context.dataset.task_type !== DatasetTaskType.Forecasting &&
+                this.context.dataset.task_type !==
+                  DatasetTaskType.Forecasting &&
                 this.props.errorAnalysisData?.[0] && (
                   <>
                     <Stack

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -205,6 +205,7 @@ export class TabsView extends React.PureComponent<
                 </>
               )}
               {t.key === GlobalTabKeys.ErrorAnalysisTab &&
+                this.context.dataset.task_type !== DatasetTaskType.Forecasting &&
                 this.props.errorAnalysisData?.[0] && (
                   <>
                     <Stack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This removes the last missing piece of error analysis that was missed in a previous PR. Forecasting does not support EA (yet).

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
