### PR TITLE
Update text insights and error_analysis_manager to handle pd.DataFrame predictions and prediction with type of string

### DIFF
--- a/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
+++ b/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
@@ -105,7 +105,7 @@ class WrappedIndexPredictorModel:
         predictions = self.predictions[index]
         if self.task_type == ModelTask.MULTILABEL_TEXT_CLASSIFICATION:
             return predictions
-        if self.classes is not None:
+        if self.classes is not None and isinstance(predictions[0], int):
             predictions = [self.classes[y] for y in predictions]
         return predictions
 

--- a/responsibleai_text/responsibleai_text/rai_text_insights/rai_text_insights.py
+++ b/responsibleai_text/responsibleai_text/rai_text_insights/rai_text_insights.py
@@ -637,8 +637,6 @@ class RAITextInsights(RAIBaseInsights):
             is_classification_task)
         predict_output = self._wrapped_model.predict(
             test_without_target_column)
-        if isinstance(predict_output, pd.DataFrame):
-            predict_output = predict_output.to_numpy()
         self._write_to_file(
             prediction_output_path / (_PREDICT + _JSON_EXTENSION),
             json.dumps(predict_output.tolist()))
@@ -646,8 +644,6 @@ class RAITextInsights(RAIBaseInsights):
         if hasattr(self.model, SKLearn.PREDICT_PROBA):
             predict_proba_output = self.model.predict_proba(
                 test_without_target_column)
-            if isinstance(predict_proba_output, pd.DataFrame):
-                predict_proba_output = predict_proba_output.to_numpy()
             self._write_to_file(
                 prediction_output_path / (_PREDICT_PROBA + _JSON_EXTENSION),
                 json.dumps(predict_proba_output.tolist()))

--- a/responsibleai_text/responsibleai_text/rai_text_insights/rai_text_insights.py
+++ b/responsibleai_text/responsibleai_text/rai_text_insights/rai_text_insights.py
@@ -637,6 +637,8 @@ class RAITextInsights(RAIBaseInsights):
             is_classification_task)
         predict_output = self._wrapped_model.predict(
             test_without_target_column)
+        if isinstance(predict_output, pd.DataFrame):
+            predict_output = predict_output.to_numpy()
         self._write_to_file(
             prediction_output_path / (_PREDICT + _JSON_EXTENSION),
             json.dumps(predict_output.tolist()))
@@ -644,6 +646,8 @@ class RAITextInsights(RAIBaseInsights):
         if hasattr(self.model, SKLearn.PREDICT_PROBA):
             predict_proba_output = self.model.predict_proba(
                 test_without_target_column)
+            if isinstance(predict_proba_output, pd.DataFrame):
+                predict_proba_output = predict_proba_output.to_numpy()
             self._write_to_file(
                 prediction_output_path / (_PREDICT_PROBA + _JSON_EXTENSION),
                 json.dumps(predict_proba_output.tolist()))


### PR DESCRIPTION
This PR updates rai_text_insights and error_analysis_manager.

For rai_text_insights, for predict_output and predict_proba_output, since we only support numpy array, this PR adds a check to handle pandas.DataFrame, and convert pd.DataFrame to numpy array.

For error_analysis_manager, in the case where the prediction value is a string, we should output the predictions directly, no need to map it from self.classes.

## Description

Here is an example AML pipeline running based on responsibleai-text package with the changes in this PR: https://ml.azure.com/experiments/id/26da27c2-760c-4ae7-af6f-fb35b708e952/runs/teal_owl_t5k6t3v2gv?wsid=/subscriptions/3d6da6ed-6af5-4a74-87c6-da367514f8e0/resourceGroups/ResponsibleAIE2E/providers/Microsoft.MachineLearningServices/workspaces/ResponsibleAIE2ETest&flight=RAIAutomlIntegration&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
Link to dashboard: https://ml.azure.com/model/analysis/distilbert-base-uncased/be98b4b8-550a-40fc-8410-fc57258184c2?wsid=/subscriptions/3d6da6ed-6af5-4a74-87c6-da367514f8e0/resourceGroups/ResponsibleAIE2E/providers/Microsoft.MachineLearningServices/workspaces/ResponsibleAIE2ETest&flight=RAIAutomlIntegration&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

## Checklist

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
