### PR TITLE
Fix ci-notebook error on failing to retrieve superconduct data zip

### DIFF
--- a/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-superconductor.ipynb
+++ b/notebooks/individual-dashboards/erroranalysis-dashboard/erroranalysis-dashboard-regression-superconductor.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "outdirname = 'superconduct'\n",
     "zipfilename = outdirname + '.zip'\n",
-    "urlretrieve('https://archive.ics.uci.edu/ml/machine-learning-databases/00464/superconduct.zip', zipfilename)\n",
+    "urlretrieve('https://archive.ics.uci.edu/static/public/464/superconductivty+data.zip', zipfilename)\n",
     "with zipfile.ZipFile(zipfilename, 'r') as unzip:\n",
     "    unzip.extractall('.')\n",
     "df = pd.read_csv(r'./train.csv')\n",


### PR DESCRIPTION
The ci-notebook is consistently failing due to 404 error on retrieving the dataset. link to failed build: https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5205027867/jobs/9390580840?pr=2099

## Description

This PR updates the link to download the dataset

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
