### PR TITLE
Add `is_valid_uuid` to `rai_test_utils`

### DIFF
--- a/rai_test_utils/rai_test_utils/utilities/__init__.py
+++ b/rai_test_utils/rai_test_utils/utilities/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Namespace for utility functions used in tests."""
+
+from .utils import is_valid_uuid
+
+__all__ = [
+    "is_valid_uuid"
+]

--- a/rai_test_utils/rai_test_utils/utilities/utils.py
+++ b/rai_test_utils/rai_test_utils/utilities/utils.py
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import uuid
+
+
+def is_valid_uuid(id: str):
+    """Check if the given id is a valid uuid.
+
+    :param id: The id to check.
+    :type id: str
+    :return: True if the id is a valid uuid, False otherwise.
+    :rtype: bool
+    """
+    try:
+        uuid.UUID(str(id))
+        return True
+    except ValueError:
+        return False

--- a/rai_test_utils/tests/test_utils.py
+++ b/rai_test_utils/tests/test_utils.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from rai_test_utils.utilities import is_valid_uuid
+
+
+class TestUtils:
+    def test_is_valid_uuid(self):
+        assert is_valid_uuid("123e4567-e89b-12d3-a456-426614174000")
+        assert not is_valid_uuid("123e4567-e89b-12d3-a456-42661417400")
+        assert not is_valid_uuid("123e4567-e89b-12d3-a456-42661417400g")
+        assert not is_valid_uuid("123e4567-e89b-12d3-a456-42661417400-")
+        assert not is_valid_uuid("123e4567-e89b-12d3-a456-42661417400-143")


### PR DESCRIPTION
## Description

Looks like we try to validate if a string is a valid UUID in our tests. So adding `is_valid_uuid` to `rai_test_utils` to import from one common place.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
