### PR TITLE
release scikit-learn upper bound in responsibleai package

### DIFF
--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # TODO: add macos
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        pythonVersion: [3.8, 3.9, "3.10"]
         flights: ["", "dataBalanceExperience"]
         notebookGroup: ["nb_group_1", "nb_group_2"]
 

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesDecisionMaking.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesDecisionMaking.ts
@@ -44,54 +44,54 @@ export const DiabetesDecisionMaking = {
     initialCohorts: [
       {
         metrics: {
-          meanAbsoluteError: "43.363",
-          meanPrediction: "154.102",
-          meanSquaredError: "2 981.101"
+          meanAbsoluteError: "43.324",
+          meanPrediction: "154.043",
+          meanSquaredError: "2 983.258"
         },
         name: "All data",
         sampleSize: "89"
       },
       {
         metrics: {
-          meanAbsoluteError: "51.611",
-          meanPrediction: "196.629",
-          meanSquaredError: "4 014.697"
+          meanAbsoluteError: "51.629",
+          meanPrediction: "196.622",
+          meanSquaredError: "4 018.715"
         },
         name: "Cohort Age and BMI",
         sampleSize: "38"
       },
       {
         metrics: {
-          meanAbsoluteError: "49.176",
+          meanAbsoluteError: "49.167",
           meanPrediction: "142.495",
-          meanSquaredError: "3 829.201"
+          meanSquaredError: "3 839.796"
         },
         name: "Cohort Index",
         sampleSize: "20"
       },
       {
         metrics: {
-          meanAbsoluteError: "40.867",
-          meanPrediction: "115.086",
-          meanSquaredError: "2 416.75"
+          meanAbsoluteError: "40.124",
+          meanPrediction: "116.04",
+          meanSquaredError: "2 374.166"
         },
         name: "Cohort Predicted Y",
-        sampleSize: "51"
+        sampleSize: "52"
       },
       {
         metrics: {
-          meanAbsoluteError: "43.044",
-          meanPrediction: "155.306",
-          meanSquaredError: "2 972.126"
+          meanAbsoluteError: "42.988",
+          meanPrediction: "155.229",
+          meanSquaredError: "2 972.082"
         },
         name: "Cohort True Y",
         sampleSize: "87"
       },
       {
         metrics: {
-          meanAbsoluteError: "57.105",
-          meanPrediction: "157.301",
-          meanSquaredError: "4 154.723"
+          meanAbsoluteError: "57.108",
+          meanPrediction: "157.322",
+          meanSquaredError: "4 157.804"
         },
         name: "Cohort Regression Error",
         sampleSize: "63"
@@ -99,9 +99,9 @@ export const DiabetesDecisionMaking = {
     ],
     newCohort: {
       metrics: {
-        meanAbsoluteError: "43.841",
-        meanPrediction: "153.958",
-        meanSquaredError: "3 014.96"
+        meanAbsoluteError: "43.802",
+        meanPrediction: "153.898",
+        meanSquaredError: "3 017.141"
       },
       name: "CohortCreateE2E-diabetes",
       sampleSize: "88"

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesRegressionModelDebugging.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/DiabetesRegressionModelDebugging.ts
@@ -47,9 +47,9 @@ export const DiabetesRegressionModelDebugging = {
     initialCohorts: [
       {
         metrics: {
-          meanAbsoluteError: "43.363",
-          meanPrediction: "154.102",
-          meanSquaredError: "2 981.101"
+          meanAbsoluteError: "43.324",
+          meanPrediction: "154.043",
+          meanSquaredError: "2 983.258"
         },
         name: "All data",
         sampleSize: "89"
@@ -57,9 +57,9 @@ export const DiabetesRegressionModelDebugging = {
     ],
     newCohort: {
       metrics: {
-        meanAbsoluteError: "43.841",
-        meanPrediction: "153.958",
-        meanSquaredError: "3 014.96"
+        meanAbsoluteError: "43.802",
+        meanPrediction: "153.898",
+        meanSquaredError: "3 017.141"
       },
       name: "CohortCreateE2E-diabetes",
       sampleSize: "88"

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -8,7 +8,7 @@ lightgbm>=2.0.11
 numpy>=1.17.2,<1.24.0
 numba<=0.55.2
 pandas>=0.25.1,<2.0.0
-scikit-learn>=0.22.1,<1.1 # See PR 1429 about upper bound
+scikit-learn>=0.22.1,!=1.1 # See PR 1429 about upper bound
 scipy>=1.4.1
 semver~=2.13.0
 ml-wrappers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It seems that the scikit-learn upper bound is causing issues in other libraries/builds where responsibleai is installed.
For example, see the PR fix for: https://github.com/interpretml/interpret-community/pull/568
Removing the upper bound here and just removing the 1.1 scikit-learn version from compatible dependencies list in the setup.py file.

Please also see the similar and related PR from a year ago:
https://github.com/microsoft/responsible-ai-toolbox/pull/1464
I think it might be a bit too early to go for just >1.1.0 yet.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
