### PR TITLE
Explicitly set chart background color

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/getErrorBarChartOptions.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/getErrorBarChartOptions.ts
@@ -18,11 +18,12 @@ export function getErrorBarChartOptions(
   const colorTheme = {
     axisColor: theme.palette.neutralPrimary,
     axisGridColor: theme.palette.neutralLight,
-    backgroundColor: theme.palette.white,
+    backgroundColor: theme.semanticColors.bodyBackground,
     fontColor: theme.semanticColors.bodyText
   };
   return {
     chart: {
+      backgroundColor: colorTheme.backgroundColor,
       type: "lowmedhigh",
       zoomType: "xy"
     },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/getIndividualChartOptions.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalIndividualView/getIndividualChartOptions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import { IGenericChartProps } from "@responsible-ai/core-ui";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
 
@@ -40,8 +41,10 @@ export function getIndividualChartOptions(
       name: ""
     };
   });
+  const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "scatter",
       zoomType: "xy"
     },

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/getTreatmentBarChartOptions.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/getTreatmentBarChartOptions.ts
@@ -17,7 +17,7 @@ export function getTreatmentBarChartOptions(
   const colorTheme = {
     axisColor: theme?.palette.neutralPrimary,
     axisGridColor: theme?.palette.neutralLight,
-    backgroundColor: theme?.palette.white,
+    backgroundColor: theme?.semanticColors.bodyBackground,
     fontColor: theme?.semanticColors.bodyText
   };
   const alwaysTreats = data?.treatment_gains
@@ -36,6 +36,7 @@ export function getTreatmentBarChartOptions(
     : [localization.Counterfactuals.recommendedPolicy];
   return {
     chart: {
+      backgroundColor: colorTheme.backgroundColor,
       type: "bar"
     },
     series: [

--- a/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.styles.ts
+++ b/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.styles.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IStyle, mergeStyleSets, IProcessedStyleSet } from "@fluentui/react";
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme
+} from "@fluentui/react";
 
 import { fullLgDown } from "../util/getCommonStyles";
 
@@ -14,34 +19,38 @@ export interface IFeatureImportanceBarStyles {
   boldText: IStyle;
 }
 
-export const featureImportanceBarStyles: IProcessedStyleSet<IFeatureImportanceBarStyles> =
-  mergeStyleSets<IFeatureImportanceBarStyles>({
-    boldText: {
-      fontWeight: "600"
-    },
-    chart: {
-      width: "95%"
-    },
-    chartWithVertical: {
-      width: "100%",
-      ...fullLgDown
-    },
-    noData: {
-      flex: "1",
-      margin: "100px auto 0 auto"
-    },
-    rotatedVerticalBox: {
-      marginLeft: "28px",
-      position: "absolute",
-      textAlign: "center",
-      top: "50%",
-      transform: "translateX(-50%) translateY(-50%) rotate(270deg)",
-      width: "max-content"
-    },
-    verticalAxis: {
-      height: "auto",
-      position: "relative",
-      top: "0px",
-      width: "64px"
-    }
-  });
+export const getFeatureImportanceBarStyles: () => IProcessedStyleSet<IFeatureImportanceBarStyles> =
+  () => {
+    const theme = getTheme();
+    return mergeStyleSets<IFeatureImportanceBarStyles>({
+      boldText: {
+        fontWeight: "600"
+      },
+      chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
+        width: "95%"
+      },
+      chartWithVertical: {
+        width: "100%",
+        ...fullLgDown
+      },
+      noData: {
+        flex: "1",
+        margin: "100px auto 0 auto"
+      },
+      rotatedVerticalBox: {
+        marginLeft: "28px",
+        position: "absolute",
+        textAlign: "center",
+        top: "50%",
+        transform: "translateX(-50%) translateY(-50%) rotate(270deg)",
+        width: "max-content"
+      },
+      verticalAxis: {
+        height: "auto",
+        position: "relative",
+        top: "0px",
+        width: "64px"
+      }
+    });
+  };

--- a/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.tsx
+++ b/libs/core-ui/src/lib/Highchart/FeatureImportanceBar.tsx
@@ -10,7 +10,7 @@ import { ChartTypes } from "../util/IGenericChartProps";
 import { JointDataset } from "../util/JointDataset";
 
 import { BasicHighChart } from "./BasicHighChart";
-import { featureImportanceBarStyles } from "./FeatureImportanceBar.styles";
+import { getFeatureImportanceBarStyles } from "./FeatureImportanceBar.styles";
 import { IHighchartsConfig } from "./IHighchartsConfig";
 
 export interface IGlobalSeries {
@@ -64,8 +64,8 @@ export class FeatureImportanceBar extends React.Component<
       });
     }
   }
-
   public render(): React.ReactNode {
+    const featureImportanceBarStyles = getFeatureImportanceBarStyles();
     return (
       <Stack
         horizontal

--- a/libs/core-ui/src/lib/Highchart/FeatureImportanceDependence.styles.ts
+++ b/libs/core-ui/src/lib/Highchart/FeatureImportanceDependence.styles.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IProcessedStyleSet, mergeStyleSets, IStyle } from "@fluentui/react";
+import {
+  IProcessedStyleSet,
+  mergeStyleSets,
+  IStyle,
+  getTheme
+} from "@fluentui/react";
 
 export interface IDependencePlotStyles {
   boldText: IStyle;
@@ -23,11 +28,14 @@ export interface IDependencePlotStyles {
 
 export const dependencePlotStyles: () => IProcessedStyleSet<IDependencePlotStyles> =
   () => {
+    const theme = getTheme();
+
     return mergeStyleSets<IDependencePlotStyles>({
       boldText: {
         fontWeight: "600"
       },
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         width: "95%"
       },
       chartWithAxes: {

--- a/libs/core-ui/src/lib/Highchart/bubbleChart/getBubbleChartOptions.ts
+++ b/libs/core-ui/src/lib/Highchart/bubbleChart/getBubbleChartOptions.ts
@@ -37,6 +37,7 @@ export function getBubbleChartOptions(
   const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       plotBorderWidth: 1,
       type: "bubble",
       zoomType: "xy"

--- a/libs/core-ui/src/lib/Highchart/bubbleChart/getScatterOption.ts
+++ b/libs/core-ui/src/lib/Highchart/bubbleChart/getScatterOption.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import { Point } from "highcharts";
 
 import { IGenericChartProps } from "../../util/IGenericChartProps";
@@ -35,9 +36,11 @@ export function getScatterOption(
     showColorAxis,
     useDifferentColorForScatterPoints
   );
+  const theme = getTheme();
 
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "scatter",
       zoomType: "xy"
     },

--- a/libs/core-ui/src/lib/Highchart/getDefaultHighchartOptions.ts
+++ b/libs/core-ui/src/lib/Highchart/getDefaultHighchartOptions.ts
@@ -8,7 +8,7 @@ export function getDefaultHighchartOptions(theme: ITheme): Highcharts.Options {
   const colorTheme = {
     axisColor: theme?.palette.neutralPrimary,
     axisGridColor: theme?.palette.neutralLight,
-    backgroundColor: theme?.palette.white,
+    backgroundColor: theme?.semanticColors.bodyBackground,
     fontColor: theme?.semanticColors.bodyText
   };
   return {

--- a/libs/core-ui/src/lib/components/OverallMetricChart.styles.ts
+++ b/libs/core-ui/src/lib/components/OverallMetricChart.styles.ts
@@ -37,6 +37,7 @@ export const overallMetricChartStyles: () => IProcessedStyleSet<IOverallMetricCh
         paddingBottom: "5px"
       },
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         flexGrow: "1"
       },
       chartWithAxes: {

--- a/libs/core-ui/src/lib/util/getDependencyChartOptions.ts
+++ b/libs/core-ui/src/lib/util/getDependencyChartOptions.ts
@@ -23,11 +23,12 @@ export function getDependencyChartOptions(
   const colorTheme = {
     axisColor: theme?.palette.neutralPrimary,
     axisGridColor: theme?.palette.neutralLight,
-    backgroundColor: theme?.palette.white,
+    backgroundColor: theme?.semanticColors.bodyBackground,
     fontColor: theme?.semanticColors.bodyText
   };
   return {
     chart: {
+      backgroundColor: colorTheme.backgroundColor,
       type: "scatter",
       zoomType: "xy"
     },

--- a/libs/core-ui/src/lib/util/getFeatureImportanceBarOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBarOptions.ts
@@ -20,7 +20,7 @@ export function getFeatureImportanceBarOptions(
   const colorTheme = {
     axisColor: theme.palette.neutralPrimary,
     axisGridColor: theme.palette.neutralLight,
-    backgroundColor: theme.palette.white,
+    backgroundColor: theme?.semanticColors.bodyBackground,
     fontColor: theme.semanticColors.bodyText
   };
   const sortedIndexVector = sortArray;
@@ -73,6 +73,7 @@ export function getFeatureImportanceBarOptions(
 
   return {
     chart: {
+      backgroundColor: colorTheme.backgroundColor,
       type: "column"
     },
     legend: {

--- a/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureImportanceBoxOptions.ts
@@ -56,8 +56,10 @@ export function getFeatureImportanceBoxOptions(
       type: "boxplot"
     });
   });
+
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "boxplot"
     },
     legend: {

--- a/libs/counterfactuals/src/lib/LocalImportanceChart.tsx
+++ b/libs/counterfactuals/src/lib/LocalImportanceChart.tsx
@@ -82,15 +82,17 @@ export class LocalImportanceChart extends React.PureComponent<ILocalImportanceCh
     const sortedData = this.getSortedData();
     const x = sortedData.map((d) => d.label);
     const y = sortedData.map((d) => d.value);
+    const theme = getTheme();
     const seriesData = [
       {
-        color: getPrimaryChartColor(getTheme()),
+        color: getPrimaryChartColor(theme),
         data: y,
         name: ""
       }
     ];
     return {
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         type: "column"
       },
       series: seriesData,

--- a/libs/counterfactuals/src/util/getCounterfactualChartOptions.ts
+++ b/libs/counterfactuals/src/util/getCounterfactualChartOptions.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import { FluentUIStyles, IGenericChartProps } from "@responsible-ai/core-ui";
 import { WhatIfConstants } from "@responsible-ai/interpret";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
@@ -46,8 +47,10 @@ export function getCounterfactualChartOptions(
       showInLegend: false
     };
   });
+  const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "scatter",
       zoomType: "xy"
     },

--- a/libs/dataset-explorer/src/lib/ChartView/utils/DatasetExplorerTab.styles.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/utils/DatasetExplorerTab.styles.ts
@@ -57,6 +57,7 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorer
         paddingTop: "10px"
       },
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         marginBottom: "40px",
         width: "85%"
       },

--- a/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetBarOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetBarOption.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import { IGenericChartProps, JointDataset } from "@responsible-ai/core-ui";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
 
@@ -13,9 +14,10 @@ export function getDatasetBarOption(
 ): any {
   const series = getDatasetBar(jointData, plotlyProps, chartProps);
   const xAxisProp = chartProps?.xAxis.property;
-
+  const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "column"
     },
     series,

--- a/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetBoxOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetBoxOption.ts
@@ -49,6 +49,7 @@ export function getDatasetBoxOption(
   });
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "boxplot"
     },
     series: boxGroupData,

--- a/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetScatterOption.ts
+++ b/libs/dataset-explorer/src/lib/ChartView/utils/getDatasetScatterOption.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import { IGenericChartProps, JointDataset } from "@responsible-ai/core-ui";
 import { IPlotlyProperty } from "@responsible-ai/mlchartlib";
 
@@ -12,8 +13,10 @@ export function getDatasetScatterOption(
   chartProps?: IGenericChartProps
 ): any {
   const dataSeries = getDatasetScatter(jointData, plotlyProps, chartProps);
+  const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "scatter"
     },
     plotOptions: {

--- a/libs/dataset-explorer/src/lib/DataBalanceView/DistributionBalanceMeasuresChart.tsx
+++ b/libs/dataset-explorer/src/lib/DataBalanceView/DistributionBalanceMeasuresChart.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Stack } from "@fluentui/react";
+import { Stack, getTheme } from "@fluentui/react";
 import {
   BasicHighChart,
   HeaderWithInfo,
@@ -185,9 +185,11 @@ export class DistributionBalanceMeasuresChart extends React.PureComponent<
         }
       }
     );
+    const theme = getTheme();
 
     return {
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         numberFormatter: (value: number): string => value.toFixed(3),
         type: "column"
       },

--- a/libs/dataset-explorer/src/lib/DataBalanceView/getFeatureBalanceMeasuresChart.ts
+++ b/libs/dataset-explorer/src/lib/DataBalanceView/getFeatureBalanceMeasuresChart.ts
@@ -169,6 +169,7 @@ export function getFeatureBalanceMeasuresChart(
 
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       numberFormatter: (value: number): string => value.toFixed(3),
       type: "heatmap"
     },

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/BarChart/getTokenImportancesChartOptions.ts
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/BarChart/getTokenImportancesChartOptions.ts
@@ -75,6 +75,7 @@ export function getTokenImportancesChartOptions(
   ];
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: "bar"
     },
     plotOptions: {

--- a/libs/interpret/src/lib/MLIDashboard/utils/getIceChartOption.ts
+++ b/libs/interpret/src/lib/MLIDashboard/utils/getIceChartOption.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { getTheme } from "@fluentui/react";
 import {
   IExplanationModelMetadata,
   isTwoDimArray,
@@ -92,8 +93,10 @@ export function getIceChartOption(
       name: d.name
     };
   });
+  const theme = getTheme();
   return {
     chart: {
+      backgroundColor: theme.semanticColors.bodyBackground,
       type: rangeType === RangeTypes.Categorical ? "scatter" : ""
     },
     plotOptions: {

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LocalImportanceChart.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView/LargeIndividualFeatureImportanceView/LocalImportanceChart.tsx
@@ -228,15 +228,17 @@ export class LocalImportanceChart extends React.PureComponent<
         this.props.weightLabels[this.props.selectedWeightVector];
       yAxisLabels = yAxisLabels.concat(" - ", weightLabel);
     }
+    const theme = getTheme();
     const seriesData = [
       {
-        color: getPrimaryChartColor(getTheme()),
+        color: getPrimaryChartColor(theme),
         data: y,
         name: ""
       }
     ];
     return {
       chart: {
+        backgroundColor: theme.semanticColors.bodyBackground,
         type: "column"
       },
       series: seriesData,


### PR DESCRIPTION
explicitly set highchart background color to semantic body background 

## Description
explicitly set highchart background color to semantic body background to align with fluent ui v2 upgrades 
to address this bug: [Bug 2306817](https://msdata.visualstudio.com/Vienna/_workitems/edit/2306817): [FluentV2Wave1] Tables and other UI elements in RAI dashboard have strange white/transparent color with new fluentui

See gif below in comments (file was too large). Follow up bug for the background not updating with the theme:
[Bug 2324252](https://msdata.visualstudio.com/Vienna/_workitems/edit/2324252): changing theme doesn't update background color when running locally
## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
