### PR TITLE
Forecasting: fix button text to say "switch time series"

### DIFF
--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1458,6 +1458,7 @@
     },
     "CohortInformation": {
       "ShiftCohort": "Switch cohort",
+      "SwitchTimeSeries": "Switch time series",
       "NewCohort": "New cohort",
       "DataPoints": "Number of datapoints",
       "DefaultCohort": " (default)",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/ChangeGlobalCohortButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/ChangeGlobalCohortButton.tsx
@@ -3,6 +3,7 @@
 
 import { DefaultButton } from "@fluentui/react";
 import {
+  DatasetTaskType,
   defaultModelAssessmentContext,
   IModelAssessmentContext,
   ModelAssessmentContext
@@ -31,10 +32,14 @@ export class ChangeGlobalCohortButton extends React.Component<
     this.state = { shiftCohortVisible: false };
   }
   public render(): React.ReactNode {
+    const buttonText =
+      this.context.dataset.task_type === DatasetTaskType.Forecasting
+        ? localization.ModelAssessment.CohortInformation.SwitchTimeSeries
+        : localization.ModelAssessment.CohortInformation.ShiftCohort;
     return (
       <>
         <DefaultButton
-          text={localization.ModelAssessment.CohortInformation.ShiftCohort}
+          text={buttonText}
           onClick={this.toggleShiftCohortVisibility}
         />
         <ChangeGlobalCohort


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The "Switch cohort" button needed adjusting for time series. In forecasting cases, it now says "Switch time series" (see below)

![image](https://user-images.githubusercontent.com/10245648/221295222-095980da-4d8a-4523-9621-5e2848719768.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
