### PR TITLE
Remove un-needed `requests` dependency

### DIFF
--- a/erroranalysis/requirements-dev.txt
+++ b/erroranalysis/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests==2.25.1
 
 requirements-parser==0.2.0
 rai_test_utils==0.2.0

--- a/rai_core_flask/requirements-dev.txt
+++ b/rai_core_flask/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests==2.25.1
+requests
 
 requirements-parser==0.2.0

--- a/rai_core_flask/requirements-dev.txt
+++ b/rai_core_flask/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests
+requests==2.25.1
 
 requirements-parser==0.2.0

--- a/rai_test_utils/requirements-dev.txt
+++ b/rai_test_utils/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests==2.25.1
 
 requirements-parser==0.2.0
 

--- a/raiutils/requirements-dev.txt
+++ b/raiutils/requirements-dev.txt
@@ -1,7 +1,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests==2.25.1
 
 requirements-parser==0.2.0
 

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -3,7 +3,6 @@
 pytest==7.0.1
 pytest-cov
 pytest-mock==3.6.1
-requests==2.25.1
 
 requirements-parser==0.2.0
 


### PR DESCRIPTION
## Description

Remove un-needed `requests` dependency. Looks like the dependent bot in the repo is flagging the pinned version of `requests`. Examining the code in repo, lot of packages don't use `requests` in tests.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
