### PR TITLE
fix error for automl object detection models when initializing error analysis and optimize explanation execution

### DIFF
--- a/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
+++ b/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
@@ -80,12 +80,23 @@ class WrappedIndexPredictorModel:
             test = np.array(
                 self.dataset.iloc[:, 0].tolist()
             )
-            test = pd.DataFrame(
-                data=[
-                    get_base64_string_from_path(img_path) for img_path in test
-                ],
-                columns=[MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE],
-            )
+            if self.task_type == ModelTask.OBJECT_DETECTION:
+                test = pd.DataFrame(
+                    data=[[x for x in get_base64_string_from_path(
+                        img_path, return_image_size=True)] for
+                        img_path in test],
+                    columns=[
+                        MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE,
+                        MLFlowSchemaLiterals.INPUT_IMAGE_SIZE],
+                )
+            else:
+                test = pd.DataFrame(
+                    data=[
+                        get_base64_string_from_path(
+                            img_path) for img_path in test
+                    ],
+                    columns=[MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE],
+                )
         else:
             test = get_images(self.dataset, self.image_mode,
                               self.transformations)


### PR DESCRIPTION

## Description

1.) Fix error for automl object detection models when initializing error analysis
2.) Optimize explanation execution by trying to get the inner automl model, thereby skipping logic to write mask back to base64 encoded string in DRISE

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
