### PR TITLE
fix multilabel erroranalysis metrics dropdown appearing blank

### DIFF
--- a/apps/dashboard/src/app/textApplications.ts
+++ b/apps/dashboard/src/app/textApplications.ts
@@ -8,7 +8,10 @@ import {
   blbooksgenre,
   blbooksgenreModelExplanationData
 } from "../model-assessment-text/__mock_data__/blbooksgenre";
-import { covid19events } from "../model-assessment-text/__mock_data__/covidevents";
+import {
+  covid19events,
+  covidEventsErrorAnalysisData
+} from "../model-assessment-text/__mock_data__/covidevents";
 import {
   emotion,
   emotionModelExplanationData
@@ -51,7 +54,8 @@ export const textApplications: ITextApplications = <const>{
       } as IModelAssessmentDataSet,
       covid19events: {
         classDimension: 3,
-        dataset: covid19events
+        dataset: covid19events,
+        errorAnalysisData: [covidEventsErrorAnalysisData]
       } as IModelAssessmentDataSet,
       emotion: {
         classDimension: 3,

--- a/apps/dashboard/src/model-assessment-text/__mock_data__/covidevents.ts
+++ b/apps/dashboard/src/model-assessment-text/__mock_data__/covidevents.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DatasetTaskType, IDataset } from "@responsible-ai/core-ui";
+import {
+  DatasetTaskType,
+  IDataset,
+  IErrorAnalysisData
+} from "@responsible-ai/core-ui";
 
 export const covid19events: IDataset = {
   categorical_features: [],
@@ -680,5 +684,117 @@ export const covid19events: IDataset = {
     [0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 1, 0, 0, 0, 0, 1],
     [1, 0, 0, 0, 0, 0, 0, 0]
+  ]
+};
+
+export const covidEventsErrorAnalysisData: IErrorAnalysisData = {
+  importances: [0, 0, 0, 0.06568140659494959, 0, 0.0650392307220089],
+  matrix: undefined,
+  maxDepth: 3,
+  metric: "Error rate",
+  minChildSamples: 20,
+  numLeaves: 31,
+  root_stats: {
+    errorCoverage: 100,
+    metricName: "Error rate",
+    metricValue: 30.864197530864196,
+    totalSize: 81
+  },
+  tree: [
+    {
+      arg: undefined,
+      badFeaturesRowCount: 0,
+      condition: "",
+      error: 25,
+      id: 0,
+      isErrorMetric: true,
+      method: "",
+      metricName: "Error rate",
+      metricValue: 0.30864197530864196,
+      nodeIndex: 0,
+      nodeName: "positive_words",
+      parentId: undefined,
+      parentNodeName: "",
+      pathFromRoot: "",
+      size: 81,
+      sourceRowKeyHash: "hashkey",
+      success: 56
+    },
+    {
+      arg: 7.500000000000001,
+      badFeaturesRowCount: 0,
+      condition: "positive_words <= 7.50",
+      error: 5,
+      id: 2,
+      isErrorMetric: true,
+      method: "less and equal",
+      metricName: "Error rate",
+      metricValue: 0.19230769230769232,
+      nodeIndex: 2,
+      nodeName: "",
+      parentId: 0,
+      parentNodeName: "positive_words",
+      pathFromRoot: "",
+      size: 26,
+      sourceRowKeyHash: "hashkey",
+      success: 21
+    },
+    {
+      arg: 7.500000000000001,
+      badFeaturesRowCount: 0,
+      condition: "positive_words > 7.50",
+      error: 20,
+      id: 1,
+      isErrorMetric: true,
+      method: "greater",
+      metricName: "Error rate",
+      metricValue: 0.36363636363636365,
+      nodeIndex: 1,
+      nodeName: "sentence_length",
+      parentId: 0,
+      parentNodeName: "positive_words",
+      pathFromRoot: "",
+      size: 55,
+      sourceRowKeyHash: "hashkey",
+      success: 35
+    },
+    {
+      arg: 287.50000000000006,
+      badFeaturesRowCount: 0,
+      condition: "sentence_length <= 287.50",
+      error: 11,
+      id: 3,
+      isErrorMetric: true,
+      method: "less and equal",
+      metricName: "Error rate",
+      metricValue: 0.3235294117647059,
+      nodeIndex: 3,
+      nodeName: "",
+      parentId: 1,
+      parentNodeName: "sentence_length",
+      pathFromRoot: "",
+      size: 34,
+      sourceRowKeyHash: "hashkey",
+      success: 23
+    },
+    {
+      arg: 287.50000000000006,
+      badFeaturesRowCount: 0,
+      condition: "sentence_length > 287.50",
+      error: 9,
+      id: 4,
+      isErrorMetric: true,
+      method: "greater",
+      metricName: "Error rate",
+      metricValue: 0.42857142857142855,
+      nodeIndex: 4,
+      nodeName: "",
+      parentId: 1,
+      parentNodeName: "sentence_length",
+      pathFromRoot: "",
+      size: 21,
+      sourceRowKeyHash: "hashkey",
+      success: 12
+    }
   ]
 };

--- a/libs/core-ui/src/lib/util/ExplanationUtils.ts
+++ b/libs/core-ui/src/lib/util/ExplanationUtils.ts
@@ -19,6 +19,13 @@ export function IsBinary(modelType: ModelTypes): boolean {
   );
 }
 
+export function IsMultilabel(modelType: ModelTypes): boolean {
+  return (
+    modelType === ModelTypes.ImageMultilabel ||
+    modelType === ModelTypes.TextMultilabel
+  );
+}
+
 export function IsClassifier(modelType: ModelTypes): boolean {
   return (
     modelType === ModelTypes.Binary ||

--- a/libs/core-ui/src/lib/util/datasetUtils/getPropertyValues.ts
+++ b/libs/core-ui/src/lib/util/datasetUtils/getPropertyValues.ts
@@ -4,7 +4,7 @@
 import { DatasetCohortColumns } from "../../DatasetCohortColumns";
 import { IDataset } from "../../Interfaces/IDataset";
 import { ModelTypes } from "../../Interfaces/IExplanationContext";
-import { IsBinary, IsMulticlass } from "../ExplanationUtils";
+import { IsBinary, IsMulticlass, IsMultilabel } from "../ExplanationUtils";
 import { MulticlassClassificationEnum } from "../JointDatasetUtils";
 
 // get property values for the selected data point
@@ -91,7 +91,7 @@ function getErrors(
     if (
       property === DatasetCohortColumns.ClassificationError &&
       modelType &&
-      IsMulticlass(modelType)
+      (IsMulticlass(modelType) || IsMultilabel(modelType))
     ) {
       return indexes.map((index) => {
         return trueY[index] !== predictedY[index]

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MetricSelector/MetricSelector.tsx
@@ -9,6 +9,7 @@ import {
   defaultModelAssessmentContext,
   IsBinary,
   IsMulticlass,
+  IsMultilabel,
   ITelemetryEvent,
   TelemetryLevels,
   TelemetryEventName
@@ -55,6 +56,8 @@ export class MetricSelector extends React.Component<IMetricSelectorProps> {
       options.push(this.addDropdownOption(Metrics.MicroF1Score));
       options.push(this.addDropdownOption(Metrics.MacroF1Score));
       options.push(this.addDropdownOption(Metrics.AccuracyScore));
+    } else if (IsMultilabel(modelType)) {
+      options.push(this.addDropdownOption(Metrics.ErrorRate));
     }
     return (
       <Dropdown

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -42,7 +42,8 @@ import {
   EditCohort,
   ShiftCohort,
   IsBinary,
-  IsMulticlass
+  IsMulticlass,
+  IsMultilabel
 } from "@responsible-ai/core-ui";
 import { DatasetExplorerTab } from "@responsible-ai/dataset-explorer";
 import { GlobalExplanationTab } from "@responsible-ai/interpret";
@@ -202,7 +203,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       );
     } else if (IsBinary(modelType)) {
       classLength = 2;
-    } else if (IsMulticlass(modelType)) {
+    } else if (IsMulticlass(modelType) || IsMultilabel(modelType)) {
       classLength = new Set(
         [...(props.trueY || [])].concat(props.predictedY || [])
       ).size;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For text and vision, the multilabel error analysis dropdown currently appears blank.
Adding just error rate metric for these scenarios.  Although we are treating it as a multiclass tree I thought it would be confusing to add all of the multiclass metrics in this case.

Previous broken blank dropdown:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/7b49ad0a-227c-4263-afb2-d05c74904cd0)


View of fixed dropdown:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/8653beaf-2260-4680-819e-f4b5d18a4856)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
