### PR TITLE
fix error analysis for RAITextInsights displaying all incorrect instances for text labels

### DIFF
--- a/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
+++ b/responsibleai_text/responsibleai_text/managers/error_analysis_manager.py
@@ -4,6 +4,7 @@
 """Defines the Error Analysis Manager class."""
 
 import json
+import numbers
 from typing import Any, List, Optional, Union
 
 import jsonschema
@@ -110,7 +111,9 @@ class WrappedIndexPredictorModel:
         predictions = self.predictions[index]
         if self.task_type == ModelTask.MULTILABEL_TEXT_CLASSIFICATION:
             return predictions
-        if self.classes is not None and isinstance(predictions[0], int):
+        # use number.Integral to check for any numpy or python number type
+        if self.classes is not None and isinstance(predictions[0],
+                                                   numbers.Integral):
             predictions = [self.classes[y] for y in predictions]
         return predictions
 

--- a/responsibleai_text/tests/rai_text_insights_validator.py
+++ b/responsibleai_text/tests/rai_text_insights_validator.py
@@ -28,6 +28,9 @@ def validate_rai_text_insights(
     assert explanation is None or isinstance(explanation, list)
     explanation_data = rai_text_insights.explainer.get_data()
     assert explanation_data is None or isinstance(explanation_data, list)
+    error_analysis_data = rai_text_insights.error_analysis.get_data()
+    assert error_analysis_data is None or isinstance(
+        error_analysis_data, list)
     if task_type == ModelTask.TEXT_CLASSIFICATION:
         np.testing.assert_array_equal(rai_text_insights._classes,
                                       classes)
@@ -40,6 +43,10 @@ def validate_rai_text_insights(
             local_importances = local_data[0].localExplanations
             text = local_data[0].text
             assert len(local_importances) == len(text)
+        if error_analysis_data:
+            root_node = error_analysis_data[0].tree[0]
+            # assert there were some successful predictions as sanity check
+            assert root_node['error'] < root_node['size']
     if task_type == ModelTask.QUESTION_ANSWERING:
         if explanation_data:
             exp_data = explanation_data[0].precomputedExplanations

--- a/responsibleai_text/tests/test_rai_text_insights.py
+++ b/responsibleai_text/tests/test_rai_text_insights.py
@@ -2,13 +2,15 @@
 # Licensed under the MIT License.
 
 from common_text_utils import (ANSWERS, BLBOOKS_LABEL, COVID19_EVENTS_LABELS,
-                               EMOTION, create_blbooks_pipeline,
+                               DBPEDIA_LABEL, EMOTION, create_blbooks_pipeline,
+                               create_dbpedia_pipeline,
                                create_multilabel_pipeline,
                                create_question_answering_pipeline,
                                create_text_classification_pipeline,
                                load_blbooks_genre_dataset,
                                load_covid19_emergency_event_dataset,
-                               load_emotion_dataset, load_squad_dataset)
+                               load_dbpedia_dataset, load_emotion_dataset,
+                               load_squad_dataset)
 from rai_text_insights_validator import validate_rai_text_insights
 
 from responsibleai.feature_metadata import FeatureMetadata
@@ -65,6 +67,12 @@ class TestRAITextInsights(object):
                                                  'annotated']
         run_rai_insights(pred, data, data[:5], BLBOOKS_LABEL, task_type,
                          feature_metadata, text_column='text')
+
+    def test_rai_insights_dbpedia(self):
+        data = load_dbpedia_dataset()
+        pred = create_dbpedia_pipeline()
+        task_type = ModelTask.TEXT_CLASSIFICATION
+        run_rai_insights(pred, data, data[:5], DBPEDIA_LABEL, task_type)
 
 
 def run_rai_insights(model, train_data, test_data,


### PR DESCRIPTION
## Description

On the DBPedia dataset, fix error analysis for RAITextInsights displaying all incorrect instances for text labels:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/9d90621d-4b59-4d3a-946c-85c1dfa53d98)
Note this is only happening for a particular multiclass text classification case where the predicted label is a numpy int type.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
