### PR TITLE
add multiclass statistics to text and tabular RAI dashboards

### DIFF
--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -38,7 +38,7 @@ export * from "./lib/util/getRandomId";
 export * from "./lib/util/getCohortFilterCount";
 export * from "./lib/util/getDependencyChartOptions";
 export * from "./lib/util/IGenericChartProps";
-export * from "./lib/util/ImageStatisticsUtils";
+export * from "./lib/util/MulticlassStatisticsUtils";
 export * from "./lib/util/initializeOfficeFabric";
 export * from "./lib/util/isNumber";
 export * from "./lib/util/ModelExplanationUtils";

--- a/libs/core-ui/src/lib/util/MulticlassStatisticsUtils.ts
+++ b/libs/core-ui/src/lib/util/MulticlassStatisticsUtils.ts
@@ -8,15 +8,7 @@ import {
   TotalCohortSamples
 } from "../Interfaces/IStatistic";
 
-export enum ImageClassificationMetrics {
-  Accuracy = "accuracy",
-  MacroF1 = "f1",
-  MacroPrecision = "precision",
-  MacroRecall = "recall",
-  MicroF1 = "microF1",
-  MicroPrecision = "microPrecision",
-  MicroRecall = "microRecall"
-}
+import { MulticlassClassificationMetrics } from "./StatisticsUtilsEnums";
 
 interface IMicroMacroRetVal {
   macroScore: number;
@@ -64,7 +56,7 @@ export const generateMicroMacroMetrics = (
   };
 };
 
-export const generateImageStats: (
+export const generateMulticlassStats: (
   trueYs: number[],
   predYs: number[]
 ) => ILabeledStatistic[] = (
@@ -90,37 +82,37 @@ export const generateImageStats: (
       stat: predYs.length
     },
     {
-      key: ImageClassificationMetrics.Accuracy,
+      key: MulticlassClassificationMetrics.Accuracy,
       label: localization.Interpret.Statistics.accuracy,
       stat: accuracy
     },
     {
-      key: ImageClassificationMetrics.MicroPrecision,
+      key: MulticlassClassificationMetrics.MicroPrecision,
       label: localization.Interpret.Statistics.precision,
       stat: microP
     },
     {
-      key: ImageClassificationMetrics.MicroRecall,
+      key: MulticlassClassificationMetrics.MicroRecall,
       label: localization.Interpret.Statistics.recall,
       stat: microR
     },
     {
-      key: ImageClassificationMetrics.MicroF1,
+      key: MulticlassClassificationMetrics.MicroF1,
       label: localization.Interpret.Statistics.f1Score,
       stat: microF1
     },
     {
-      key: ImageClassificationMetrics.MacroPrecision,
+      key: MulticlassClassificationMetrics.MacroPrecision,
       label: localization.Interpret.Statistics.precision,
       stat: macroP
     },
     {
-      key: ImageClassificationMetrics.MacroRecall,
+      key: MulticlassClassificationMetrics.MacroRecall,
       label: localization.Interpret.Statistics.recall,
       stat: macroR
     },
     {
-      key: ImageClassificationMetrics.MacroF1,
+      key: MulticlassClassificationMetrics.MacroF1,
       label: localization.Interpret.Statistics.f1Score,
       stat: macroF1
     }

--- a/libs/core-ui/src/lib/util/StatisticsUtilsEnums.ts
+++ b/libs/core-ui/src/lib/util/StatisticsUtilsEnums.ts
@@ -19,5 +19,11 @@ export enum RegressionMetrics {
 }
 
 export enum MulticlassClassificationMetrics {
-  Accuracy = "accuracy"
+  Accuracy = "accuracy",
+  MacroF1 = "f1",
+  MacroPrecision = "precision",
+  MacroRecall = "recall",
+  MicroF1 = "microF1",
+  MicroPrecision = "microPrecision",
+  MicroRecall = "microRecall"
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/MulticlassDnnModelDebugging.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/MulticlassDnnModelDebugging.ts
@@ -63,7 +63,10 @@ export const MulticlassDnnModelDebugging = {
     initialCohorts: [
       {
         metrics: {
-          accuracy: "0.674"
+          accuracy: "0.674",
+          macroF1Score: "0.673",
+          macroPrecisionScore: "0.669",
+          macroRecallScore: "0.677"
         },
         name: "All data",
         sampleSize: "89"
@@ -71,7 +74,10 @@ export const MulticlassDnnModelDebugging = {
     ],
     newCohort: {
       metrics: {
-        accuracy: "0.67"
+        accuracy: "0.67",
+        macroF1Score: "0.671",
+        macroPrecisionScore: "0.666",
+        macroRecallScore: "0.675"
       },
       name: "CohortCreateE2E-multiclass-dnn",
       sampleSize: "88"

--- a/libs/e2e/src/lib/describer/modelAssessment/modelOverview/ensureAllModelOverviewDatasetCohortsViewBasicElementsArePresent.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/modelOverview/ensureAllModelOverviewDatasetCohortsViewBasicElementsArePresent.ts
@@ -75,6 +75,12 @@ export function ensureAllModelOverviewDatasetCohortsViewBasicElementsArePresent(
         "falseNegativeRate",
         "selectionRate"
       );
+    } else {
+      metricsOrder.push(
+        "macroF1Score",
+        "macroPrecisionScore",
+        "macroRecallScore"
+      );
     }
   }
 

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -33,7 +33,6 @@ import {
   TelemetryLevels,
   TelemetryEventName,
   DatasetTaskType,
-  ImageClassificationMetrics,
   QuestionAnsweringMetrics,
   TotalCohortSamples
 } from "@responsible-ai/core-ui";
@@ -147,17 +146,13 @@ export class ModelOverview extends React.Component<
           BinaryClassificationMetrics.FalseNegativeRate,
           BinaryClassificationMetrics.SelectionRate
         ];
-      } else if (
-        this.context.dataset.task_type === DatasetTaskType.ImageClassification
-      ) {
-        defaultSelectedMetrics = [
-          ImageClassificationMetrics.Accuracy,
-          ImageClassificationMetrics.MacroF1,
-          ImageClassificationMetrics.MacroPrecision,
-          ImageClassificationMetrics.MacroRecall
-        ];
       } else {
-        defaultSelectedMetrics = [MulticlassClassificationMetrics.Accuracy];
+        defaultSelectedMetrics = [
+          MulticlassClassificationMetrics.Accuracy,
+          MulticlassClassificationMetrics.MacroF1,
+          MulticlassClassificationMetrics.MacroPrecision,
+          MulticlassClassificationMetrics.MacroRecall
+        ];
       }
     } else if (
       this.context.dataset.task_type ===

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -8,7 +8,6 @@ import {
   ErrorCohort,
   HighchartsNull,
   ILabeledStatistic,
-  ImageClassificationMetrics,
   MulticlassClassificationMetrics,
   MultilabelMetrics,
   ObjectDetectionMetrics,
@@ -258,74 +257,63 @@ export function getSelectableMetrics(
     taskType === DatasetTaskType.ImageClassification
   ) {
     if (isMulticlass) {
-      if (taskType === DatasetTaskType.ImageClassification) {
-        selectableMetrics.push(
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.accuracy
-                .description,
-            key: ImageClassificationMetrics.Accuracy,
-            text: localization.ModelAssessment.ModelOverview.metrics.accuracy
-              .name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.precisionMacro
-                .description,
-            key: ImageClassificationMetrics.MacroPrecision,
-            text: localization.ModelAssessment.ModelOverview.metrics
-              .precisionMacro.name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.recallMacro
-                .description,
-            key: ImageClassificationMetrics.MacroRecall,
-            text: localization.ModelAssessment.ModelOverview.metrics.recallMacro
-              .name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.f1ScoreMacro
-                .description,
-            key: ImageClassificationMetrics.MacroF1,
-            text: localization.ModelAssessment.ModelOverview.metrics
-              .f1ScoreMacro.name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.precisionMicro
-                .description,
-            key: ImageClassificationMetrics.MicroPrecision,
-            text: localization.ModelAssessment.ModelOverview.metrics
-              .precisionMicro.name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.recallMicro
-                .description,
-            key: ImageClassificationMetrics.MicroRecall,
-            text: localization.ModelAssessment.ModelOverview.metrics.recallMicro
-              .name
-          },
-          {
-            description:
-              localization.ModelAssessment.ModelOverview.metrics.f1ScoreMicro
-                .description,
-            key: ImageClassificationMetrics.MicroF1,
-            text: localization.ModelAssessment.ModelOverview.metrics
-              .f1ScoreMicro.name
-          }
-        );
-      } else {
-        selectableMetrics.push({
+      selectableMetrics.push(
+        {
           description:
             localization.ModelAssessment.ModelOverview.metrics.accuracy
               .description,
           key: MulticlassClassificationMetrics.Accuracy,
           text: localization.ModelAssessment.ModelOverview.metrics.accuracy.name
-        });
-      }
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.precisionMacro
+              .description,
+          key: MulticlassClassificationMetrics.MacroPrecision,
+          text: localization.ModelAssessment.ModelOverview.metrics
+            .precisionMacro.name
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.recallMacro
+              .description,
+          key: MulticlassClassificationMetrics.MacroRecall,
+          text: localization.ModelAssessment.ModelOverview.metrics.recallMacro
+            .name
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.f1ScoreMacro
+              .description,
+          key: MulticlassClassificationMetrics.MacroF1,
+          text: localization.ModelAssessment.ModelOverview.metrics.f1ScoreMacro
+            .name
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.precisionMicro
+              .description,
+          key: MulticlassClassificationMetrics.MicroPrecision,
+          text: localization.ModelAssessment.ModelOverview.metrics
+            .precisionMicro.name
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.recallMicro
+              .description,
+          key: MulticlassClassificationMetrics.MicroRecall,
+          text: localization.ModelAssessment.ModelOverview.metrics.recallMicro
+            .name
+        },
+        {
+          description:
+            localization.ModelAssessment.ModelOverview.metrics.f1ScoreMicro
+              .description,
+          key: MulticlassClassificationMetrics.MicroF1,
+          text: localization.ModelAssessment.ModelOverview.metrics.f1ScoreMicro
+            .name
+        }
+      );
     } else {
       selectableMetrics.push(
         {


### PR DESCRIPTION
## Description

Add multiclass precision, recall, F1 score macro and micro statistics to text and tabular RAI dashboards by refactoring vision code to central multiclass stats method.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
