### PR TITLE
fix failing vision tests due to new RAI validation logic which doesn't allow non string dropped column names

### DIFF
--- a/responsibleai_text/responsibleai_text/utils/feature_extractors.py
+++ b/responsibleai_text/responsibleai_text/utils/feature_extractors.py
@@ -134,7 +134,7 @@ def append_metadata_values(start_meta_index, text_dataset, i,
     for j in range(start_meta_index, text_dataset.shape[1]):
         if has_dropped_features and column_names[j] in dropped_features:
             continue
-        extracted_features.append(text_dataset.iloc[i][j])
+        extracted_features.append(text_dataset.iloc[i, j])
     return extracted_features
 
 

--- a/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
+++ b/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
@@ -45,7 +45,7 @@ def extract_features(image_dataset: pd.DataFrame,
             continue
         feature_names.append(column_names[j])
     for i in tqdm(range(image_dataset.shape[0])):
-        image = image_dataset.iloc[i][0]
+        image = image_dataset.iloc[i, 0]
         if isinstance(image, str):
             image = get_image_from_path(image, image_mode)
         mean_pixel_value = image.mean()
@@ -54,6 +54,6 @@ def extract_features(image_dataset: pd.DataFrame,
         for j in range(start_meta_index, image_dataset.shape[1]):
             if has_dropped_features and column_names[j] in dropped_features:
                 continue
-            row_feature_values.append(image_dataset.iloc[i][j])
+            row_feature_values.append(image_dataset.iloc[i, j])
         results.append(row_feature_values)
     return results, feature_names

--- a/responsibleai_vision/tests/test_rai_vision_insights.py
+++ b/responsibleai_vision/tests/test_rai_vision_insights.py
@@ -223,7 +223,11 @@ class TestRAIVisionInsights(object):
         task_type = ModelTask.OBJECT_DETECTION
         class_names = np.array(['can', 'carton',
                                 'milk_bottle', 'water_bottle'])
-        dropped_features = [i for i in range(0, 10)]
+        dropped_cols_num = [i for i in range(0, 10)]
+        dropped_features = ["{}".format(i) for i in dropped_cols_num]
+        # rename column names to strings since RAI validation fails otherwise
+        data = data.rename(columns={i: j for i, j in zip(
+            dropped_cols_num, dropped_features)}).reset_index(drop=True)
         run_rai_insights(model, data[:3], ImageColumns.LABEL,
                          task_type, class_names,
                          dropped_features=dropped_features)


### PR DESCRIPTION
## Description

After responsibleai v0.30.0 package release, one of the vision tests started failing due to new validation logic introduced in the v0.30.0 package:

```
        for column_name in column_names:
            if not isinstance(column_name, str):
>               raise UserConfigValidationException(
                    'Entries in {} must be strings.'.format(column_purpose))
E               raiutils.exceptions.UserConfigValidationException: Entries in dropped feature must be strings.
```

The new validation logic does not allow dropped features to be non-strings (in this case integers).  However, pandas does allow integer column names and in this case the dataset in the test had integer column names.  To fix the test, I modified the pandas dataframe integer columns to be text type instead of int type, so that the new validation logic would pass.  An alternative fix might be to allow dropped features to have integer values instead of strings.

In addition I changed iloc to use two dimensional indexing always since I noticed the behavior could be different than expected when using metadata features with iloc indexing followed by row index if index is not reset as a safeguard - which I noticed while debugging.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
