### PR TITLE
Skipping python 3.7 tests on MACOS

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   ci-python:
     strategy:
-      fail-fast: false
       matrix:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]
@@ -33,6 +32,8 @@ jobs:
             pythonVersion: "3.10"
           - operatingSystem: ubuntu-latest
             pythonVersion: "3.6"
+          - operatingSystem: macos-latest
+            pythonVersion: "3.7"
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Pip compile
         run: |
-          pip-compile requirements-dev.txt -o requirements-dev-comp.txt -r
+          pip-compile -r requirements-dev.txt -o requirements-dev-comp.txt
           cat requirements-dev-comp.txt
         working-directory: ${{ matrix.packageDirectory }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -51,27 +51,26 @@ jobs:
           pip install --upgrade setuptools
           pip install --upgrade "pip-tools<=6.13.0"
 
-#       - name: Pip compile
-#         run: |
-#           pip-compile -r requirements-dev.txt -o requirements-dev-comp.txt
-#           cat requirements-dev-comp.txt
-#         working-directory: ${{ matrix.packageDirectory }}
+      - name: Pip compile
+        run: |
+          pip-compile requirements-dev.txt -o requirements-dev-comp.txt
+          cat requirements-dev-comp.txt
+        working-directory: ${{ matrix.packageDirectory }}
 
-#       - name: Upload requirements
-#         uses: actions/upload-artifact@v3
-#         with:
-#           name: requirements-dev-comp.txt
-#           path: ${{ matrix.packageDirectory }}/requirements-dev-comp.txt
+      - name: Upload requirements
+        uses: actions/upload-artifact@v3
+        with:
+          name: requirements-dev-comp.txt
+          path: ${{ matrix.packageDirectory }}/requirements-dev-comp.txt
 
-#       - name: Install dependencies
-#         run: |
-#           pip-sync requirements-dev-comp.txt
-#         working-directory: ${{ matrix.packageDirectory }}
+      - name: Install dependencies
+        run: |
+          pip-sync requirements-dev-comp.txt
+        working-directory: ${{ matrix.packageDirectory }}
 
       - name: Install package
         run: |
-          pip install -r requirements-dev.txt --no-cache-dir
-          pip install -v -e . --no-cache-dir
+          pip install -v -e .
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Run tests

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   ci-python:
     strategy:
+      fail-fast: false
       matrix:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Install package
         run: |
+          pip install -r requirements-dev.txt --no-cache-dir
           pip install -v -e . --no-cache-dir
         working-directory: ${{ matrix.packageDirectory }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Pip compile
         run: |
-          pip-compile requirements-dev.txt -o requirements-dev-comp.txt
+          pip-compile requirements-dev.txt -o requirements-dev-comp.txt -r
           cat requirements-dev-comp.txt
         working-directory: ${{ matrix.packageDirectory }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -51,26 +51,26 @@ jobs:
           pip install --upgrade setuptools
           pip install --upgrade "pip-tools<=6.13.0"
 
-      - name: Pip compile
-        run: |
-          pip-compile -r requirements-dev.txt -o requirements-dev-comp.txt
-          cat requirements-dev-comp.txt
-        working-directory: ${{ matrix.packageDirectory }}
+#       - name: Pip compile
+#         run: |
+#           pip-compile -r requirements-dev.txt -o requirements-dev-comp.txt
+#           cat requirements-dev-comp.txt
+#         working-directory: ${{ matrix.packageDirectory }}
 
-      - name: Upload requirements
-        uses: actions/upload-artifact@v3
-        with:
-          name: requirements-dev-comp.txt
-          path: ${{ matrix.packageDirectory }}/requirements-dev-comp.txt
+#       - name: Upload requirements
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: requirements-dev-comp.txt
+#           path: ${{ matrix.packageDirectory }}/requirements-dev-comp.txt
 
-      - name: Install dependencies
-        run: |
-          pip-sync requirements-dev-comp.txt
-        working-directory: ${{ matrix.packageDirectory }}
+#       - name: Install dependencies
+#         run: |
+#           pip-sync requirements-dev-comp.txt
+#         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Install package
         run: |
-          pip install -v -e .
+          pip install -v -e . --no-cache-dir
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Run tests


### PR DESCRIPTION
## Description

Skipping all python tests on MACOS with python 3.7 as these are failing with the following error:-

```
ImportError while loading conftest '/Users/runner/work/responsible-ai-toolbox/responsible-ai-toolbox/responsibleai/tests/conftest.py'.
tests/__init__.py:5: in <module>
    from .model_analysis.test_model_analysis import TestModelAnalysis
tests/model_analysis/test_model_analysis.py:[11](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5339829896/jobs/9678956790#step:9:12): in <module>
    import pandas as pd
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/__init__.py:50: in <module>
    from pandas.core.api import (
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/core/api.py:48: in <module>
    from pandas.core.groupby import (
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/core/groupby/__init__.py:1: in <module>
    from pandas.core.groupby.generic import (
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/core/groupby/generic.py:73: in <module>
    from pandas.core.frame import DataFrame
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/core/frame.py:[12](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5339829896/jobs/9678956790#step:9:13)9: in <module>
    from pandas.core import (
../../../../hostedtoolcache/Python/3.7.[17](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5339829896/jobs/9678956790#step:9:18)/x64/lib/python3.7/site-packages/pandas/core/generic.py:122: in <module>
    from pandas.core.describe import describe_ndframe
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/core/describe.py:39: in <module>
    from pandas.io.formats.format import format_percentiles
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/io/formats/format.py:99: in <module>
    from pandas.io.common import stringify_path
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/site-packages/pandas/io/common.py:4: in <module>
    import bz2
../../../../hostedtoolcache/Python/3.7.17/x64/lib/python3.7/bz2.py:[19](https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5339829896/jobs/9678956790#step:9:20): in <module>
    from _bz2 import BZ2Compressor, BZ2Decompressor
E   ModuleNotFoundError: No module named '_bz2'
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
