### PR TITLE
Update explanation-dashboard-employee-attrition.ipynb to remove deprecated `iteritems()` and use `items()` instead

### DIFF
--- a/notebooks/individual-dashboards/explanation-dashboard/explanation-dashboard-employee-attrition.ipynb
+++ b/notebooks/individual-dashboards/explanation-dashboard/explanation-dashboard-employee-attrition.ipynb
@@ -125,7 +125,7 @@
    "source": [
     "# Creating dummy columns for each categorical feature\n",
     "categorical = []\n",
-    "for col, value in attritionXData.iteritems():\n",
+    "for col, value in attritionXData.items():\n",
     "    if value.dtype == 'object':\n",
     "        categorical.append(col)\n",
     "        \n",


### PR DESCRIPTION
## Description

Update explanation-dashboard-employee-attrition.ipynb to remove deprecated `iteritems()` and use `items()` instead

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
