### PR TITLE
fix responsibleai-vision pypi release script by installing pycocotools from conda

### DIFF
--- a/.github/workflows/release-rai-vision.yml
+++ b/.github/workflows/release-rai-vision.yml
@@ -32,6 +32,12 @@ jobs:
         run: |
           conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
 
+      # pycocotools is a downstream dependency of automl requirements, but fails to install with pip
+      - name: Install pycocotools
+        shell: bash -l {0}
+        run: |
+          conda install pycocotools==2.0.4 -c conda-forge
+
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix responsibleai-vision pypi release script by installing pycocotools from conda
link to failing release:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5716100671/job/15486845399

green build from this branch to release to pypi test:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5716511338/job/15488200943

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
