### PR TITLE
Agemawat/od cache ext

### DIFF
--- a/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
+++ b/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
@@ -1165,4 +1165,16 @@ class RAIVisionInsights(RAIBaseInsights):
                            ['mar_100_per_class'][index].item(), 2)
                 all_cohort_metrics.append([mAP, AP, AR])
 
+                for i in range(len(cohort_classes)):
+                    class_name = cohort_classes[i]
+                    key = ','.join([str(cid) for cid in cohort_indices] +
+                                   [aggregate_method, class_name, str(iou_thresh)])
+                    if key not in object_detection_cache:
+                        class_AP = round(object_detection_values
+                                         ['map_per_class'][index].item(), 2)
+                        class_AR = round(object_detection_values
+                                         ['mar_100_per_class'][index].item(), 2)
+                        object_detection_cache[key] = [mAP, class_AP, class_AR]
+
+
         return all_cohort_metrics


### PR DESCRIPTION
This PR extends the OD cache support from #2158 as the torchmetrics API calculates the metrics for all classes at once, which are now all cached as part of this PR.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
