### PR TITLE
remove vision e2e notebook tests from raiwidgets and responsibleai release workflow

### DIFF
--- a/.github/workflows/release-rai.yml
+++ b/.github/workflows/release-rai.yml
@@ -139,9 +139,6 @@ jobs:
           yarn e2e-widget -n "responsibleaidashboard-housing-classification-model-debugging" -f ""
           yarn e2e-widget -n "responsibleaidashboard-diabetes-decision-making" -f ""
           yarn e2e-widget -n "responsibleaidashboard-multiclass-dnn-model-debugging" -f ""
-          yarn e2e-widget -n "responsibleaidashboard-fridge-image-classification-model-debugging" -f ""
-          yarn e2e-widget -n "responsibleaidashboard-fridge-multilabel-image-classification-model-debugging" -f ""
-          yarn e2e-widget -n "responsibleaidashboard-fridge-object-detection-model-debugging" -f ""
 
       - name: Upload e2e test screen shot
         if: always()


### PR DESCRIPTION
## Description

remove vision e2e notebook tests from raiwidgets and responsibleai release workflow

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
