### PR TITLE
fix RAI explanation error for dropped categorical features after serialization

### DIFF
--- a/responsibleai/responsibleai/managers/explainer_manager.py
+++ b/responsibleai/responsibleai/managers/explainer_manager.py
@@ -413,7 +413,7 @@ class ExplainerManager(BaseManager):
         inst.__dict__['_' + Metadata.MODEL] = rai_insights.model
         inst.__dict__['_' + CLASSES] = rai_insights._classes
         inst.__dict__['_' + CATEGORICAL_FEATURES] = \
-            rai_insights.categorical_features
+            rai_insights.get_categorical_features_after_drop()
         target_column = rai_insights.target_column
         train = rai_insights.get_train_data().drop(columns=[target_column])
         test = rai_insights.get_test_data().drop(columns=[target_column])

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -14,6 +14,10 @@ from rai_test_utils.datasets.tabular import \
     create_iris_data as _create_iris_data
 from raiutils.common.retries import retry_function
 
+ADULT_DROPPED_FEATURES = ['workclass', 'education', 'marital_status',
+                          'occupation', 'race', 'gender']
+ADULT_CATEGORICAL_FEATURES_AFTER_DROP = ['age', 'hours_per_week']
+
 
 def create_iris_data():
     (


### PR DESCRIPTION

## Description

Fix RAI explanation error for dropped categorical features after serialization.

Customer was running into error:
```
ValueError in dataset_wrapper <listcomp> when return [features.index(categorical_feature) for categorical_feature in categorical_features]
```

After investigation, it seems it occurs due to a combination of dropped categorical features and RAI Insights serialization followed by deserialization and calling add/compute.  The fix was to call the same get_categorical_features_after_drop() method in the explainer_manager load method as in the original init call within RAIInsights when creating the explainer_manager.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
