### PR TITLE
Update notebooks for categorical features to pass through FeatureMetadata

### DIFF
--- a/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
@@ -196,7 +196,7 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments.",
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
     "\n",
     "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
@@ -196,7 +196,7 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments.",
     "\n",
     "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
@@ -209,7 +209,16 @@
    "outputs": [],
    "source": [
     "from responsibleai.feature_metadata import FeatureMetadata\n",
-    "feature_metadata = FeatureMetadata(categorical_features=categorical_features, dropped_features=[])\n",
+    "feature_metadata = FeatureMetadata(categorical_features=categorical_features, dropped_features=[])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bulgarian-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "rai_insights = RAIInsights(model, train_data, test_data_sample, target_feature, 'classification',\n",
     "                           feature_metadata=feature_metadata)"
    ]

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
@@ -197,6 +197,8 @@
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
     "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "\n",
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
   },
   {
@@ -206,8 +208,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from responsibleai.feature_metadata import FeatureMetadata\n",
+    "feature_metadata = FeatureMetadata(categorical_features=categorical_features, dropped_features=[])\n",
     "rai_insights = RAIInsights(model, train_data, test_data_sample, target_feature, 'classification',\n",
-    "                           categorical_features=categorical_features)"
+    "                           feature_metadata=feature_metadata)"
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
@@ -198,7 +198,7 @@
     "\n",
     "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
     "\n",
-    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -178,7 +178,7 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments.\n",
+    "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string and the task type string as its arguments.\n",
     "\n",
     "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -191,7 +191,8 @@
    "outputs": [],
    "source": [
     "from responsibleai.feature_metadata import FeatureMetadata\n",
-    "# Add 's1' as an identity feature, set features_to_drop as dropped features\n"
+    "# Add 's1' as an identity feature, set features_to_drop as dropped features\n",
+    "feature_metadata = FeatureMetadata(identity_feature_name='s1', dropped_features=features_to_drop)\n"
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -186,13 +186,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d965f769",
+   "id": "d965f768",
    "metadata": {},
    "outputs": [],
    "source": [
     "from responsibleai.feature_metadata import FeatureMetadata\n",
     "# Add 's1' as an identity feature, set features_to_drop as dropped features\n",
-    "feature_metadata = FeatureMetadata(identity_feature_name='s1', dropped_features=features_to_drop)\n"
+    "feature_metadata = FeatureMetadata(identity_feature_name='s1', categorical_features=[], dropped_features=features_to_drop)\n"
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string and the task type string as its arguments.\n",
     "\n",
-    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -191,8 +191,16 @@
    "outputs": [],
    "source": [
     "from responsibleai.feature_metadata import FeatureMetadata\n",
-    "# Add 's1' as an identity feature, set features_to_drop as dropped features\n",
-    "feature_metadata = FeatureMetadata(identity_feature_name='s1', dropped_features=features_to_drop, categorical_features=[])\n",
+    "# Add 's1' as an identity feature, set features_to_drop as dropped features\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d965f769",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "rai_insights = RAIInsights(model, train_data, test_data, target_feature, 'regression',\n",
     "                           feature_metadata=feature_metadata)"
    ]

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -192,9 +192,9 @@
    "source": [
     "from responsibleai.feature_metadata import FeatureMetadata\n",
     "# Add 's1' as an identity feature, set features_to_drop as dropped features\n",
-    "feature_metadata = FeatureMetadata(identity_feature_name='s1', dropped_features=features_to_drop)\n",
+    "feature_metadata = FeatureMetadata(identity_feature_name='s1', dropped_features=features_to_drop, categorical_features=[])\n",
     "rai_insights = RAIInsights(model, train_data, test_data, target_feature, 'regression',\n",
-    "                           categorical_features=[], feature_metadata=feature_metadata)"
+    "                           feature_metadata=feature_metadata)"
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
@@ -151,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bulgarian-hepatitis",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
@@ -143,7 +143,20 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the train dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
+    "\n",
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bulgarian-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from responsibleai.feature_metadata import FeatureMetadata\n",
+    "feature_metadata = FeatureMetadata(categorical_features=[], dropped_features=[])\n"
    ]
   },
   {
@@ -153,7 +166,7 @@
    "outputs": [],
    "source": [
     "rai_insights = RAIInsights(model, train_data, test_data, target_feature, 'regression',\n",
-    "                               categorical_features=[])"
+    "                               feature_metadata=feature_metadata)"
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-regression-model-debugging.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
     "\n",
-    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -181,7 +181,7 @@
     "\n",
     "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
     "\n",
-    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
   },
   {

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -179,7 +179,20 @@
    "source": [
     "To use Responsible AI Dashboard, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
+    "\n",
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bulgarian-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from responsibleai.feature_metadata import FeatureMetadata\n",
+    "feature_metadata = FeatureMetadata(categorical_features=categorical_features, dropped_features=[])\n"
    ]
   },
   {
@@ -193,7 +206,7 @@
     "\n",
     "dashboard_pipeline = Pipeline(steps=[('preprocess', feat_pipe), ('model', model)])\n",
     "rai_insights = RAIInsights(dashboard_pipeline, train_data, test_data, target_feature, 'classification',\n",
-    "                             categorical_features=categorical_features, \n",
+    "                             feature_metadata=feature_metadata, \n",
     "                             classes=['Less than median', 'More than median'])"
    ]
   },

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-classification-model-debugging.ipynb
@@ -187,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bulgarian-hepatitis",
+   "id": "d965f768",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bulgarian-hepatitis",
+   "id": "d965f768",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-housing-decision-making.ipynb
@@ -148,9 +148,20 @@
    "source": [
     "To use Responsible AI Dashboard, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments.\n",
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
     "\n",
-    "Here you can pass None as the model object as we only require historic data to make causal decisions."
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bulgarian-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from responsibleai.feature_metadata import FeatureMetadata\n",
+    "feature_metadata = FeatureMetadata(categorical_features=categorical_features, dropped_features=[])\n"
    ]
   },
   {
@@ -161,7 +172,7 @@
    "outputs": [],
    "source": [
     "rai_insights = RAIInsights(None, train_data, test_data, target_feature, 'regression',\n",
-    "                             categorical_features=categorical_features, \n",
+    "                             feature_metadata=feature_metadata, \n",
     "                             classes=['Less than median', 'More than median'])"
    ]
   },

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-multiclass-dnn-model-debugging.ipynb
@@ -227,7 +227,20 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string, the task type string, and a list of strings of categorical feature names as its arguments."
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
+    "\n",
+    "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bulgarian-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from responsibleai.feature_metadata import FeatureMetadata\n",
+    "feature_metadata = FeatureMetadata(categorical_features=[], dropped_features=[])\n"
    ]
   },
   {
@@ -243,7 +256,8 @@
     "X_train[target_feature] = y_train\n",
     "X_test[target_feature] = y_test\n",
     "\n",
-    "rai_insights = RAIInsights(model, X_train, X_test, target_feature, 'classification')"
+    "rai_insights = RAIInsights(model, X_train, X_test, target_feature, 'classification',\n",
+    "                           feature_metadata=feature_metadata)"
    ]
   },
   {


### PR DESCRIPTION
Previously we have a PR where we deprecated the existing categorical_features arg with a note to switch to feature_metadata.categorical_features: https://github.com/microsoft/responsible-ai-toolbox/pull/1934

This PR updates the sample notebooks for customers to pass categorical_features via feature_metadata.categorical_features

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
