### PR TITLE
fix failing builds by upgrading pip-tools after latest pip release

### DIFF
--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade "pip-tools<6.12.2"
+          pip install --upgrade "pip-tools<=6.13.0"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade "pip-tools<6.12.2"
+          pip install --upgrade "pip-tools<=6.13.0"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -29,6 +29,8 @@ jobs:
             pythonVersion: "3.8"
           - operatingSystem: ubuntu-20.04
             pythonVersion: "3.9"
+          - operatingSystem: ubuntu-20.04
+            pythonVersion: "3.10"
           - operatingSystem: ubuntu-latest
             pythonVersion: "3.6"
 
@@ -50,23 +52,23 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade "pip-tools<6.12.2"
+          pip install --upgrade "pip-tools<=6.13.0"
 
       - name: Pip compile
         run: |
-          pip-compile requirements-dev.txt
-          cat requirements-dev.txt
+          pip-compile requirements-dev.txt -o requirements-dev-comp.txt
+          cat requirements-dev-comp.txt
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload requirements
         uses: actions/upload-artifact@v3
         with:
-          name: requirements-dev.txt
-          path: ${{ matrix.packageDirectory }}/requirements-dev.txt
+          name: requirements-dev-comp.txt
+          path: ${{ matrix.packageDirectory }}/requirements-dev-comp.txt
 
       - name: Install dependencies
         run: |
-          pip-sync requirements-dev.txt
+          pip-sync requirements-dev-comp.txt
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Install package

--- a/.github/workflows/CI-rai_core_flask-pytest.yml
+++ b/.github/workflows/CI-rai_core_flask-pytest.yml
@@ -28,6 +28,8 @@ jobs:
             pythonVersion: "3.8"
           - operatingSystem: ubuntu-20.04
             pythonVersion: "3.9"
+          - operatingSystem: ubuntu-20.04
+            pythonVersion: "3.10"
           - operatingSystem: ubuntu-latest
             pythonVersion: "3.6"
           - operatingSystem: ubuntu-latest
@@ -49,23 +51,23 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade "pip-tools<6.12.2"
+          pip install --upgrade "pip-tools<=6.13.0"
 
       - name: Pip compile
         run: |
-          pip-compile requirements-dev.txt
-          cat requirements-dev.txt
+          pip-compile requirements-dev.txt -o requirements-dev-comp.txt
+          cat requirements-dev-comp.txt
         working-directory: rai_core_flask
 
       - name: Upload requirements
         uses: actions/upload-artifact@v3
         with:
-          name: requirements-dev.txt
-          path: rai_core_flask/requirements-dev.txt
+          name: requirements-dev-comp.txt
+          path: rai_core_flask/requirements-dev-comp.txt
 
       - name: Install dependencies
         run: |
-          pip-sync requirements-dev.txt
+          pip-sync requirements-dev-comp.txt
         working-directory: rai_core_flask
 
       - name: Install package

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools
-          pip install --upgrade "pip-tools<6.12.2"
+          pip install --upgrade "pip-tools<=6.13.0"
 
       - name: Install dependencies
         shell: bash -l {0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Latest builds are failing with error:

```
in get_dependencies
    wheel_cache = WheelCache(self._cache_dir, self.options.format_control)
TypeError: __init__() takes 2 positional arguments but 3 were given
```

The latest pip release broke compatibility with old pip-tools.  Solution seems to be to upgrade pip-tools since we are pinned to an old version currently.

See related issue: https://github.com/jazzband/pip-tools/issues/1823

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
