### PR TITLE
Add pandas timestamp support to json serialization utility function in raiutils

### DIFF
--- a/raiutils/raiutils/data_processing/data_processing_utils.py
+++ b/raiutils/raiutils/data_processing/data_processing_utils.py
@@ -143,7 +143,7 @@ def serialize_json_safe(o: Any):
         if isinstance(o, str):
             return json.dumps(o)[1:-1]
         return o
-    elif isinstance(o, datetime.datetime):
+    elif isinstance(o, datetime.datetime) or isinstance(o, pd.Timestamp):
         return o.__str__()
     elif isinstance(o, dict):
         return {k: serialize_json_safe(v, ) for k, v in o.items()}

--- a/raiutils/tests/test_data_processing_utils.py
+++ b/raiutils/tests/test_data_processing_utils.py
@@ -253,7 +253,7 @@ class TestSerializationUtilities:
         datetime_object = datetime.datetime.strptime(datetime_str, "%Y-%m-%d")
         result = serialize_json_safe(datetime_object)
         assert datetime_str in result
-    
+
     def test_serialize_pandas_timestamp(self):
         datetime_str = "2020-10-10"
         datetime_object = pd.Timestamp(datetime_str)

--- a/raiutils/tests/test_data_processing_utils.py
+++ b/raiutils/tests/test_data_processing_utils.py
@@ -253,6 +253,12 @@ class TestSerializationUtilities:
         datetime_object = datetime.datetime.strptime(datetime_str, "%Y-%m-%d")
         result = serialize_json_safe(datetime_object)
         assert datetime_str in result
+    
+    def test_serialize_pandas_timestamp(self):
+        datetime_str = "2020-10-10"
+        datetime_object = pd.Timestamp(datetime_str)
+        result = serialize_json_safe(datetime_object)
+        assert datetime_str in result
 
     def test_serialize_via_json_timestamp(self):
         timestamp_obj = pd.Timestamp(2020, 1, 1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add pandas timestamp support to json serialization utility function in raiutils.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
