### PR TITLE
fix choose cohorts close or cancel updating feature cohorts selection in flyout

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutProps.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutProps.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ErrorCohort } from "@responsible-ai/core-ui";
+
+export interface IChartConfigurationFlyoutProps {
+  isOpen: boolean;
+  onDismissFlyout: () => void;
+  datasetCohorts: ErrorCohort[];
+  featureBasedCohorts: ErrorCohort[];
+  selectedDatasetCohorts?: number[];
+  selectedFeatureBasedCohorts?: number[];
+  updateCohortSelection: (
+    selectedDatasetCohorts: number[],
+    selectedFeatureBasedCohorts: number[],
+    datasetCohortChartIsSelected: boolean
+  ) => void;
+  datasetCohortViewIsSelected: boolean;
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutState.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutState.tsx
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export interface IChartConfigurationFlyoutState {
+  newlySelectedDatasetCohorts: number[];
+  newlySelectedFeatureBasedCohorts: number[];
+  datasetCohortViewIsNewlySelected: boolean;
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutUtils.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ChartConfigurationFlyoutUtils.tsx
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IDropdownOption } from "@fluentui/react";
+import { ErrorCohort } from "@responsible-ai/core-ui";
+
+export const selectAllOptionKey = "selectAll";
+
+export function getInitialNewlySelectedDatasetCohorts(
+  selectedDatasetCohorts: number[] | undefined,
+  datasetCohorts: ErrorCohort[]
+): number[] {
+  return (
+    selectedDatasetCohorts ??
+    datasetCohorts.map((errorCohort) => errorCohort.cohort.getCohortID())
+  );
+}
+
+export function getInitialNewlySelectedFeatureCohorts(
+  selectedFeatureBasedCohorts: number[] | undefined,
+  featureBasedCohorts: ErrorCohort[]
+): number[] {
+  return (
+    selectedFeatureBasedCohorts ?? featureBasedCohorts.map((_, index) => index)
+  );
+}
+
+export function makeChartCohortOptionSelectionChange(
+  currentlySelected: number[],
+  allItems: number[],
+  item: IDropdownOption
+): number[] {
+  if (item.key === selectAllOptionKey) {
+    // if all items were selected before then unselect all now
+    // if at least some items were not selected before then select all now
+    if (currentlySelected.length !== allItems.length) {
+      return allItems;
+    }
+    return [];
+  }
+  const key = Number(item.key);
+
+  if (item.selected && !currentlySelected.includes(key)) {
+    // update with newly selected item
+    return currentlySelected.concat([key]);
+  } else if (!item.selected && currentlySelected.includes(key)) {
+    // update by removing the unselected item
+    return currentlySelected.filter((idx) => idx !== key);
+  }
+
+  return currentlySelected;
+}
+
+export function getIndexAndNames(
+  errorCohorts: ErrorCohort[]
+): IDropdownOption[] {
+  return errorCohorts.map((cohort, index) => {
+    return { key: index.toString(), text: cohort.cohort.name };
+  });
+}
+
+export function getIdAndNames(errorCohorts: ErrorCohort[]): IDropdownOption[] {
+  return errorCohorts.map((errorCohort) => {
+    return {
+      key: errorCohort.cohort.getCohortID().toString(),
+      text: errorCohort.cohort.name
+    };
+  });
+}
+
+export function getMaxCohortId(cohorts: ErrorCohort[]): number {
+  return Math.max(
+    ...cohorts.map((errorCohort) => errorCohort.cohort.getCohortID())
+  );
+}
+
+export function noCohortIsSelected(
+  datasetCohortViewIsNewlySelected: boolean,
+  newlySelectedDatasetCohorts: number[],
+  newlySelectedFeatureBasedCohorts: number[]
+): boolean {
+  return (
+    (datasetCohortViewIsNewlySelected &&
+      newlySelectedDatasetCohorts.length === 0) ||
+    (!datasetCohortViewIsNewlySelected &&
+      newlySelectedFeatureBasedCohorts.length === 0)
+  );
+}


### PR DESCRIPTION
## Description

Fixing bug from bug bash discovered by @vinuthakaranth 
The "Choose cohorts" flyout was saving the user's selection even when they clicked cancel or close buttons.
This issue was found during text/vision dashboard bugbash but it looks like a general issue that is in the tabular dashboard as well.

Video of functionality prior to fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/5afe7832-69fe-43b6-aa03-da0ed53e7bc3


Video of functionality after fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/f0f9b577-dedd-4ad7-ad54-71f0270a79d2




## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
