### PR TITLE
fix build failures due to lint errors for onelocbuild yml

### DIFF
--- a/.azure-devops/msdata-rai-widgets-onelocbuild.yml
+++ b/.azure-devops/msdata-rai-widgets-onelocbuild.yml
@@ -5,11 +5,11 @@ trigger: none
 pr: none
 
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight build
-  branches:
-    include:
-    - main
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build
+    branches:
+      include:
+        - main
 
 pool:
   vmImage: "windows-latest"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix build failures due to lint errors for onelocbuild yml

It seems a previous commit was merged directly:
https://github.com/microsoft/responsible-ai-toolbox/commit/9a3c43e48e0bb30ac201c027d6a6157acbd3228d
and this has caused build failures due to linting issues.  Fixing the linting issues in this PR by just running 'yarn lintfix'.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
