### PR TITLE
Update the python version to 3.8 in release workflows

### DIFF
--- a/.github/workflows/release-erroranalysis.yml
+++ b/.github/workflows/release-erroranalysis.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         run: |

--- a/.github/workflows/release-nlp-feature-extractors.yml
+++ b/.github/workflows/release-nlp-feature-extractors.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         run: |

--- a/.github/workflows/release-rai-test-utils.yml
+++ b/.github/workflows/release-rai-test-utils.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         run: |

--- a/.github/workflows/release-rai-text.yml
+++ b/.github/workflows/release-rai-text.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install pytorch
         shell: bash -l {0}

--- a/.github/workflows/release-rai-vision.yml
+++ b/.github/workflows/release-rai-vision.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install pytorch
         shell: bash -l {0}

--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/release-raiutils.yml
+++ b/.github/workflows/release-raiutils.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         run: |


### PR DESCRIPTION
## Description

Update the python version to 3.8 in release workflows. Python 3.7 has reached end of life. Updating to 3.8.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
