### PR TITLE
Robot page exception in DatasetUtils where jointDataset.metaDict[property] is undefined

### DIFF
--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -180,7 +180,7 @@ function pushRowData(
   jointDataset: JointDataset,
   row: { [key: string]: number }
 ): void {
-  const categories = jointDataset.metaDict[property].sortedCategoricalValues;
+  const categories = jointDataset.metaDict[property]?.sortedCategoricalValues;
   if (jointDataset.metaDict[property].isCategorical && categories) {
     tableRow.push(categories[row[property]]);
   } else {
@@ -197,7 +197,8 @@ function pushMultilabelRowData(
   const values = [];
   for (let i = 0; i < jointDataset.numLabels; i++) {
     const labelProp = property + i.toString();
-    const categories = jointDataset.metaDict[labelProp].sortedCategoricalValues;
+    const categories =
+      jointDataset.metaDict[labelProp]?.sortedCategoricalValues;
     if (jointDataset.metaDict[labelProp].isCategorical && categories) {
       const value = categories[row[labelProp]];
       if (value) {


### PR DESCRIPTION
We were seeing two robot page exceptions where jointDataset.metaDict[property] is undefined and is not handled properly.
```
TypeError: TypeError: Cannot read properties of undefined (reading 'sortedCategoricalValues')
    at xa (../../../../node_modules/@responsible-ai/core-ui/core-ui.esm.js:5609:54)
    at pushMultilabelRowData (../../../../node_modules/@responsible-ai/core-ui/core-ui.esm.js:5499:8)
    at constructRows (../../../../node_modules/@responsible-ai/dataset-explorer/dataset-explorer.esm.js:2975:15)
    at new n (../../../../node_modules/@responsible-ai/dataset-explorer/dataset-explorer.esm.js:2830:27)
    at Bde (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:135:171)
    at Mg (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:181:145)
    at pi (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:269:426)
    at ck (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:250:346)
    at bk (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:250:277)
    at ak (../../../../node_modules/react-dom/cjs/react-dom.production.min.js:250:137)
```

## Description



## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
