### PR TITLE
Removed python 3.6 from python PR gate

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -20,7 +20,7 @@ jobs:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]
         operatingSystem:
           [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        pythonVersion: ["3.7", "3.8", "3.9", "3.10"]
         exclude:
           - operatingSystem: ubuntu-20.04
             pythonVersion: "3.7"
@@ -30,8 +30,6 @@ jobs:
             pythonVersion: "3.9"
           - operatingSystem: ubuntu-20.04
             pythonVersion: "3.10"
-          - operatingSystem: ubuntu-latest
-            pythonVersion: "3.6"
           - operatingSystem: macos-latest
             pythonVersion: "3.7"
 
@@ -45,7 +43,7 @@ jobs:
         with:
           python-version: ${{ matrix.pythonVersion }}
 
-      - if: ${{ matrix.pythonVersion == '3.6' || matrix.pythonVersion == '3.7' }}
+      - if: ${{ matrix.pythonVersion == '3.7' }}
         name: Setup tools for python lt 3.8
         run: |
           python -m pip install --upgrade "pip<=23.1.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed 3.6 from PR gate due to deprecation and issues with torch versions above 1.12.x (eg - 1.13.1).

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
