### PR TITLE
RAI Text Dashboard a11y: make scrollable pane focusable and use label attribute on slider

### DIFF
--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/SidePanelOfChart.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextExplanationView/SidePanelOfChart.tsx
@@ -4,7 +4,6 @@
 import {
   ChoiceGroup,
   IChoiceGroupOption,
-  Label,
   Slider,
   Stack,
   Text
@@ -97,10 +96,6 @@ export class SidePanelOfChart extends React.PureComponent<ISidePanelOfChartProps
               </Stack.Item>
             )}
 
-            <Stack.Item>
-              <Label>{localization.InterpretText.View.importantWords}</Label>
-            </Stack.Item>
-
             <Stack.Item id="TextTopKSlider">
               <Slider
                 min={1}
@@ -110,6 +105,7 @@ export class SidePanelOfChart extends React.PureComponent<ISidePanelOfChartProps
                 showValue
                 onChange={this.props.setTopK}
                 ariaLabel={localization.InterpretText.View.sliderAriaLabel}
+                label={localization.InterpretText.View.importantWords}
               />
             </Stack.Item>
             {!this.props.isQA && (

--- a/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHightlighting.tsx
+++ b/libs/interpret-text/src/lib/TextExplanationDashboard/Control/TextHighlighting/TextHightlighting.tsx
@@ -35,7 +35,10 @@ export class TextHighlighting extends React.Component<IChartProps> {
     const sortedList = Utils.sortedTopK(importances, k, this.props.radio);
     return (
       <Stack styles={scrollablePaneStyles}>
-        <ScrollablePane scrollbarVisibility={ScrollbarVisibility.auto}>
+        <ScrollablePane
+          scrollbarVisibility={ScrollbarVisibility.auto}
+          scrollContainerFocus
+        >
           <Stack
             id="TextHighlighting"
             horizontal


### PR DESCRIPTION
## Description

RAI Text Dashboard a11y: make scrollable pane focusable and use label attribute on slider

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/f3ad5e86-ca16-4a12-8f05-3995c3b8cf7e)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
