### PR TITLE
fix true y and pred y not appearing for QA text dashboard in table view

### DIFF
--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -66,7 +66,13 @@ export function constructRows(
           row
         );
       } else {
-        pushRowData(tableRow, JointDataset.TrueYLabel, jointDataset, row);
+        pushRowData(
+          tableRow,
+          JointDataset.TrueYLabel,
+          jointDataset,
+          row,
+          index
+        );
       }
     }
     if (jointDataset.hasPredictedY) {
@@ -78,7 +84,13 @@ export function constructRows(
           row
         );
       } else {
-        pushRowData(tableRow, JointDataset.PredictedYLabel, jointDataset, row);
+        pushRowData(
+          tableRow,
+          JointDataset.PredictedYLabel,
+          jointDataset,
+          row,
+          index
+        );
       }
     }
     tableRow.push(...data);
@@ -178,13 +190,19 @@ function pushRowData(
   tableRow: any[],
   property: string,
   jointDataset: JointDataset,
-  row: { [key: string]: number }
+  row: { [key: string]: number },
+  index: number
 ): void {
   const categories = jointDataset.metaDict[property]?.sortedCategoricalValues;
-  if (jointDataset.metaDict[property].isCategorical && categories) {
-    tableRow.push(categories[row[property]]);
-  } else {
-    tableRow.push(row[property]);
+  const rowValue = row[property];
+  if (rowValue !== undefined) {
+    if (jointDataset.metaDict[property].isCategorical && categories) {
+      tableRow.push(categories[row[property]]);
+    } else {
+      tableRow.push(row[property]);
+    }
+  } else if (jointDataset.strDataDict) {
+    tableRow.push(jointDataset.strDataDict[index][property]);
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix true y and pred y not appearing for QA text dashboard in table view

These columns were appearing as blank for QA scenario.  This PR fixes the columns to contain the string values:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/dd584106-a9b2-444d-b576-db129dbd7887)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
