### PR TITLE
add conversion to numpy array

### DIFF
--- a/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
+++ b/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
@@ -72,7 +72,8 @@ class WrappedIndexPredictorModel:
         if self.task_type in classif_tasks:
             dataset = self.dataset.iloc[:, 0].tolist()
             self.predictions = self.model.predict(dataset)
-            self.predictions = np.array(self.predictions)
+            if not isinstance(self.predictions, np.ndarray):
+                self.predictions = np.array(self.predictions)
             self.predict_proba = self.model.predict_proba(dataset)
         elif self.task_type == ModelTask.QUESTION_ANSWERING:
             self.predictions = self.model.predict(

--- a/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
+++ b/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
@@ -72,6 +72,7 @@ class WrappedIndexPredictorModel:
         if self.task_type in classif_tasks:
             dataset = self.dataset.iloc[:, 0].tolist()
             self.predictions = self.model.predict(dataset)
+            self.predictions = np.array(self.predictions)
             self.predict_proba = self.model.predict_proba(dataset)
         elif self.task_type == ModelTask.QUESTION_ANSWERING:
             self.predictions = self.model.predict(

--- a/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
+++ b/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
@@ -92,6 +92,7 @@ class WrappedIndexPredictorModel:
             test = get_images(self.dataset, self.image_mode,
                               self.transformations)
         self.predictions = self.model.predict(test)
+        self.predictions = np.array(self.predictions)
         if task_type == ModelTask.MULTILABEL_IMAGE_CLASSIFICATION:
             predictions_joined = []
             for row in self.predictions:

--- a/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
+++ b/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
@@ -92,7 +92,8 @@ class WrappedIndexPredictorModel:
             test = get_images(self.dataset, self.image_mode,
                               self.transformations)
         self.predictions = self.model.predict(test)
-        self.predictions = np.array(self.predictions)
+        if not isinstance(self.predictions, np.ndarray):
+            self.predictions = np.array(self.predictions)
         if task_type == ModelTask.MULTILABEL_IMAGE_CLASSIFICATION:
             predictions_joined = []
             for row in self.predictions:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If the user brings their own model, the result of predictions isn't necessarily a numpy array which is what we expect. The conversion to a numpy array was missing in text classficication, image classfication, and object detection which resulted in a RangeIndex error. This address this bug: [Bug 2532332](https://msdata.visualstudio.com/Vienna/_workitems/edit/2532332): RangeIndex Error when users bring their own model with text and vision

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
