### PR TITLE
Heatmap Support for Object Detection

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DatasetCohortStatsTable.tsx
@@ -19,6 +19,7 @@ interface IDatasetCohortStatsTableProps {
   selectableMetrics: IDropdownOption[];
   selectedMetrics: string[];
   showHeatmapColors: boolean;
+  modelType: string;
 }
 
 class IDatasetCohortStatsTableState {}
@@ -37,7 +38,8 @@ export class DatasetCohortStatsTable extends React.Component<
       this.props.selectableMetrics,
       this.props.labeledStatistics,
       this.props.selectedMetrics,
-      this.props.showHeatmapColors
+      this.props.showHeatmapColors,
+      this.props.modelType
     ).items;
 
     const showColors =

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisTable.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/DisaggregatedAnalysisTable.tsx
@@ -21,6 +21,7 @@ interface IDisaggregatedAnalysisTableProps {
   selectedFeatures: number[];
   featureBasedCohorts: ErrorCohort[];
   showHeatmapColors: boolean;
+  modelType: string;
 }
 
 class IDisaggregatedAnalysisTableState {}
@@ -39,7 +40,8 @@ export class DisaggregatedAnalysisTable extends React.Component<
       this.props.selectableMetrics,
       this.props.labeledStatistics,
       this.props.selectedMetrics,
-      this.props.showHeatmapColors
+      this.props.showHeatmapColors,
+      this.props.modelType
     );
     if (this.props.selectedFeatures.length === 0) {
       return React.Fragment;

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -546,8 +546,10 @@ export class ModelOverview extends React.Component<
       this.state.selectedFeatures.length > 0 &&
       this.state.featureBasedCohorts.length > 1;
 
-    return showHeatmapToggleInDatasetCohortView ||
-    showHeatmapToggleInFeatureCohortView;
+    return (
+      showHeatmapToggleInDatasetCohortView ||
+      showHeatmapToggleInFeatureCohortView
+    );
   }
 
   private shouldRenderModelOverviewChartPivot(): boolean {

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.tsx
@@ -424,11 +424,8 @@ export class ModelOverview extends React.Component<
               labeledStatistics={this.state.datasetCohortLabeledStatistics}
               selectableMetrics={selectableMetrics}
               selectedMetrics={this.state.selectedMetrics}
-              showHeatmapColors={
-                this.state.showHeatmapColors &&
-                this.context.dataset.task_type !==
-                  DatasetTaskType.ObjectDetection
-              }
+              showHeatmapColors={this.state.showHeatmapColors}
+              modelType={this.context.modelMetadata.modelType}
             />
           ) : (
             <>
@@ -478,11 +475,8 @@ export class ModelOverview extends React.Component<
                 selectedMetrics={this.state.selectedMetrics}
                 selectedFeatures={this.state.selectedFeatures}
                 featureBasedCohorts={this.state.featureBasedCohorts}
-                showHeatmapColors={
-                  this.state.showHeatmapColors &&
-                  this.context.dataset.task_type !==
-                    DatasetTaskType.ObjectDetection
-                }
+                showHeatmapColors={this.state.showHeatmapColors}
+                modelType={this.context.modelMetadata.modelType}
               />
             </>
           )}
@@ -552,12 +546,8 @@ export class ModelOverview extends React.Component<
       this.state.selectedFeatures.length > 0 &&
       this.state.featureBasedCohorts.length > 1;
 
-    return (
-      (showHeatmapToggleInDatasetCohortView ||
-        showHeatmapToggleInFeatureCohortView) &&
-      // excluding object detection scenario
-      this.context.dataset.task_type !== DatasetTaskType.ObjectDetection
-    );
+    return showHeatmapToggleInDatasetCohortView ||
+    showHeatmapToggleInFeatureCohortView;
   }
 
   private shouldRenderModelOverviewChartPivot(): boolean {

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -8,6 +8,7 @@ import {
   ErrorCohort,
   HighchartsNull,
   ILabeledStatistic,
+  ModelTypes,
   MulticlassClassificationMetrics,
   MultilabelMetrics,
   ObjectDetectionMetrics,
@@ -32,7 +33,8 @@ export function generateCohortsStatsTable(
   selectableMetrics: IDropdownOption[],
   labeledStatistics: ILabeledStatistic[][],
   selectedMetrics: string[],
-  useTexturedBackgroundForNaN: boolean
+  useTexturedBackgroundForNaN: boolean,
+  modelType: string
 ): {
   fairnessStats: IFairnessStats[];
   items: PointOptionsObject[];
@@ -149,8 +151,11 @@ export function generateCohortsStatsTable(
         } else {
           const theme = getTheme();
           // not a numeric value (NaN), so just put null and use textured color
-          const colorConfig = useTexturedBackgroundForNaN
-            ? {
+          const colorConfig = (
+            useTexturedBackgroundForNaN &&
+            modelType !== ModelTypes.ObjectDetection &&
+            modelType !== ModelTypes.QuestionAnswering
+          ) ? {
                 color: {
                   pattern: {
                     aspectRatio: 1,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/StatsTableUtils.ts
@@ -151,29 +151,29 @@ export function generateCohortsStatsTable(
         } else {
           const theme = getTheme();
           // not a numeric value (NaN), so just put null and use textured color
-          const colorConfig = (
+          const colorConfig =
             useTexturedBackgroundForNaN &&
             modelType !== ModelTypes.ObjectDetection &&
             modelType !== ModelTypes.QuestionAnswering
-          ) ? {
-                color: {
-                  pattern: {
-                    aspectRatio: 1,
-                    backgroundColor: theme.semanticColors.bodyBackground,
-                    color: theme.palette.magentaLight,
-                    height: 10,
-                    image: "",
-                    opacity: 0.5,
-                    path: {
-                      d: "M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11",
-                      strokeWidth: 3
-                    },
-                    patternTransform: "",
-                    width: 10
+              ? {
+                  color: {
+                    pattern: {
+                      aspectRatio: 1,
+                      backgroundColor: theme.semanticColors.bodyBackground,
+                      color: theme.palette.magentaLight,
+                      height: 10,
+                      image: "",
+                      opacity: 0.5,
+                      path: {
+                        d: "M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11",
+                        strokeWidth: 3
+                      },
+                      patternTransform: "",
+                      width: 10
+                    }
                   }
                 }
-              }
-            : { color: "transparent" };
+              : { color: "transparent" };
           items.push({
             ...colorConfig,
             // null is treated as a special value by highcharts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds heatmap support for OD scenario to achieve corresponding feature parity with other dashboards.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/02237d62-b3fc-4727-a7c7-6d32c445af2d)

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/78b7bf16-bb55-434f-9a94-412a2a994a2e)

The main drawback of this support is I had to end up disabling the magenta color during `N/A` status while metrics are being computed, because I could not override the metrics to have transparent color anywhere in StatsTableUtils.ts as that ended up overriding the heatmap colors.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/9cc419e1-4276-47fe-a67c-8c93c9c673f7)

Considering the magenta color with `N/A` display is only valid for OD & QA scenarios, and is not a breaking feature change but a nice-to-have UI (not to mention potentially switching this with async loaders), this support can be enabled in a future PR.


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
