### PR TITLE
Move import of `cohort` module from `raiwidgets` to `raituils`

### DIFF
--- a/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-census-classification-model-debugging.ipynb
@@ -196,7 +196,7 @@
    "source": [
     "To use Responsible AI Toolbox, initialize a RAIInsights object upon which different components can be loaded.\n",
     "\n",
-    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.",
+    "RAIInsights accepts the model, the full dataset, the test dataset, the target feature string and the task type string as its arguments.\n",
     "\n",
     "You may also create the `FeatureMetadata` container, identify any feature of your choice as the `identity_feature`, specify a list of strings of categorical feature names via the `categorical_features` parameter, and specify dropped features via the `dropped_features` parameter. The `FeatureMetadata` may also be passed into the `RAIInsights`."
    ]
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
+    "from raiutils.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
     "\n",
     "# Cohort on age and hours-per-week features in the dataset\n",
     "cohort_filter_age = CohortFilter(\n",

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raiwidgets.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
+    "from raitutils.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
     "\n",
     "# Cohort on age and bmi features in the dataset\n",
     "cohort_filter_age = CohortFilter(\n",

--- a/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
+++ b/notebooks/responsibleaidashboard/responsibleaidashboard-diabetes-decision-making.ipynb
@@ -261,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from raitutils.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
+    "from raiutils.cohort import Cohort, CohortFilter, CohortFilterMethods\n",
     "\n",
     "# Cohort on age and bmi features in the dataset\n",
     "cohort_filter_age = CohortFilter(\n",

--- a/raiwidgets/raiwidgets/cohort.py
+++ b/raiwidgets/raiwidgets/cohort.py
@@ -4,12 +4,19 @@
 """Module for defining cohorts in raiwidgets package."""
 
 import json
+import warnings
 from typing import Any, List, Optional
 
 import numpy as np
 import pandas as pd
 
 from responsibleai.exceptions import UserConfigValidationException
+
+warnings.warn(
+    "MODULE-DEPRECATION-WARNING: The module "
+    "raiwidgets.cohort is deprecated and will be removed in a later release. "
+    "Please use raiutils.cohort instead.",
+    DeprecationWarning)
 
 
 class CohortFilterMethods:

--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -8,9 +8,9 @@ import numpy as np
 import pandas as pd
 
 from erroranalysis._internal.constants import ModelTask, display_name_to_metric
+from raiutils.cohort import Cohort
 from raiutils.data_processing import convert_to_list, serialize_json_safe
 from raiutils.models import is_classifier
-from raiutils.cohort import Cohort
 from raiwidgets.constants import ErrorMessages
 from raiwidgets.error_handling import _format_exception
 from raiwidgets.interfaces import WidgetRequestResponseConstants

--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -10,7 +10,7 @@ import pandas as pd
 from erroranalysis._internal.constants import ModelTask, display_name_to_metric
 from raiutils.data_processing import convert_to_list, serialize_json_safe
 from raiutils.models import is_classifier
-from raiwidgets.cohort import Cohort
+from raiutils.cohort import Cohort
 from raiwidgets.constants import ErrorMessages
 from raiwidgets.error_handling import _format_exception
 from raiwidgets.interfaces import WidgetRequestResponseConstants

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
@@ -8,7 +8,7 @@ import pytest
 
 from raiutils.data_processing import serialize_json_safe
 from raiwidgets import ResponsibleAIDashboard
-from raiwidgets.cohort import Cohort, CohortFilter, CohortFilterMethods
+from raiutils.cohort import Cohort, CohortFilter, CohortFilterMethods
 from raiwidgets.dashboard import invalid_feature_flights_error
 from responsibleai._interfaces import (CausalData, CounterfactualData, Dataset,
                                        ErrorAnalysisData, ModelExplanationData)

--- a/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/responsibleai_dashboard/test_responsibleai_dashboard.py
@@ -6,9 +6,9 @@ import re
 
 import pytest
 
+from raiutils.cohort import Cohort, CohortFilter, CohortFilterMethods
 from raiutils.data_processing import serialize_json_safe
 from raiwidgets import ResponsibleAIDashboard
-from raiutils.cohort import Cohort, CohortFilter, CohortFilterMethods
 from raiwidgets.dashboard import invalid_feature_flights_error
 from responsibleai._interfaces import (CausalData, CounterfactualData, Dataset,
                                        ErrorAnalysisData, ModelExplanationData)


### PR DESCRIPTION
## Description

Move import of `cohort` module from `raiwidgets` to `raituils` and add deprecation message in `raiwidgets.cohort` module.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
