### PR TITLE
improve notebook test logging and verbosity to diagnose timeouts

### DIFF
--- a/.github/workflows/CI-notebook-vision.yml
+++ b/.github/workflows/CI-notebook-vision.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run notebook tests
         shell: bash -l {0}
-        run: python -m pytest notebooks -m vision_notebooks
+        run: python -m pytest -s -v notebooks -m vision_notebooks
 
       - name: Upload notebook test result
         if: always()

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run notebook tests
         shell: bash -l {0}
-        run: python -m pytest notebooks -m notebooks
+        run: python -m pytest -s -v notebooks -m notebooks
 
       - name: Upload notebook test result
         if: always()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

improve notebook test logging and verbosity to diagnose timeouts

Seeing 5 hour timeouts on notebook vision tests like in this build:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/5731734226/job/15533264630
I suspect this is due to high memory usage.  Adding better debugging flags to pytest to help diagnose such issues better.  See guide for more info on flags:
https://docs.pytest.org/en/6.2.x/reference.html?highlight=verbosity
```
 -s                    shortcut for --capture=no.
...
  -v, --verbose         increase verbosity.
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
