### PR TITLE
fix for aggregate parameter passed to torchmetrics

### DIFF
--- a/.github/workflows/CI-responsibleai-text-vision-pytest.yml
+++ b/.github/workflows/CI-responsibleai-text-vision-pytest.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/CI-responsibleai-text-pytest.yml"
 
 jobs:
-  ci-python:
+  ci-responsibleai-text-vision-python:
     strategy:
       matrix:
         packageDirectory: ["responsibleai_text", "responsibleai_vision"]
@@ -85,12 +85,16 @@ jobs:
         run: |
           python -m spacy download en_core_web_sm
 
+      - if: ${{ (matrix.packageDirectory == 'responsibleai_vision') }}
+        name: Install pycocotools dependency
+        shell: bash -l {0}
+        run: |
+          conda install pycocotools==2.0.4 -c conda-forge
+
       - if: ${{ (matrix.packageDirectory == 'responsibleai_vision') && ((matrix.pythonVersion == '3.7') || (matrix.pythonVersion == '3.8')) }}
         name: Install automl dependencies
         shell: bash -l {0}
-        # pycocotools is a downstream dependency of automl requirements, but fails to install with pip
         run: |
-          conda install pycocotools==2.0.4 -c conda-forge
           pip install -r ${{ matrix.packageDirectory }}/requirements-automl.txt
 
       - name: Install package

--- a/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
+++ b/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
@@ -1091,9 +1091,6 @@ class RAIVisionInsights(RAIBaseInsights):
         dashboard_dataset = self.get_data().dataset
         true_y = dashboard_dataset.object_detection_true_y
         predicted_y = dashboard_dataset.object_detection_predicted_y
-        dashboard_dataset = self.get_data().dataset
-        true_y = dashboard_dataset.object_detection_true_y
-        predicted_y = dashboard_dataset.object_detection_predicted_y
 
         normalized_iou_threshold = [iou_threshold / 100.0]
         all_cohort_metrics = []
@@ -1106,8 +1103,7 @@ class RAIVisionInsights(RAIBaseInsights):
 
             metric_OD = MeanAveragePrecision(
                 class_metrics=True,
-                iou_thresholds=normalized_iou_threshold,
-                average=aggregate_method)
+                iou_thresholds=normalized_iou_threshold)
             true_y_cohort = [true_y[cohort_index] for cohort_index
                              in cohort_indices]
             predicted_y_cohort = [predicted_y[cohort_index] for cohort_index
@@ -1169,5 +1165,4 @@ class RAIVisionInsights(RAIBaseInsights):
                 all_submetrics = [[mAP, APs[i], ARs[i]]
                                   for i in range(len(APs))]
                 all_cohort_metrics.append(all_submetrics)
-
         return [all_cohort_metrics, cohort_classes]

--- a/responsibleai_vision/tests/test_rai_vision_insights.py
+++ b/responsibleai_vision/tests/test_rai_vision_insights.py
@@ -287,3 +287,13 @@ def run_rai_insights(model, test_data, target_column,
     validate_rai_vision_insights(
         rai_insights, test_data,
         target_column, task_type)
+    if task_type == ModelTask.OBJECT_DETECTION:
+        selection_indexes = [[0]]
+        aggregate_method = 'Macro'
+        class_name = classes[0]
+        iou_threshold = 70
+        object_detection_cache = {}
+        metrics = rai_insights.compute_object_detection_metrics(
+            selection_indexes, aggregate_method, class_name, iou_threshold,
+            object_detection_cache)
+        assert len(metrics) == 2


### PR DESCRIPTION
## Description

The MeanAveragePrecision no longer takes in an aggregate parameter.  This PR fixes this issue by removing it and adding a test to validate the compute_object_detection_metrics call.  Note I do not remove the UI changes here since we may still want to keep this parameter when computing in aggregate metrics across classes - but we need to call a different method in this case anyway, and this is currently not yet supported.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
