### PR TITLE
Null Error Analysis Attribute Fix

### DIFF
--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -48,7 +48,8 @@ class ResponsibleAIDashboardInput:
             self.dashboard_input.cohortData = []
 
         self._feature_length = len(self.dashboard_input.dataset.feature_names)
-        if hasattr(analysis, ManagerNames.ERROR_ANALYSIS):
+        if (hasattr(analysis, ManagerNames.ERROR_ANALYSIS)
+           and analysis.error_analysis is not None):
             self._error_analyzer = analysis.error_analysis._analyzer
 
     def _validate_cohort_list(self, cohort_list=None):


### PR DESCRIPTION
A recent PR added error analysis for vision: https://msdata.visualstudio.com/DefaultCollection/Vienna/_git/responsibleai/commit/40024c11ba423920f93c542fc72508440516a056?refName=refs/heads/nisak/dpv2_precomp_expl_v2&path=/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py

However, the raiwidget package assumed that if the error_analysis attribute existed, it must be non None. This is not the case for all vision scenarios (yet), so this fix ensures that the e2e flow remains intact. 