### PR TITLE
responsibleai: Add test case for dataset having boolean features

### DIFF
--- a/responsibleai/tests/rai_insights/test_rai_insights.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights.py
@@ -115,12 +115,19 @@ class TestRAIInsights(object):
                                               ManagerNames.ERROR_ANALYSIS,
                                               ManagerNames.EXPLAINER,
                                               ManagerNames.COUNTERFACTUAL])
-    def test_rai_insights_binary_mixed_types(self, manager_type):
+    @pytest.mark.parametrize('add_boolean', [True, False])
+    def test_rai_insights_binary_mixed_types(self, manager_type, add_boolean):
 
         data_train, data_test, y_train, y_test, categorical_features, \
             continuous_features, target_name, classes, \
             feature_columns, feature_range_keys = \
             create_adult_income_dataset()
+
+        if add_boolean:
+            data_train['is_adult'] = data_train['age'] >= 18
+            data_test['is_adult'] = data_test['age'] >= 18
+            categorical_features = categorical_features + ['is_adult']
+
         X_train = data_train.drop([target_name], axis=1)
 
         model = create_complex_classification_pipeline(


### PR DESCRIPTION
## Description
responsibleai: Add test case for dataset having boolean features. There was a customer who was facing issue with dataset having boolean features. Adding a test for boolean feature as it doesn't exist right now.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
