### PR TITLE
fix multilabel RAI Vision Dashboard table view labels squished

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
@@ -245,10 +245,14 @@ export class TableList extends React.Component<
   ): React.ReactNode => {
     const classNames = visionExplanationDashboardStyles();
 
-    const value =
+    let value =
       item && column && column.fieldName
         ? item[column.fieldName as keyof IVisionListItem]
         : "";
+    // Handle multilabel case for trueY and predictedY
+    if (value && Array.isArray(value)) {
+      value = value.join(", ");
+    }
 
     const image =
       item && column && column.fieldName === "image"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix multilabel RAI Vision Dashboard table view labels squished

before:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/fab9dd64-9349-4c42-8731-d1ff4351ebbe)


after:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/6e475a26-38d6-4c08-a5ba-737e6f1bcb57)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
