### PR TITLE
Update CI-notebook-vision.yml to remove windows build

### DIFF
--- a/.github/workflows/CI-notebook-vision.yml
+++ b/.github/workflows/CI-notebook-vision.yml
@@ -12,7 +12,7 @@ jobs:
       node-version: 16.x
     strategy:
       matrix:
-        operatingSystem: [ubuntu-latest, windows-latest]
+        operatingSystem: [ubuntu-latest]
         pythonVersion: [3.7, 3.8, 3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

disabling windows build for notebook vision gate until the pyarrow pinning is merged.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
