### PR TITLE
enable confusion matrix for binary and multiclass text and vision RAI dashboards

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverviewChartPivot.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverviewChartPivot.tsx
@@ -181,8 +181,8 @@ export class ModelOverviewChartPivot extends React.Component<
           />
         </PivotItem>
         {!ifEnableLargeData(this.context.dataset) &&
-          (this.context.modelMetadata.modelType === ModelTypes.Binary ||
-            this.context.modelMetadata.modelType === ModelTypes.Multiclass) && (
+          (IsBinary(this.context.modelMetadata.modelType) ||
+            IsMulticlass(this.context.modelMetadata.modelType)) && (
             <PivotItem
               headerText={
                 localization.ModelAssessment.ModelOverview


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable the confusion matrix in the RAI dashboard for:
1.) binary text classification scenario
2.) multiclass text classification scenario
3.) binary vision scenario
4.) multiclass vision scenario

Multiclass vision screenshot after functionality has been enabled with the confusion matrix tab now showing:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/003dbde2-d41e-46c4-b5b2-0dc83f60eddf)

Binary text screenshot after functionality has been enabled with the confusion matrix tab now showing:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/2a75dfa0-e270-4db3-9c53-b743b4e71eb1)




## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
