### PR TITLE
RAIInsights: prevent failures on optional methods & fix feature range formatting for timestamps

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1305,8 +1305,8 @@ class RAIInsights(RAIBaseInsights):
                 res_object[_UNIQUE_VALUES] = unique_value.tolist()
             elif datetime_features is not None and col in datetime_features:
                 res_object[_RANGE_TYPE] = "datetime"
-                res_object[_MIN_VALUE] = test[col].min()
-                res_object[_MAX_VALUE] = test[col].max()
+                res_object[_MIN_VALUE] = test[col].min().strftime("%Y-%m-%d %H:%M:%S")
+                res_object[_MAX_VALUE] = test[col].max().strftime("%Y-%m-%d %H:%M:%S")
             else:
                 col_min = test[col].min()
                 col_max = test[col].max()

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1186,7 +1186,6 @@ class RAIInsights(RAIBaseInsights):
         if methods[0].optional and not hasattr(self.model, methods[0].name):
             return None
         return getattr(self.model, methods[0].name)
-        
 
     def _get_model_output(self, *, input_data: Union[None, np.array],
                           purpose: MethodPurpose):
@@ -1315,8 +1314,10 @@ class RAIInsights(RAIBaseInsights):
                 res_object[_UNIQUE_VALUES] = unique_value.tolist()
             elif datetime_features is not None and col in datetime_features:
                 res_object[_RANGE_TYPE] = "datetime"
-                res_object[_MIN_VALUE] = test[col].min().strftime("%Y-%m-%d %H:%M:%S")
-                res_object[_MAX_VALUE] = test[col].max().strftime("%Y-%m-%d %H:%M:%S")
+                res_object[_MIN_VALUE] = \
+                    test[col].min().strftime("%Y-%m-%d %H:%M:%S")
+                res_object[_MAX_VALUE] = \
+                    test[col].max().strftime("%Y-%m-%d %H:%M:%S")
             else:
                 col_min = test[col].min()
                 col_max = test[col].max()

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1182,7 +1182,14 @@ class RAIInsights(RAIBaseInsights):
                    if m.purpose == purpose]
         if len(methods) == 0:
             return None
+        # If a method is optional don't fail
+        if methods[0].optional:
+            try:
+                return getattr(self.model, methods[0].name)
+            except:
+                return None
         return getattr(self.model, methods[0].name)
+        
 
     def _get_model_output(self, *, input_data: Union[None, np.array],
                           purpose: MethodPurpose):

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1183,11 +1183,8 @@ class RAIInsights(RAIBaseInsights):
         if len(methods) == 0:
             return None
         # If a method is optional don't fail
-        if methods[0].optional:
-            try:
-                return getattr(self.model, methods[0].name)
-            except:
-                return None
+        if methods[0].optional and not hasattr(self.model, methods[0].name):
+            return None
         return getattr(self.model, methods[0].name)
         
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1221,8 +1221,9 @@ class RAIInsights(RAIBaseInsights):
                 model_method = getattr(self.model, method.name)
                 model_method(input_data)
             except Exception:
-                raise UserConfigValidationException(
-                    _MODEL_METHOD_EXCEPTION_MESSAGE.format(method.name))
+                if not method.optional:
+                    raise UserConfigValidationException(
+                        _MODEL_METHOD_EXCEPTION_MESSAGE.format(method.name))
             self._validate_features_same(input_features, input_data,
                                          method.name)
 

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -51,6 +51,8 @@ _CATEGORICAL_FEATURES = 'categorical_features'
 _DROPPED_FEATURES = 'dropped_features'
 _FORECASTING_RAI_INSIGHTS_ENABLED = "forecasting_enabled"
 
+_STRF_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 _MODEL_METHOD_EXCEPTION_MESSAGE = (
     'The passed model cannot be used for getting predictions via {0}')
 
@@ -1042,7 +1044,7 @@ class RAIInsights(RAIBaseInsights):
                         self._feature_metadata.datetime_features[0]
                     dashboard_dataset.index = convert_to_list(
                         pd.to_datetime(self.test[time_column_name])
-                        .apply(lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%SZ")))
+                        .apply(lambda dt: dt.strftime(_STRF_TIME_FORMAT)))
             except Exception as ex:
                 raise ValueError(
                     "The datetime feature should be parseable by "
@@ -1315,9 +1317,9 @@ class RAIInsights(RAIBaseInsights):
             elif datetime_features is not None and col in datetime_features:
                 res_object[_RANGE_TYPE] = "datetime"
                 res_object[_MIN_VALUE] = \
-                    test[col].min().strftime("%Y-%m-%d %H:%M:%S")
+                    test[col].min().strftime(_STRF_TIME_FORMAT)
                 res_object[_MAX_VALUE] = \
-                    test[col].max().strftime("%Y-%m-%d %H:%M:%S")
+                    test[col].max().strftime(_STRF_TIME_FORMAT)
             else:
                 col_min = test[col].min()
                 col_max = test[col].max()

--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -1226,11 +1226,17 @@ class RAIInsights(RAIBaseInsights):
                     _MODEL_METHOD_EXCEPTION_MESSAGE.format(method.name))
             try:
                 model_method = getattr(self.model, method.name)
-                model_method(input_data)
             except Exception:
                 if not method.optional:
                     raise UserConfigValidationException(
                         _MODEL_METHOD_EXCEPTION_MESSAGE.format(method.name))
+                # skip if method is optional and unavailable
+                continue
+            try:
+                model_method(input_data)
+            except Exception:
+                raise UserConfigValidationException(
+                    _MODEL_METHOD_EXCEPTION_MESSAGE.format(method.name))
             self._validate_features_same(input_features, input_data,
                                          method.name)
 

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -36,6 +36,30 @@ def create_iris_data():
     return X_train, X_test, y_train, y_test, feature_names, classes
 
 
+def create_tiny_forecasting_dataset():
+    X_train = pd.DataFrame({
+        "time": [
+            pd.Timestamp("2023-08-18T06:00:00"),
+            pd.Timestamp("2023-08-18T07:00:00"),
+            pd.Timestamp("2023-08-18T08:00:00"),
+            pd.Timestamp("2023-08-18T09:00:00")
+        ],
+        "id": [1, 1, 1, 1]
+    })
+    X_test = pd.DataFrame({
+        "time": [
+            pd.Timestamp("2023-08-18T10:00:00"),
+            pd.Timestamp("2023-08-18T11:00:00"),
+            pd.Timestamp("2023-08-18T12:00:00"),
+            pd.Timestamp("2023-08-18T13:00:00")
+        ],
+        "id": [1, 1, 1, 1]
+    })
+    y_train = [0, 1, 2, 3]
+    y_test = [4, 5, 6, 7]
+    return X_train, X_test, y_train, y_test
+
+
 class FetchDiceAdultCensusIncomeDataset(object):
     def __init__(self):
         pass

--- a/responsibleai/tests/rai_insights/test_rai_insights_validations.py
+++ b/responsibleai/tests/rai_insights/test_rai_insights_validations.py
@@ -2,13 +2,15 @@
 # Licensed under the MIT License.
 
 import logging
+import random
 from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
 import pytest
 from lightgbm import LGBMClassifier
-from tests.common_utils import create_iris_data
+from tests.common_utils import (create_iris_data,
+                                create_tiny_forecasting_dataset)
 
 from rai_test_utils.datasets.tabular import (
     create_binary_classification_dataset, create_cancer_data,
@@ -20,6 +22,8 @@ from rai_test_utils.models.sklearn import (
 from raiutils.exceptions import UserConfigValidationException
 from responsibleai import RAIInsights
 from responsibleai.feature_metadata import FeatureMetadata
+from responsibleai.rai_insights.rai_insights import \
+    _MODEL_METHOD_EXCEPTION_MESSAGE
 
 TARGET = 'target'
 
@@ -1185,3 +1189,118 @@ class TestCounterfactualUserConfigValidations:
                 test=X_test,
                 target_column=TARGET,
                 task_type='classification')
+
+    def test_optional_method_not_present(self):
+        X_train, X_test, y_train, y_test = create_tiny_forecasting_dataset()
+
+        class ForecastModelWithoutQuantiles():
+            def forecast(self, X):
+                return [random.random() for _ in range(len(X))]
+
+        model = ForecastModelWithoutQuantiles()
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column=TARGET,
+            task_type='forecasting',
+            feature_metadata=FeatureMetadata(
+                datetime_features=['time'],
+                time_series_id_features=['id']
+            ),
+            forecasting_enabled=True)
+
+    def test_optional_method_present(self):
+        X_train, X_test, y_train, y_test = create_tiny_forecasting_dataset()
+
+        class ForecastModelWithoutQuantiles():
+            def forecast(self, X):
+                return [random.random() for _ in range(len(X))]
+
+            def forecast_quantiles(self, X, quantiles):
+                return [
+                    [random.random() for _ in range(len(X))],
+                    [random.random() for _ in range(len(X))]
+                ]
+
+        model = ForecastModelWithoutQuantiles()
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column=TARGET,
+            task_type='forecasting',
+            feature_metadata=FeatureMetadata(
+                datetime_features=['time'],
+                time_series_id_features=['id']
+            ),
+            forecasting_enabled=True)
+
+    def test_optional_method_failing(self):
+        X_train, X_test, y_train, y_test = create_tiny_forecasting_dataset()
+
+        class ForecastModelWithFailingQuantiles():
+            def forecast(self, X):
+                return [random.random() for _ in range(len(X))]
+
+            def forecast_quantiles(self, X):
+                raise Exception("Failed to forecast quantiles!")
+
+        model = ForecastModelWithFailingQuantiles()
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        message = _MODEL_METHOD_EXCEPTION_MESSAGE.format("forecast_quantiles")
+        with pytest.raises(
+                UserConfigValidationException, match=message):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='forecasting',
+                feature_metadata=FeatureMetadata(
+                    datetime_features=['time'],
+                    time_series_id_features=['id']
+                ),
+                forecasting_enabled=True)
+
+    def test_required_method_failing(self):
+        X_train, X_test, y_train, y_test = create_tiny_forecasting_dataset()
+
+        class ForecastModelWithFailingForecast():
+            def forecast(self, X):
+                raise Exception("Failed to forecast!")
+
+        model = ForecastModelWithFailingForecast()
+        X_train = X_train.copy()
+        X_test = X_test.copy()
+        X_train[TARGET] = y_train
+        X_test[TARGET] = y_test
+
+        message = _MODEL_METHOD_EXCEPTION_MESSAGE.format("forecast")
+        with pytest.raises(
+                UserConfigValidationException, match=message):
+            RAIInsights(
+                model=model,
+                train=X_train,
+                test=X_test,
+                target_column=TARGET,
+                task_type='forecasting',
+                feature_metadata=FeatureMetadata(
+                    datetime_features=['time'],
+                    time_series_id_features=['id']
+                ),
+                forecasting_enabled=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With optional methods such as `forecast_quantiles` we need to be able to check if the model has the method at all without getting a failure. This PR adjusts the handling slightly to prevent unintended issues.

Secondly, the feature ranges need to be specified in a JSON-serializable format, so we're storing them as strings now.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
