### PR TITLE
remove QA statistics which were mistakenly added to multilabel metrics

### DIFF
--- a/libs/core-ui/src/lib/util/MultilabelStatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/MultilabelStatisticsUtils.ts
@@ -11,13 +11,8 @@ import {
 import { JointDataset } from "./JointDataset";
 
 export enum MultilabelMetrics {
-  BleuScore = "bleuScore",
   ExactMatchRatio = "exactMatchRatio",
-  HammingScore = "hammingScore",
-  F1Score = "f1Score",
-
-  MeteorScore = "meteorScore",
-  RougeScore = "rougeScore"
+  HammingScore = "hammingScore"
 }
 
 export const generateMultilabelStats: (
@@ -55,10 +50,6 @@ export const generateMultilabelStats: (
     hammingScore = hammingScore / numLabels;
     const sum = matchingLabels.reduce((prev, curr) => prev + curr, 0);
     const exactMatchRatio = sum / (numLabels * selectionArray.length);
-    const meteorScore = 0;
-    const f1Score = 0;
-    const rougeScore = 0;
-    const bleuScore = 0;
 
     return [
       {
@@ -70,26 +61,6 @@ export const generateMultilabelStats: (
         key: MultilabelMetrics.ExactMatchRatio,
         label: localization.Interpret.Statistics.exactMatchRatio,
         stat: exactMatchRatio
-      },
-      {
-        key: MultilabelMetrics.MeteorScore,
-        label: localization.Interpret.Statistics.meteorScore,
-        stat: meteorScore
-      },
-      {
-        key: MultilabelMetrics.F1Score,
-        label: localization.Interpret.Statistics.f1Score,
-        stat: f1Score
-      },
-      {
-        key: MultilabelMetrics.BleuScore,
-        label: localization.Interpret.Statistics.bleuScore,
-        stat: bleuScore
-      },
-      {
-        key: MultilabelMetrics.RougeScore,
-        label: localization.Interpret.Statistics.rougeScore,
-        stat: rougeScore
       },
       {
         key: MultilabelMetrics.HammingScore,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -153,11 +153,7 @@ export class ModelOverview extends React.Component<
     ) {
       defaultSelectedMetrics = [
         MultilabelMetrics.ExactMatchRatio,
-        MultilabelMetrics.HammingScore,
-        MultilabelMetrics.MeteorScore,
-        MultilabelMetrics.BleuScore,
-        MultilabelMetrics.F1Score,
-        MultilabelMetrics.RougeScore
+        MultilabelMetrics.HammingScore
       ];
     } else if (
       this.context.dataset.task_type === DatasetTaskType.ObjectDetection
@@ -172,7 +168,9 @@ export class ModelOverview extends React.Component<
     ) {
       defaultSelectedMetrics = [
         QuestionAnsweringMetrics.ExactMatchRatio,
-        QuestionAnsweringMetrics.F1Score
+        QuestionAnsweringMetrics.MeteorScore,
+        QuestionAnsweringMetrics.BleuScore,
+        QuestionAnsweringMetrics.RougeScore
       ];
     } else {
       // task_type === "regression"

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -13,7 +13,8 @@ import {
   MultilabelMetrics,
   ObjectDetectionMetrics,
   RegressionMetrics,
-  TotalCohortSamples
+  TotalCohortSamples,
+  QuestionAnsweringMetrics
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { PointOptionsObject } from "highcharts";
@@ -399,35 +400,6 @@ export function getSelectableMetrics(
       },
       {
         description:
-          localization.ModelAssessment.ModelOverview.metrics.meteorScore
-            .description,
-        key: MultilabelMetrics.MeteorScore,
-        text: localization.ModelAssessment.ModelOverview.metrics.meteorScore
-          .name
-      },
-      {
-        description:
-          localization.ModelAssessment.ModelOverview.metrics.f1Score
-            .description,
-        key: MultilabelMetrics.F1Score,
-        text: localization.ModelAssessment.ModelOverview.metrics.f1Score.name
-      },
-      {
-        description:
-          localization.ModelAssessment.ModelOverview.metrics.bleuScore
-            .description,
-        key: MultilabelMetrics.BleuScore,
-        text: localization.ModelAssessment.ModelOverview.metrics.bleuScore.name
-      },
-      {
-        description:
-          localization.ModelAssessment.ModelOverview.metrics.rougeScore
-            .description,
-        key: MultilabelMetrics.RougeScore,
-        text: localization.ModelAssessment.ModelOverview.metrics.rougeScore.name
-      },
-      {
-        description:
           localization.ModelAssessment.ModelOverview.metrics.hammingScore
             .description,
         key: MultilabelMetrics.HammingScore,
@@ -468,7 +440,7 @@ export function getSelectableMetrics(
         description:
           localization.ModelAssessment.ModelOverview.metrics.exactMatchRatio
             .description,
-        key: MultilabelMetrics.ExactMatchRatio,
+        key: QuestionAnsweringMetrics.ExactMatchRatio,
         text: localization.ModelAssessment.ModelOverview.metrics.exactMatchRatio
           .name
       },
@@ -476,7 +448,7 @@ export function getSelectableMetrics(
         description:
           localization.ModelAssessment.ModelOverview.metrics.meteorScore
             .description,
-        key: MultilabelMetrics.MeteorScore,
+        key: QuestionAnsweringMetrics.MeteorScore,
         text: localization.ModelAssessment.ModelOverview.metrics.meteorScore
           .name
       },
@@ -484,21 +456,21 @@ export function getSelectableMetrics(
         description:
           localization.ModelAssessment.ModelOverview.metrics.f1Score
             .description,
-        key: MultilabelMetrics.F1Score,
+        key: QuestionAnsweringMetrics.F1Score,
         text: localization.ModelAssessment.ModelOverview.metrics.f1Score.name
       },
       {
         description:
           localization.ModelAssessment.ModelOverview.metrics.bleuScore
             .description,
-        key: MultilabelMetrics.BleuScore,
+        key: QuestionAnsweringMetrics.BleuScore,
         text: localization.ModelAssessment.ModelOverview.metrics.bleuScore.name
       },
       {
         description:
           localization.ModelAssessment.ModelOverview.metrics.rougeScore
             .description,
-        key: MultilabelMetrics.RougeScore,
+        key: QuestionAnsweringMetrics.RougeScore,
         text: localization.ModelAssessment.ModelOverview.metrics.rougeScore.name
       }
     );

--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -97,7 +97,7 @@ class ResponsibleAIDashboard(Dashboard):
             data = request.get_json(force=True)
             return jsonify(self.input.get_question_answering_metrics(data))
         self.add_url_rule(
-            get_exp,
+            get_question_answering_metrics,
             '/get_question_answering_metrics',
             methods=["POST"]
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR to add new statistics for QA task:
https://github.com/microsoft/responsible-ai-toolbox/pull/2034
It looks like some QA metrics were mistakenly added for multilabel text and vision scenarios.
This PR removes these metrics, which currently just show dummy zero values.

![image](https://user-images.githubusercontent.com/24683184/235700965-43a6a03a-ff89-4fe1-9dc7-f8e49fcd4e9e.png)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
