### PR TITLE
add EBM and LightGBM with TreeShap methods to calculate error correlation in error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/constants.py
+++ b/erroranalysis/erroranalysis/_internal/constants.py
@@ -124,6 +124,16 @@ class TreeNode(str, Enum):
     METRIC_VALUE = MetricKeys.METRIC_VALUE.value
 
 
+class ErrorCorrelationMethods(str, Enum):
+    """Provide the supported error correlation methods.
+
+    The supported methods are 'mutual_info', 'ebm' and 'gbm_shap'.
+    """
+    MUTUAL_INFO = 'mutual_info'
+    EBM = 'ebm'
+    GBM_SHAP = 'gbm_shap'
+
+
 metric_to_display_name = {
     Metrics.ACCURACY_SCORE: 'Accuracy score',
     Metrics.MEAN_PREDICTION: 'Mean prediction',

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -10,7 +10,8 @@ import pandas as pd
 from sklearn.feature_selection import (mutual_info_classif,
                                        mutual_info_regression)
 
-from erroranalysis._internal.constants import (MatrixParams, Metrics,
+from erroranalysis._internal.constants import (ErrorCorrelationMethods,
+                                               MatrixParams, Metrics,
                                                ModelTask, RootKeys,
                                                metric_to_display_name)
 from erroranalysis._internal.matrix_filter import \
@@ -25,11 +26,14 @@ from erroranalysis._internal.surrogate_error_tree import \
     compute_error_tree_on_dataset as _compute_error_tree_on_dataset
 from erroranalysis._internal.utils import generate_random_unique_indexes
 from erroranalysis._internal.version_checker import check_pandas_version
+from erroranalysis.error_correlation_methods import (
+    compute_ebm_global_importance, compute_gbm_global_importance)
 from erroranalysis.report import ErrorReport
 
 BIN_THRESHOLD = MatrixParams.BIN_THRESHOLD
 IMPORTANCES_THRESHOLD = 50000
 ROOT_COVERAGE = 100
+MUTUAL_INFO = ErrorCorrelationMethods.MUTUAL_INFO.value
 
 
 class BaseAnalyzer(ABC):
@@ -372,7 +376,8 @@ class BaseAnalyzer(ABC):
                             num_leaves=None,
                             min_child_samples=None,
                             compute_importances=False,
-                            compute_root_stats=False):
+                            compute_root_stats=False,
+                            error_correlation_method=MUTUAL_INFO):
         """Creates the error analysis ErrorReport.
 
         The ErrorReport contains the importances, heatmap and tree view json.
@@ -409,7 +414,7 @@ class BaseAnalyzer(ABC):
                                          None)
         importances = None
         if compute_importances:
-            importances = self.compute_importances()
+            importances = self.compute_importances(error_correlation_method)
         root_stats = None
         if compute_root_stats:
             root_stats = self.compute_root_stats()
@@ -419,7 +424,7 @@ class BaseAnalyzer(ABC):
                            importances=importances,
                            root_stats=root_stats)
 
-    def compute_importances(self):
+    def compute_importances(self, error_correlation_method=MUTUAL_INFO):
         """Compute the importances or correlation between features and error.
 
         Computes the feature importances or the correlation between
@@ -428,6 +433,8 @@ class BaseAnalyzer(ABC):
         uses the scikit-learn methods mutual_info_classif for classification
         and mutual_info_regression for regression tasks.
 
+        :param error_correlation_method: Method to compute error correlation.
+        :type error_correlation_method: str
         :return: The computed importances or correlation between the
             features and error.
         :rtype: list[float]
@@ -451,24 +458,29 @@ class BaseAnalyzer(ABC):
             input_data = input_data[indexes]
             diff = diff[indexes]
         try:
-            importances = self._compute_mutual_info(input_data, diff)
+            importances = self._compute_error_correlation(
+                input_data, diff, error_correlation_method)
         except ValueError:
             # Impute input_data if it contains NaNs, infinity or a value too
             # large for dtype('float64')
             input_data = np.nan_to_num(input_data)
-            importances = self._compute_mutual_info(input_data, diff)
+            importances = self._compute_error_correlation(
+                input_data, diff, error_correlation_method)
         return importances
 
-    def _compute_mutual_info(self, input_data, diff):
-        """Compute the mutual information between the features and error.
+    def _compute_error_correlation(self, input_data, diff,
+                                   error_correlation_method):
+        """Compute the correlation between the features and error.
 
-        :param input_data: The input data to compute the mutual information
+        :param input_data: The input data to compute the error correlation
             on.
         :type input_data: numpy.ndarray
         :param diff: The difference between the label and prediction
             columns.
         :type diff: numpy.ndarray
-        :return: The computed mutual information between the features and
+        :param error_correlation_method: Method to compute error correlation.
+        :type error_correlation_method: str
+        :return: The computed error correlation between the features and
             error.
         :rtype: list[float]
         """
@@ -476,13 +488,20 @@ class BaseAnalyzer(ABC):
         if input_data.shape[0] == 1:
             input_data = np.concatenate((input_data, input_data))
             diff = np.concatenate((diff, diff))
-        n_neighbors = min(3, input_data.shape[0] - 1)
-        if self._model_task == ModelTask.CLASSIFICATION:
-            return mutual_info_classif(
-                input_data, diff, n_neighbors=n_neighbors).tolist()
+        if error_correlation_method == ErrorCorrelationMethods.MUTUAL_INFO:
+            n_neighbors = min(3, input_data.shape[0] - 1)
+            if self._model_task == ModelTask.CLASSIFICATION:
+                return mutual_info_classif(
+                    input_data, diff, n_neighbors=n_neighbors).tolist()
+            else:
+                return mutual_info_regression(
+                    input_data, diff, n_neighbors=n_neighbors).tolist()
+        elif error_correlation_method == ErrorCorrelationMethods.EBM:
+            return compute_ebm_global_importance(
+                input_data, diff, self._model_task)
         else:
-            return mutual_info_regression(
-                input_data, diff, n_neighbors=n_neighbors).tolist()
+            return compute_gbm_global_importance(
+                input_data, diff, self._model_task, self._categorical_indexes)
 
     def compute_root_stats(self):
         """Compute the root all data statistics.

--- a/erroranalysis/erroranalysis/error_correlation_methods/__init__.py
+++ b/erroranalysis/erroranalysis/error_correlation_methods/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Module for defining error correlation methods."""
+
+from .ebm import compute_ebm_global_importance
+from .gbm import compute_gbm_global_importance
+
+__all__ = ["compute_ebm_global_importance", "compute_gbm_global_importance"]

--- a/erroranalysis/erroranalysis/error_correlation_methods/ebm.py
+++ b/erroranalysis/erroranalysis/error_correlation_methods/ebm.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Defines the error correlation computation using an EBM."""
+
+try:
+    from interpret.glassbox import (ExplainableBoostingClassifier,
+                                    ExplainableBoostingRegressor)
+    ebm_installed = True
+except ImportError:
+    ebm_installed = False
+
+from erroranalysis._internal.constants import ModelTask
+
+
+def compute_ebm_global_importance(input_data, diff, model_task):
+    """Compute global importance score for EBM between the features and error.
+    :param input_data: The input data to compute the EBM global importance
+        score on.
+    :type input_data: numpy.ndarray
+    :param diff: The difference between the label and prediction
+        columns.
+    :type diff: numpy.ndarray
+    :param model_task: The model task.
+    :type model_task: str
+    :return: The computed EBM global importance score between the features and
+        error.
+    :rtype: list[float]
+    """
+    if not ebm_installed:
+        raise ImportError('EBM is not installed. Please install it by running '
+                          '"pip install interpret"')
+    if model_task == ModelTask.CLASSIFICATION:
+        model = ExplainableBoostingClassifier(interactions=0)
+    else:
+        model = ExplainableBoostingRegressor(interactions=0)
+    model.fit(input_data, diff)
+    ebm_importances = model.term_importances()
+    return ebm_importances.tolist()

--- a/erroranalysis/erroranalysis/error_correlation_methods/gbm.py
+++ b/erroranalysis/erroranalysis/error_correlation_methods/gbm.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Defines the error correlation computation using LightGBM with TreeShap."""
+
+import numpy as np
+import shap
+from lightgbm import LGBMClassifier, LGBMRegressor
+
+from erroranalysis._internal.constants import ModelTask
+
+
+def compute_gbm_global_importance(input_data, diff, model_task,
+                                  categorical_indexes):
+    """Compute global importance score for EBM between the features and error.
+    :param input_data: The input data to compute the EBM global importance
+        score on.
+    :type input_data: numpy.ndarray
+    :param diff: The difference between the label and prediction
+        columns.
+    :type diff: numpy.ndarray
+    :param model_task: The model task.
+    :type model_task: str
+    :return: The computed EBM global importance score between the features and
+        error.
+    :rtype: list[float]
+    """
+    is_classification = model_task == ModelTask.CLASSIFICATION
+    if is_classification:
+        model = LGBMClassifier()
+    else:
+        model = LGBMRegressor()
+    model.fit(input_data, diff, categorical_feature=categorical_indexes)
+    explainer = shap.TreeExplainer(model)
+    shap_values = explainer.shap_values(input_data)
+    shap_mean_abs = np.abs(shap_values).mean(axis=0)
+    if is_classification:
+        shap_mean_abs = shap_mean_abs.mean(axis=0)
+    return shap_mean_abs.tolist()

--- a/erroranalysis/requirements-dev.txt
+++ b/erroranalysis/requirements-dev.txt
@@ -5,3 +5,4 @@ requests==2.25.1
 
 requirements-parser==0.2.0
 rai_test_utils==0.1.0
+interpret-core[required]<=0.3.2


### PR DESCRIPTION
## Description

Allow users to select EBM or LightGBM with TreeShap for the error correlation scores in the feature list panel.
Users will now be able to specify the error_correlation_method parameter, set by default to mutual_info, to be set to ebm or gbm_shap to allow them to compute the error correlations (or feature importances with respect to errors) via the new methods.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
