### PR TITLE
add validation that target column is not continuous

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -567,14 +567,12 @@ class RAIInsights(RAIBaseInsights):
                         "Please check your test data.")
 
         # Validate that the target column isn't continuous if the
-        # user is running multiclass classification
-        is_multiclass = len(np.unique(
-            train[target_column].values).tolist()) > 2
-        if (is_multiclass and task_type == ModelTask.CLASSIFICATION and
+        # user is running classification scenario
+        if (task_type == ModelTask.CLASSIFICATION and
                 train[target_column].dtype == "float64"):
             raise UserConfigValidationException(
                 "Target column type must not be continuous "
-                "for multiclass scenario")
+                "for classification scenario.")
         # Check if any features exist that are not numeric, datetime, or
         # categorical.
         train_features = train.drop(columns=[target_column]).columns

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -566,12 +566,16 @@ class RAIInsights(RAIBaseInsights):
                         f"Error finding unique values in column {column}. "
                         "Please check your test data.")
     
-        # Validate that the target column isn't continuous if the user is running multiclass classification
-        is_multiclass = len(np.unique(train[target_column].values).tolist()) > 2
-        if is_multiclass and task_type == ModelTask.CLASSIFICATION and train[target_column].dtype == "float64":
+        # Validate that the target column isn't continuous if the 
+        # user is running multiclass classification
+        is_multiclass = len(np.unique(
+            train[target_column].values).tolist()) > 2
+        if (is_multiclass and task_type == ModelTask.CLASSIFICATION
+            and train[target_column].dtype == "float64"):
             raise UserConfigValidationException(
-                "Target column type must not be continuous for multiclass scenario")
-        
+                "Target column type must not be continuous "
+                "for multiclass scenario")
+
         # Check if any features exist that are not numeric, datetime, or
         # categorical.
         train_features = train.drop(columns=[target_column]).columns

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -565,7 +565,13 @@ class RAIInsights(RAIBaseInsights):
                     raise UserConfigValidationException(
                         f"Error finding unique values in column {column}. "
                         "Please check your test data.")
-
+    
+        # Validate that the target column isn't continuous if the user is running multiclass classification
+        is_multiclass = len(np.unique(train[target_column].values).tolist()) > 2
+        if is_multiclass and task_type == ModelTask.CLASSIFICATION and train[target_column].dtype == "float64":
+            raise UserConfigValidationException(
+                "Target column type must not be continuous for multiclass scenario")
+        
         # Check if any features exist that are not numeric, datetime, or
         # categorical.
         train_features = train.drop(columns=[target_column]).columns

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -571,11 +571,10 @@ class RAIInsights(RAIBaseInsights):
         is_multiclass = len(np.unique(
             train[target_column].values).tolist()) > 2
         if (is_multiclass and task_type == ModelTask.CLASSIFICATION and
-            train[target_column].dtype == "float64"):
+                train[target_column].dtype == "float64"):
             raise UserConfigValidationException(
                 "Target column type must not be continuous "
                 "for multiclass scenario")
-
         # Check if any features exist that are not numeric, datetime, or
         # categorical.
         train_features = train.drop(columns=[target_column]).columns

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -565,13 +565,13 @@ class RAIInsights(RAIBaseInsights):
                     raise UserConfigValidationException(
                         f"Error finding unique values in column {column}. "
                         "Please check your test data.")
-    
-        # Validate that the target column isn't continuous if the 
+
+        # Validate that the target column isn't continuous if the
         # user is running multiclass classification
         is_multiclass = len(np.unique(
             train[target_column].values).tolist()) > 2
-        if (is_multiclass and task_type == ModelTask.CLASSIFICATION
-            and train[target_column].dtype == "float64"):
+        if (is_multiclass and task_type == ModelTask.CLASSIFICATION and
+            train[target_column].dtype == "float64"):
             raise UserConfigValidationException(
                 "Target column type must not be continuous "
                 "for multiclass scenario")

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -199,6 +199,7 @@ class TestRAIInsightsValidations:
         data = pd.DataFrame(raw_data)
         X_data = data.drop(columns=['Target'])
         X_data[TARGET]= data['Target'].values
+
         # use valid target data to create the model
         y_train = np.array([1, 1, 2, 0, 1])
         model = create_lightgbm_classifier(X_data, y_train)

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -206,8 +206,8 @@ class TestRAIInsightsValidations:
 
         with pytest.raises(
                 UserConfigValidationException,
-                match="Target column type must not "
-                "be continuous for multiclass scenario"):
+                match="Target column type must not be continuous "
+                "for classification scenario."):
             RAIInsights(
                 model=model,
                 train=X_data,

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -190,6 +190,39 @@ class TestRAIInsightsValidations:
                 task_type='classification',
                 categorical_features=['not_a_feature'])
 
+    def test_validate_multi_classification_continuous_target_column(self):
+        train_data = {
+            'Column1': [10, 20, 90, 40, 50],
+            'Column2': [10, 20, 90, 40, 50],
+            'Target': [.1, .2, .9, .4, .5]
+        }
+        train = pd.DataFrame(train_data)
+
+        test_data = {
+            'Column1': [10, 20, 100, 40, 50],
+            'Column2': [10, 20, 90, 40, 50],
+            'Target': [.1, .2, .9, .4, .5]
+        }
+        test = pd.DataFrame(test_data)
+        X_train = train.drop(columns=['Target'])
+        y_train = train['Target'].values
+        X_test = test.drop(columns=['Target'])
+        y_test = test['Target'].values
+
+        model = create_lightgbm_classifier(X_train, y_train)
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match='Target column type must not be continuous for multiclass scenario'):
+           RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column=TARGET,
+            task_type='classification')
+
     def test_validate_serializer(self):
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data(return_dataframe=True)

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -215,13 +215,14 @@ class TestRAIInsightsValidations:
 
         with pytest.raises(
                 UserConfigValidationException,
-                match='Target column type must not be continuous for multiclass scenario'):
-           RAIInsights(
-            model=model,
-            train=X_train,
-            test=X_test,
-            target_column=TARGET,
-            task_type='classification')
+                match="Target column type must not "
+                        "be continuous for multiclass scenario"):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='classification')
 
     def test_validate_serializer(self):
         X_train, X_test, y_train, y_test, _, _ = \

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -198,7 +198,7 @@ class TestRAIInsightsValidations:
         }
         data = pd.DataFrame(raw_data)
         X_data = data.drop(columns=['Target'])
-        X_data[TARGET]= data['Target'].values
+        X_data[TARGET] = data['Target'].values
 
         # use valid target data to create the model
         y_train = np.array([1, 1, 2, 0, 1])

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -191,36 +191,26 @@ class TestRAIInsightsValidations:
                 categorical_features=['not_a_feature'])
 
     def test_validate_multi_classification_continuous_target_column(self):
-        train_data = {
+        raw_data = {
             'Column1': [10, 20, 90, 40, 50],
             'Column2': [10, 20, 90, 40, 50],
             'Target': [.1, .2, .9, .4, .5]
         }
-        train = pd.DataFrame(train_data)
-
-        test_data = {
-            'Column1': [10, 20, 100, 40, 50],
-            'Column2': [10, 20, 90, 40, 50],
-            'Target': [.1, .2, .9, .4, .5]
-        }
-        test = pd.DataFrame(test_data)
-        X_train = train.drop(columns=['Target'])
-        y_train = train['Target'].values
-        X_test = test.drop(columns=['Target'])
-        y_test = test['Target'].values
-
-        model = create_lightgbm_classifier(X_train, y_train)
-        X_train[TARGET] = y_train
-        X_test[TARGET] = y_test
+        data = pd.DataFrame(raw_data)
+        X_data = data.drop(columns=['Target'])
+        X_data[TARGET]= data['Target'].values
+        # use valid target data to create the model
+        y_train = np.array([1, 1, 2, 0, 1])
+        model = create_lightgbm_classifier(X_data, y_train)
 
         with pytest.raises(
                 UserConfigValidationException,
                 match="Target column type must not "
-                        "be continuous for multiclass scenario"):
+                "be continuous for multiclass scenario"):
             RAIInsights(
                 model=model,
-                train=X_train,
-                test=X_test,
+                train=X_data,
+                test=X_data,
                 target_column=TARGET,
                 task_type='classification')
 


### PR DESCRIPTION

## Description
Add validation check to ensure that the target column is not continuous (ie of type float) for multiclass classification. This is to address the following bug: [Bug 2472415](https://msdata.visualstudio.com/Vienna/_workitems/edit/2472415): [Live site bug] raise ValueError("Unknown label type: %r" % y_type) in 0.8.0 which resulted from a sklearn error. 
Add unit tests for this scenario

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
