### PR TITLE
CanvasTools OD Bounding Box Fix

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/FlyoutObjectDetectionUtils.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/FlyoutObjectDetectionUtils.tsx
@@ -6,7 +6,6 @@ import { IDataset, IVisionListItem } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { CanvasTools } from "vott-ct";
 import { Editor } from "vott-ct/lib/js/CanvasTools/CanvasTools.Editor";
-import { Color } from "vott-ct/lib/js/CanvasTools/Core/Colors/Color";
 import { RegionData } from "vott-ct/lib/js/CanvasTools/Core/RegionData";
 
 export interface IFlyoutProps {
@@ -83,7 +82,7 @@ export function drawBox(
   );
 
   // Initializing bounding box tag
-  const predTag = new CanvasTools.Core.Tag(annotation, new Color(colorCode));
+  const predTag = new CanvasTools.Core.Tag(annotation, colorCode);
   const predTagDesc = new CanvasTools.Core.TagsDescriptor([predTag]);
 
   // Drawing bounding box with vott


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Replaced vott-ct's `Color` class to literal string for potential fix on AML Studio UI.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

AML Studio UI doesn't show the bounding boxes with vott-ct (perhaps coz of CSS score overwriting) despite boxes displayed both locally and on the test app.

This refreshes the implementation by directly passing in the color string to see if that'll work on AML Studio.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/9ce99b1b-f737-44b6-8198-4d6ac1d0384e)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
