### PR TITLE
add text feature importance e2e unit tests for blbooksgenre jupyter notebook

### DIFF
--- a/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxBlbooksgenreBinaryTextClassificationModelDebugging/individualTextFeatureImportance.spec.ts
+++ b/apps/widget-e2e/src/integration/modelAssessment/responsibleaitoolboxBlbooksgenreBinaryTextClassificationModelDebugging/individualTextFeatureImportance.spec.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  describeModelAssessmentTextFeatureImportance,
+  modelAssessmentDatasets
+} from "@responsible-ai/e2e";
+
+const datasetShape =
+  modelAssessmentDatasets.BlbooksgenreTextClassificationModelDebugging;
+describeModelAssessmentTextFeatureImportance(
+  datasetShape,
+  "BlbooksgenreTextClassificationModelDebugging"
+);

--- a/libs/e2e/src/lib/describer/interpretText/IInterpretTextData.ts
+++ b/libs/e2e/src/lib/describer/interpretText/IInterpretTextData.ts
@@ -11,4 +11,5 @@ export interface IInterpretTextData {
     positiveFeaturesExpectedValues: number;
   };
   explanationIndex: number;
+  expandCorrect?: boolean;
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/BlbooksgenreTextClassificationModelDebugging.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/BlbooksgenreTextClassificationModelDebugging.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { textExplanationData } from "./BlbooksgenreTextExplanationData";
+
 export const BlbooksgenreTextClassificationModelDebugging = {
   causalAnalysisData: {
     hasCausalAnalysisComponent: false
@@ -48,5 +50,6 @@ export const BlbooksgenreTextClassificationModelDebugging = {
       name: "CohortCreateE2E-text-classification",
       sampleSize: "19"
     }
-  }
+  },
+  textExplanationData
 };

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/BlbooksgenreTextExplanationData.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/BlbooksgenreTextExplanationData.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const localExplanationData = [
+  [0, 0],
+  [-0.005633711814880371, 0.005633684573695064],
+  [-0.016269147396087646, 0.016269136918708682],
+  [-0.010049201548099518, 0.010049237171187997],
+  [0.009819332510232925, -0.009819337516091764],
+  [0.05134781077504158, -0.05134780355729163],
+  [-0.013548329472541809, 0.01354830723721534],
+  [0.004447728395462036, -0.004447765881195664],
+  [0, 0]
+];
+
+export const textExplanationData = {
+  classNames: ["0", "1"],
+  expandCorrect: true,
+  expectedFeaturesValues: {
+    allFeaturesExpectedValues: 3,
+    negativeFeaturesExpectedValues: 3,
+    positiveFeaturesExpectedValues: 3
+  },
+  explanationIndex: 19,
+  localExplanations: localExplanationData,
+  text: ["", "Maximilian", ", ", "and ", "other ", "poems", ", ", "etc", ""]
+};

--- a/libs/e2e/src/lib/describer/modelAssessment/featureImportances/textFeatureImportance/describeModelAssessmentTextFeatureImportance.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/featureImportances/textFeatureImportance/describeModelAssessmentTextFeatureImportance.ts
@@ -27,6 +27,9 @@ export function describeModelAssessmentTextFeatureImportance(
     if (datasetShape.textExplanationData) {
       const textExplanationData = datasetShape.textExplanationData;
       it("should be able to select a table row for testing", () => {
+        if (textExplanationData.expandCorrect) {
+          cy.get(Locators.IFICollapseButton).first().click();
+        }
         selectRow(
           "Index",
           textExplanationData.explanationIndex.toString(),


### PR DESCRIPTION
## Description

add text feature importance e2e unit tests for blbooksgenre jupyter notebook

Video of new text feature importance tests on blbooksgenre dataset:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/bcf2f59b-31ea-4186-aa20-ef68979a1258

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
