### PR TITLE
Move missing value validations before unique value validations

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -534,6 +534,10 @@ class RAIInsights(RAIBaseInsights):
             raise UserConfigValidationException(
                 f'Target name {target_column} not present in train/test data')
 
+        # Check if any of the data is missing in test and train data
+        self._validate_data_is_not_missing(test, "test")
+        self._validate_data_is_not_missing(train, "train")
+
         categorical_features = feature_metadata.categorical_features
         if (categorical_features is not None and
                 len(categorical_features) > 0):
@@ -596,10 +600,6 @@ class RAIInsights(RAIBaseInsights):
                 "The following string features were not "
                 "identified as categorical features: "
                 f"{non_categorical_or_time_string_columns}")
-
-        # Check if any of the data is missing in test and train data
-        self._validate_data_is_not_missing(test, "test")
-        self._validate_data_is_not_missing(train, "train")
 
         self._validate_feature_metadata(
             feature_metadata, train, task_type, model, target_column)

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -398,7 +398,7 @@ class TestRAIInsightsValidations:
             str(ucve.value)
 
     def test_dirty_train_test_data(self):
-        X_train = pd.DataFrame(data=[['1', np.nan], ['2', '3']],
+        X_train = pd.DataFrame(data=[['1', 1], ['2', '3']],
                                columns=['c1', 'c2'])
         y_train = np.array([1, 0])
         X_test = pd.DataFrame(data=[['1', '2'], ['2', '3']],


### PR DESCRIPTION
## Description

The np.unique() call downstream will fail in case of missing values in data. So doing the missing value validation up front.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
