### PR TITLE
Pass categorical features after dropping dropped features in CounterfactualManager

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -387,7 +387,7 @@ class RAIInsights(RAIBaseInsights):
             model=self.model, train=self.get_train_data(),
             test=self.get_test_data(),
             target_column=self.target_column, task_type=self.task_type,
-            categorical_features=self.categorical_features)
+            categorical_features=self.get_categorical_features_after_drop())
 
         self._data_balance_manager = DataBalanceManager(
             train=self.train, test=self.test, target_column=self.target_column,


### PR DESCRIPTION

## Description
It seems we are passing categorical_features without dropping the dropped features from it.


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
