### PR TITLE
Fix CONTRIBUTING.md regarding e2e testing command and GPG key setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,16 @@ require you to agree to a Contributor License Agreement (CLA) declaring that
 you have the right to, and actually do, grant us the rights to use your
 contribution. For details, visit <https://cla.opensource.microsoft.com>.
 
+Before contributing, please check that you have the correct configurations of
+(1) Contributor License Agreement and (2) GPG key.
+
+(1) Contributor License Agreement
 When you submit a pull request, a CLA bot will automatically determine whether
 you need to provide a CLA and decorate the PR appropriately (e.g., status
 check, comment). Simply follow the instructions provided by the bot. You will
 only need to do this once across all repos using our CLA.
 
-If you have previously committed changes that were not signed follow
-[these steps](https://dev.to/jrushlow/oops-i-forgot-to-sign-my-commit-from-last-monday-2jke)
-to sign them retroactively after setting up your GPG key as described in the
-[GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).
+(2) GPG Key
 
 Setting up a GPG key has three stages:
 
@@ -25,6 +26,12 @@ Setting up a GPG key has three stages:
 
 Note that the `GitBash` shell installed by Git on Windows already has GPG
 installed, so there is no need to install GPG separately.
+
+If you have previously committed changes that were not signed follow
+[these steps](https://dev.to/jrushlow/oops-i-forgot-to-sign-my-commit-from-last-monday-2jke)
+to sign them retroactively after setting up your GPG key as described in the
+[GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).
+
 
 ## Code of conduct
 
@@ -121,7 +128,7 @@ once.
 2. `cd responsible-ai-toolbox`
 3. `yarn install`
 4. `yarn build`
-5. To execute tests run `yarn e2eall`. Sometimes it is preferable to watch the execution and select only individual test cases. This is possible using `yarn e2e --watch`.
+5. To execute tests run `yarn e2e`. Sometimes it is preferable to watch the execution and select only individual test cases. This is possible using `yarn e2e --watch`.
 
 cypress window will open locally - select test file to run the tests
 


### PR DESCRIPTION
1. Fixed CONTRIBUTING.md command for running e2e testing (yarn e2e rather than e2eall)
2. Changed wording regarding setting up GPG key setup to clarify setup is needed even if there is no previously committed unsigned pr

