### PR TITLE
Use only Fairlearn v0.7.0 due to breaking changes in v0.9.0 and lack of Python 3.7 support in v0.8.0

### DIFF
--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -8,7 +8,7 @@ requirements-parser==0.2.0
 
 wheel
 
-fairlearn==0.6.0
+fairlearn>=0.7.0,<0.9.0
 ml-wrappers>=0.4.0
 
 # Jupyter dependency that fails with python 3.6

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -8,7 +8,7 @@ requirements-parser==0.2.0
 
 wheel
 
-fairlearn>=0.7.0,<0.9.0
+fairlearn==0.7.0
 ml-wrappers>=0.4.0
 
 # Jupyter dependency that fails with python 3.6

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,5 +6,5 @@ itsdangerous<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.4.4
-fairlearn>=0.7.0
+fairlearn>=0.7.0,<0.9.0
 raiutils>=0.4.0

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,5 +6,5 @@ itsdangerous<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.4.4
-fairlearn>=0.7.0,<0.9.0
+fairlearn==0.7.0
 raiutils>=0.4.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fairlearn v0.9.0 was released now and includes a breaking change (for us only since we're using _extra_metrics). To fix this for now we can prevent v0.9.0 or later from getting installed. For the future I'm creating another PR. We can't work around the issues yet because Fairlearn v0.9.0 doesn't support Python 3.7 which raiwidgets still supports, so whenever we drop support for 3.7 we can merge the other PR.

Fairlearn v0.8.0 doesn't support Python 3.7 either, but also does not yet include the breaking change. We should probably just skip it for raiwidgets.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
