### PR TITLE
Fix robot page exception on feature importance when dropped_feature is defined

### DIFF
--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -554,8 +554,18 @@ export class GlobalExplanationTab extends React.PureComponent<
     if (typeof item?.key === "string") {
       const key = item.key;
       const index = this.context.jointDataset.metaDict[key].index;
-      if (index !== undefined) {
-        this.handleFeatureSelection(this.state.selectedCohortIndex, index);
+      let indexAfterDrop;
+      for (const i of this.featureIndexMap.keys()) {
+        if (index && this.featureIndexMap.get(i) === index) {
+          indexAfterDrop = i;
+          break;
+        }
+      }
+      if (indexAfterDrop !== undefined) {
+        this.handleFeatureSelection(
+          this.state.selectedCohortIndex,
+          indexAfterDrop
+        );
       }
     }
   };
@@ -589,8 +599,7 @@ export class GlobalExplanationTab extends React.PureComponent<
     const xIsDithered =
       this.context.jointDataset.metaDict[xKey]?.treatAsCategorical;
     const yKey =
-      JointDataset.ReducedLocalImportanceRoot +
-      featureIndexBeforeDrop.toString();
+      JointDataset.ReducedLocalImportanceRoot + featureIndex.toString();
     const chartProps: IGenericChartProps = {
       chartType: ChartTypes.Scatter,
       xAxis: {

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -554,18 +554,11 @@ export class GlobalExplanationTab extends React.PureComponent<
     if (typeof item?.key === "string") {
       const key = item.key;
       const index = this.context.jointDataset.metaDict[key].index;
-      let indexAfterDrop;
       for (const i of this.featureIndexMap.keys()) {
         if (index && this.featureIndexMap.get(i) === index) {
-          indexAfterDrop = i;
+          this.handleFeatureSelection(this.state.selectedCohortIndex, i);
           break;
         }
-      }
-      if (indexAfterDrop !== undefined) {
-        this.handleFeatureSelection(
-          this.state.selectedCohortIndex,
-          indexAfterDrop
-        );
       }
     }
   };


### PR DESCRIPTION
This PR fixes the bug where the index for x axis and y axisfor feature importances plot was not correctly set when dropped_feature has length > 0.

## Description
There are two issues:
1) y axis: Feature importances are only calculated for non-dropped features. So we should pass featureIndex instead of featureIndexBeforeDrop to yKey (change on line 602)
2) x axis: this.handleFeatureSelection is a shared method for both <FeatureImportanceBar/> and FeatureOptions' <ComboBox/>. We should pass indexAfterDrop to this.handleFeatureSelection method. 
![feautureImportanceRobotPage](https://user-images.githubusercontent.com/91754176/236070980-8f5c4fc6-6a65-40a3-8cd4-20d4e81abafc.gif)

## Checklist

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
