### PR TITLE
Fix deprecated DataFrame indexer type in Error Analysis package

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -605,7 +605,7 @@ def filter_to_used_features(df, tree):
     """
     features = tree[CACHED_SUBTREE_FEATURES]
     features = features.union({PRED_Y, TRUE_Y, DIFF})
-    return df[features]
+    return df[list(features)]
 
 
 def cache_subtree_features(tree, feature_names, parent=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In latest Pandas version(2.0.0), passing a set as an indexer is deprecated, and will raise an error:
![G S4W55~CZU)UN P3(F3UM](https://user-images.githubusercontent.com/86736305/229166262-88dfb793-2e60-4156-a6d8-ea054706d332.png)

Convert the indexer type to list to accomodate newer versions of Pandas


<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
