### PR TITLE
fix question answering pipeline indexing error in shap due to varied token length after masking

### DIFF
--- a/responsibleai_text/tests/test_rai_text_insights.py
+++ b/responsibleai_text/tests/test_rai_text_insights.py
@@ -29,7 +29,16 @@ class TestRAITextInsights(object):
         data = load_squad_dataset()
         pred = create_question_answering_pipeline()
         task_type = ModelTask.QUESTION_ANSWERING
-        run_rai_insights(pred, data, data[:5], ANSWERS, task_type)
+        run_rai_insights(pred, data, data[:3], ANSWERS, task_type)
+
+    def test_rai_insights_question_answering_varied_outputs(self):
+        data = load_squad_dataset()
+        pred = create_question_answering_pipeline()
+        task_type = ModelTask.QUESTION_ANSWERING
+        # data[6:7] seems to create varied output sizes for some masking
+        # adding to test suite to ensure this passes
+        test_data = data[6:7].reset_index(drop=True)
+        run_rai_insights(pred, data, test_data, ANSWERS, task_type)
 
     def test_rai_insights_question_answering_metadata(self):
         data = load_squad_dataset(with_metadata=True)
@@ -37,7 +46,7 @@ class TestRAITextInsights(object):
         task_type = ModelTask.QUESTION_ANSWERING
         feature_metadata = FeatureMetadata()
         feature_metadata.categorical_features = ['title']
-        run_rai_insights(pred, data, data[:5], ANSWERS, task_type,
+        run_rai_insights(pred, data, data[:3], ANSWERS, task_type,
                          feature_metadata)
 
     def test_rai_insights_multilabel(self):


### PR DESCRIPTION
## Description

In some cases, we are seeing shap explainer failing for certain question answering models/pipelines on certain text datasets with the error:

```
TypeError: only size-1 arrays can be converted to Python scalars

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "./rai_text_insights.py", line 408, in <module>
    main(args)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/azureml/rai/utils/telemetry/loggerfactory.py", line 153, in wrapper
    return func(*args, **kwargs)
  File "./rai_text_insights.py", line 377, in main
    rai_ti.compute()
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/responsibleai/rai_insights/rai_base_insights.py", line 84, in compute
    manager.compute()
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/responsibleai_text/managers/explainer_manager.py", line 132, in compute
    self._explanation = [explainer_start(eval_examples),
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/explainers/_partition.py", line 136, in __call__
    return super().__call__(
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/explainers/_explainer.py", line 266, in __call__
    row_result = self.explain_row(
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/explainers/_partition.py", line 184, in explain_row
    self.owen(fm, self._curr_base_value, f11, max_evals - 2, outputs, fixed_context, batch_size, silent)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/explainers/_partition.py", line 296, in owen
    fout = fm(batch_masks)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/utils/_masked_model.py", line 67, in __call__
    return self._full_masking_call(masks, batch_size=batch_size)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/utils/_masked_model.py", line 158, in _full_masking_call
    _build_fixed_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, self.link, self._linearizing_weights)
  File "/azureml-envs/responsibleai-text/lib/python3.8/site-packages/shap/utils/_masked_model.py", line 358, in _build_fixed_output
    _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights)
ValueError: setting an array element with a sequence.
```

After investigating in depth, we found that shap uses [MASK] to permute text tokens (to turn tokens "off"), but the tokenizer in certain pipelines on very rare cases may interpret those masks as extra tokens.  Afterward, the code may fail on returning the vector of token indexes for inferencing to the original model - when converting to numpy, these are treated as a jagged array, and the subsequent code fails.  The simple fix for these rare cases is to ensure that the length of all arrays within the inferencing batch is the same.  There may be a better fix inside shap codebase for replacing tokens with [MASK]s such that the tokenizer always interprets the input text in the same manner, although this also may not be feasible for every possible type of tokenizer. Since this issue occurs very rarely this fix seems sufficient for now.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
