### PR TITLE
[Image Explorer] CanvasTools Image Loading support for Object Detection

### DIFF
--- a/apps/dashboard/src/model-assessment-vision/__mock_data__/fridgeObjectDetection.ts
+++ b/apps/dashboard/src/model-assessment-vision/__mock_data__/fridgeObjectDetection.ts
@@ -12,8 +12,8 @@ export const fridgeObjectDetection: IDataset = {
   features: [
     [96.30899737412763],
     [95.32630225415797],
-    [1003762680516188],
-    [92000130390912],
+    [100.3762680516188],
+    [92.000130390912],
     [95.33849179841164]
   ],
   images: fridgeObjectDetectionImages,

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
@@ -94,6 +94,7 @@ export class VisionExplanationDashboard extends React.Component<
         </Stack.Item>
         <Stack.Item>
           <FlyoutObjectDetection
+            dataset={this.context.dataset}
             explanations={this.state.computedExplanations}
             isOpen={this.state.panelOpen}
             item={this.state.selectedItem}

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
@@ -74,7 +74,7 @@ export function preprocessData(
   const trueY = mapClassNames(dataSummary.true_y, classNames);
 
   const features = dataSummary.features?.map((featuresArr) => {
-    return featuresArr[0] as number;
+    return Number((featuresArr[0] as number).toFixed(2));
   });
 
   const fieldNames = dataSummary.feature_names;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "0.13.7",
     "tslib": "^2.5.0",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.0",
+    "vott-ct": "^2.4.2-rc.0"
   },
   "devDependencies": {
     "@babel/core": "7.11.1",


### PR DESCRIPTION
This PR replaces the existing image loading logic in the Flyout (using `<Image>` from FluentUI) to CanvasTools.

## Description

Advantages:
1. Reusability with Data Labeling team's work, which also unlocks loading and overlaying elements on images for CV tasks.
2. Unlocks the potential to draw bounding boxes in the _frontend_, which'll enable _on-the-fly_ functionality of filtering/displaying bounding boxes based on user inputs related to error types, classes etc. Aligned with customer feedback & feature requests.
3. Piggybacks on CanvasTools' accessibility standards (including for overlaid elements)
4. Slightly higher res display compared to `<Image>`


<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/ff6d61b5-8b56-41d9-b581-1988a8245c45)

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/9c4ec240-a589-447d-a29b-df326a9a491d)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
