### PR TITLE
update dependencies for rai-core-flask, raiwidgets and responsibleai packages

### DIFF
--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -5,5 +5,5 @@ ipython>=7.31.1; python_version > '3.6'
 itsdangerous>=2.0.1
 greenlet>=1.1.2
 gevent>=21.12.0
-markupsafe<2.1.0
-Werkzeug<2.1.0
+markupsafe<=2.1.2
+Werkzeug<=2.2.3

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.17.2,<1.24.0
 pandas>=0.25.1
 scipy>=1.4.1
 rai-core-flask==0.5.0
-itsdangerous==2.0.1
+itsdangerou<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.4.2

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -5,7 +5,7 @@ erroranalysis>=0.4.2
 interpret-community>=0.28.0
 lightgbm>=2.0.11
 numpy>=1.17.2,<1.24.0
-numba<0.54.0
+numba<=0.55.2
 pandas>=0.25.1
 scikit-learn>=0.22.1,<1.1 # See PR 1429 about upper bound
 scipy>=1.4.1
@@ -14,6 +14,6 @@ ml_wrappers
 
 # Pinned dependencies
 networkx<=2.5
-ipykernel<=6.6.0
-markupsafe<2.1.0
+ipykernel<=6.8.0
+markupsafe<=2.1.2
 raiutils>=0.4.0


### PR DESCRIPTION

## Description

Updating to the following packages/versions:
```
ipykernel 6.8.0
markupsafe 2.1.2
numba 0.55.2
itsdangerous 2.1.2
markupsafe 2.1.2
werkzeug 2.2.3
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
