### PR TITLE
Prevent overwriting of dataset in `erroranalysis`

### DIFF
--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -302,7 +302,7 @@ def get_surrogate_booster_local(filtered_df, analyzer, is_model_analyzer,
     if is_pandas:
         true_y = true_y.to_numpy()
     else:
-        input_data = input_data.to_numpy()
+        input_data = input_data.to_numpy(copy=True)
     if is_model_analyzer:
         pred_y = analyzer.model.predict(input_data)
     if analyzer.model_task == ModelTask.CLASSIFICATION:
@@ -316,7 +316,7 @@ def get_surrogate_booster_local(filtered_df, analyzer, is_model_analyzer,
     if not isinstance(true_y, np.ndarray):
         true_y = np.array(true_y)
     if is_pandas:
-        input_data = input_data.to_numpy()
+        input_data = input_data.to_numpy(copy=True)
 
     if analyzer.categorical_features:
         # Inplace replacement of columns

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -442,7 +442,7 @@ class BaseAnalyzer(ABC):
         input_data = self.dataset
         diff = self.get_diff()
         if isinstance(self.dataset, pd.DataFrame):
-            input_data = input_data.to_numpy()
+            input_data = input_data.to_numpy(copy=True)
         if self.categorical_features:
             # Inplace replacement of columns
             indexes = self.categorical_indexes

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -11,9 +11,12 @@ from erroranalysis._internal.error_analyzer import ModelAnalyzer
 from erroranalysis._internal.error_report import ErrorReport
 from rai_test_utils.datasets.tabular import (create_cancer_data,
                                              create_housing_data,
-                                             create_iris_data)
+                                             create_iris_data,
+                                             create_simple_titanic_data)
 from rai_test_utils.models.model_utils import (create_models_classification,
                                                create_models_regression)
+from rai_test_utils.models.sklearn import \
+    create_complex_classification_pipeline
 
 
 class TestErrorReport(object):
@@ -78,6 +81,22 @@ class TestErrorReport(object):
             run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features,
                                filter_features=filter_features)
+
+    def test_error_report_titanic(self):
+        X_train, X_test, y_train, y_test, numeric, categorical = \
+            create_simple_titanic_data()
+
+        # Drop all numeric features
+        X_train = X_train.drop(['pclass', 'age', 'fare'], axis=1)
+        X_test = X_test.drop(['pclass', 'age', 'fare'], axis=1)
+
+        clf = create_complex_classification_pipeline(
+            X_train, y_train, [], ['embarked', 'sex'])
+
+        # Pass the remaining categorical features
+        run_error_analyzer(clf, X_test, y_test, ['embarked', 'sex'],
+                           ['embarked', 'sex'],
+                           filter_features=[])
 
 
 def is_valid_uuid(id):


### PR DESCRIPTION
## Description

Fix overwriting of dataset in `erroranalysis`. This overwriting only happens in case there are only categorical features in the dataset. It doesn't trigger in case there only numerical features or mix of numerical and categorical features.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
