### PR TITLE
Change `ValueError` to `UserConfigValidationException` in casual_manager.py

### DIFF
--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -253,7 +253,8 @@ class CausalManager(BaseManager):
                 "upper_bound_on_cat_expansion={})."
             ).format(max_cat_expansion, max_cat_expansion)
             if expected in message:
-                raise ValueError(message + clarification)
+                raise UserConfigValidationException(
+                  message + clarification)
             raise e
 
     def _create_policy(

--- a/responsibleai/responsibleai/managers/causal_manager.py
+++ b/responsibleai/responsibleai/managers/causal_manager.py
@@ -254,7 +254,7 @@ class CausalManager(BaseManager):
             ).format(max_cat_expansion, max_cat_expansion)
             if expected in message:
                 raise UserConfigValidationException(
-                  message + clarification)
+                    message + clarification)
             raise e
 
     def _create_policy(

--- a/responsibleai/tests/causal/test_causal_manager.py
+++ b/responsibleai/tests/causal/test_causal_manager.py
@@ -85,7 +85,8 @@ class TestCausalManager:
                                 ModelTask.REGRESSION, ['state', 'attraction'])
 
         expected = "Increase the value 50"
-        with pytest.raises(ValueError, match=expected):
+        with pytest.raises(
+                UserConfigValidationException, match=expected):
             manager.add(['state'])
             manager.compute()
 


### PR DESCRIPTION
The `ValueError` being raised is asking user to update the configuration. So this should be `UserConfigValidationException`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
