### PR TITLE
Upgrade to Fairlearn v0.9.0

### DIFF
--- a/docs/fairness-dashboard-README.md
+++ b/docs/fairness-dashboard-README.md
@@ -22,7 +22,7 @@ You can further navigate trade offs between fairness and performance of your loa
 
 ## Fairness Dashboard
 
-Please refer to [Fairlearn](https://github.com/fairlearn/fairlearn)'s README and [user guide](https://fairlearn.github.io/v0.5.0/user_guide/index.html) to learn how you can assess and mitigate model's fairness issues. Once your model is trained, load the Fairness dashboard in your notebook to understand how your model’s predictions impact different groups (e.g., different ethnicities). Compare multiple models along different fairness and performance metrics.
+Please refer to [Fairlearn](https://github.com/fairlearn/fairlearn)'s README and [user guide](https://fairlearn.github.io/v0.9/user_guide/index.html) to learn how you can assess and mitigate model's fairness issues. Once your model is trained, load the Fairness dashboard in your notebook to understand how your model’s predictions impact different groups (e.g., different ethnicities). Compare multiple models along different fairness and performance metrics.
 
 ### Setup and single-model assessment
 
@@ -60,7 +60,7 @@ These selections are then used to obtain the visualization of the model’s impa
 
 ### Comparing multiple models
 
-The dashboard also enables comparison of multiple models, such as the models produced by different learning algorithms and different mitigation approaches, including Fairlearn's [GridSearch](https://fairlearn.github.io/v0.5.0/api_reference/fairlearn.reductions.html#fairlearn.reductions.GridSearch), [ExponentiatedGradient](https://fairlearn.github.io/v0.5.0/api_reference/fairlearn.reductions.html#fairlearn.reductions.ExponentiatedGradient), and [ThresholdOptimizer](https://fairlearn.github.io/v0.5.0/api_reference/fairlearn.postprocessing.html#fairlearn.postprocessing.ThresholdOptimizer).
+The dashboard also enables comparison of multiple models, such as the models produced by different learning algorithms and different mitigation approaches, including Fairlearn's [GridSearch](https://fairlearn.org/v0.9/api_reference/generated/fairlearn.reductions.GridSearch.html), [ExponentiatedGradient](https://fairlearn.org/v0.9/api_reference/generated/fairlearn.reductions.ExponentiatedGradient.html), and [ThresholdOptimizer](https://fairlearn.org/v0.9/api_reference/generated/fairlearn.postprocessing.ThresholdOptimizer.html).
 
 As before, select the sensitive feature and the performance metric. The model comparison view then depicts the performance and disparity of all the provided models in a scatter plot. This allows the you to examine trade-offs between performance and fairness. Each of the dots can be clicked to open the assessment of the corresponding model. The figure below shows the model comparison view with `binary gender` selected as a sensitive feature and accuracy rate selected as the performance metric.
 

--- a/docs/source/landing_page/index.html
+++ b/docs/source/landing_page/index.html
@@ -383,7 +383,7 @@
             </h3>
             <p class="text-lightblue">
               Assess fairness & mitigate unfairness using
-              <a href="https://fairlearn.github.io/">Fairlearn</a>
+              <a href="https://fairlearn.org/">Fairlearn</a>
             </p>
             <p class="text-lightblue mb-0">
               Understand model behaviors using

--- a/notebooks/cognitive-services-examples/face-verification/README.md
+++ b/notebooks/cognitive-services-examples/face-verification/README.md
@@ -39,4 +39,4 @@ The following files are intended to be replaced by the user. They are provided t
   - [Documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/face/)
   - [Face SDK](https://docs.microsoft.com/en-us/python/api/azure-cognitiveservices-vision-face/azure.cognitiveservices.vision.face?view=azure-python)
   - [Face API Reference](https://docs.microsoft.com/en-us/azure/cognitive-services/face/APIReference)
-  - [Fairlearn API Reference](https://fairlearn.org/v0.7.0/api_reference/index.html)
+  - [Fairlearn API Reference](https://fairlearn.org/v0.9/api_reference/index.html)

--- a/notebooks/cognitive-services-examples/face-verification/analyze_face_fairness.ipynb
+++ b/notebooks/cognitive-services-examples/face-verification/analyze_face_fairness.ipynb
@@ -154,7 +154,7 @@
    "id": "bd393f5f",
    "metadata": {},
    "source": [
-    "Using the terminology recommended by the [Fairlearn User Guide](https://fairlearn.org/v0.7.0/user_guide/fairness_in_machine_learning.html#fairness-of-ai-systems), we are interested in mitigating **quality-of-service harms**. **Quality-of-Service** harms are focused on whether a systems achieves the same level of performance for one person as it does for others, even when no opportunities or resources are withheld.  The *Face validation* system produces this harm if it fails to validate faces for members of one demographic group higher compared to other demographic groups."
+    "Using the terminology recommended by the [Fairlearn User Guide](https://fairlearn.org/v0.9/user_guide/fairness_in_machine_learning.html#fairness-of-ai-systems), we are interested in mitigating **quality-of-service harms**. **Quality-of-Service** harms are focused on whether a systems achieves the same level of performance for one person as it does for others, even when no opportunities or resources are withheld.  The *Face validation* system produces this harm if it fails to validate faces for members of one demographic group higher compared to other demographic groups."
    ]
   },
   {

--- a/notebooks/cognitive-services-examples/speech-to-text/README.md
+++ b/notebooks/cognitive-services-examples/speech-to-text/README.md
@@ -34,4 +34,4 @@ This quickstart and example
   - [Documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/)
   - [Speech SDK](https://docs.microsoft.com/en-us/python/api/azure-cognitiveservices-speech/azure.cognitiveservices.speech?view=azure-pythonn)
   - [Speech API Reference](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/APIReference)
-  - [Fairlearn API Reference](https://fairlearn.org/v0.7.0/api_reference/index.html)
+  - [Fairlearn API Reference](https://fairlearn.org/v0.9/api_reference/index.html)

--- a/notebooks/cognitive-services-examples/speech-to-text/analyze_stt_fairness.ipynb
+++ b/notebooks/cognitive-services-examples/speech-to-text/analyze_stt_fairness.ipynb
@@ -169,7 +169,7 @@
    "id": "electrical-olympus",
    "metadata": {},
    "source": [
-    "The first step of the fairness assessment is identifying the types of fairness-related harms we expect users of the systems to experience. From the harms taxonomy in the [Fairlearn User Guide]( https://fairlearn.org/v0.7.0/user_guide/fairness_in_machine_learning.html#types-of-harms), we expect our *speech-to-text* system produces *quality of service* harms to users. \n",
+    "The first step of the fairness assessment is identifying the types of fairness-related harms we expect users of the systems to experience. From the harms taxonomy in the [Fairlearn User Guide](https://fairlearn.org/v0.9/user_guide/fairness_in_machine_learning.html#types-of-harms), we expect our *speech-to-text* system produces *quality of service* harms to users. \n",
     "\n",
     "*Quality-of-service* harms occur when an AI system does not work as well for one person as it does for others, even when no resources or opportunities are withheld."
    ]

--- a/notebooks/individual-dashboards/fairness-dashboard/fairness-dashboard-loan-allocation.ipynb
+++ b/notebooks/individual-dashboards/fairness-dashboard/fairness-dashboard-loan-allocation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Using Fairness Dashboard with Loan Allocation Data\n",
     "\n",
-    "This notebook shows how to use [`Fairlearn`](https://fairlearn.github.io/) and the Responsible AI Widget's Fairness dashboard to generate predictors for the Census dataset. This dataset is a classification problem - given a range of data about 32,000 individuals, predict whether their annual income is above or below fifty thousand dollars per year.\n",
+    "This notebook shows how to use [`Fairlearn`](https://fairlearn.org/) and the Responsible AI Widget's Fairness dashboard to generate predictors for the Census dataset. This dataset is a classification problem - given a range of data about 32,000 individuals, predict whether their annual income is above or below fifty thousand dollars per year.\n",
     "\n",
     "For the purposes of this notebook, we shall treat this as a loan decision problem. We will pretend that the label indicates whether or not each individual repaid a loan in the past. We will use the data to train a predictor to predict whether previously unseen individuals will repay a loan or not. The assumption is that the model predictions are used to decide whether an individual should be offered a loan.\n",
     "\n",

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -8,7 +8,7 @@ requirements-parser==0.2.0
 
 wheel
 
-fairlearn==0.6.0
+fairlearn==0.9.0
 ml-wrappers>=0.4.0
 
 # Jupyter dependency that fails with python 3.6

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,5 +6,5 @@ itsdangerous<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.4.4
-fairlearn>=0.7.0
+fairlearn==0.9.0
 raiutils>=0.4.0


### PR DESCRIPTION

## Description

Related to https://github.com/microsoft/responsible-ai-toolbox/pull/2194
This is a more extensive replacement of the older Fairlearn versions. It can only be merged once we drop support for Python 3.7 since Fairlearn v0.8.0 and later don't support it.

Note that the metrics functions added here were just copied from Fairlearn v0.8.0 since they were dropped with v0.9.0. They were only in Fairlearn because we need them here anyway, and since that's not a concern for Fairlearn we decided to migrate them here instead.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
