### PR TITLE
NoLabel fix for Object Detection

### DIFF
--- a/apps/dashboard/src/model-assessment-vision/__mock_data__/fridgeObjectDetection.ts
+++ b/apps/dashboard/src/model-assessment-vision/__mock_data__/fridgeObjectDetection.ts
@@ -105,27 +105,27 @@ export const fridgeObjectDetection: IDataset = {
     {
       aggregate: "2 correct, 0 incorrect",
       correct: "1 milk_bottle, 1 can",
-      incorrect: "None"
+      incorrect: "(none)"
     },
     {
       aggregate: "2 correct, 0 incorrect",
       correct: "1 milk_bottle, 1 can",
-      incorrect: "None"
+      incorrect: "(none)"
     },
     {
       aggregate: "2 correct, 0 incorrect",
       correct: "1 carton, 1 water_bottle",
-      incorrect: "None"
+      incorrect: "(none)"
     },
     {
       aggregate: "2 correct, 0 incorrect",
       correct: "1 can, 1 milk_bottle",
-      incorrect: "None"
+      incorrect: "(none)"
     },
     {
       aggregate: "2 correct, 0 incorrect",
       correct: "1 carton, 1 water_bottle",
-      incorrect: "None"
+      incorrect: "(none)"
     }
   ],
   predicted_y: [

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
@@ -16,7 +16,7 @@ import { localization } from "@responsible-ai/localization";
 
 import { IVisionExplanationDashboardProps } from "./Interfaces/IVisionExplanationDashboardProps";
 import { IVisionExplanationDashboardState } from "./Interfaces/IVisionExplanationDashboardState";
-import { getJoinedLabelString } from "./utils/labelUtils";
+import { getJoinedLabelString, NoLabel } from "./utils/labelUtils";
 
 export enum VisionDatasetExplorerTabOptions {
   ImageExplorerView = "Image explorer view",
@@ -115,7 +115,7 @@ export function preprocessData(
     const predictedYValue = getJoinedLabelString(item.predictedY);
     const trueYValue = getJoinedLabelString(item.trueY);
     if (dataset.task_type === DatasetTaskType.ObjectDetection) {
-      item.odIncorrect === "None"
+      item.odIncorrect === NoLabel
         ? successInstances.push(item)
         : errorInstances.push(item);
     } else {

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/labelUtils.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/labelUtils.ts
@@ -3,7 +3,7 @@
 
 import { IVisionListItem } from "@responsible-ai/core-ui";
 
-const NoLabel = "(none)";
+export const NoLabel = "(none)";
 
 export function getJoinedLabelString(
   labels: string | string[] | undefined

--- a/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
+++ b/responsibleai_vision/responsibleai_vision/rai_vision_insights/rai_vision_insights.py
@@ -88,6 +88,7 @@ _DROPPED_FEATURES = 'dropped_features'
 _INCORRECT = 'incorrect'
 _CORRECT = 'correct'
 _AGGREGATE_LABEL = 'aggregate'
+_NOLABEL = '(none)'
 
 
 def reshape_image(image):
@@ -746,12 +747,12 @@ class RAIVisionInsights(RAIBaseInsights):
                 f'{value} {key}' for key, value in
                 image_labels[_CORRECT].items())
             if len(rendered_labels[_CORRECT]) == 0:
-                rendered_labels[_CORRECT] = 'None'
+                rendered_labels[_CORRECT] = _NOLABEL
             rendered_labels[_INCORRECT] = ', '.join(
                 f'{value} {key}' for key, value in
                 image_labels[_INCORRECT].items())
             if len(rendered_labels[_INCORRECT]) == 0:
-                rendered_labels[_INCORRECT] = 'None'
+                rendered_labels[_INCORRECT] = _NOLABEL
             rendered_labels[_AGGREGATE_LABEL] = \
                 f"{sum(image_labels[_CORRECT].values())} {_CORRECT}, \
                   {sum(image_labels[_INCORRECT].values())} \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the nolabel for object detection, by bringing all nolabels to `(none)`, similar to the rest of the image dashboards.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/ba57c85b-0fd5-4ffe-90c6-bc25816be91f)

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/f09d0742-a9c9-4828-b3f5-f2b0283cf66d)

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/f92ad7a5-151e-4904-84fa-59235f8679f7)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
