### PR TITLE
fix data analysis description and tooltips hidden for large screens

### DIFF
--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -186,6 +186,12 @@
     "showTop": "Datapoints with the largest estimated causal responses to treatment feature: {0}",
     "whatifDescription": "What-if allows you to perturb features for any input and observe how the model's prediction changes. You can perturb features manually or specify the desired prediction (e.g., class label for a classifier) to see a list of closest data points to the original input that would lead to the desired prediction. Also known as prediction counterfactuals, you can use them for exploring the relationships learnt by the model; understanding important, necessary features for the model's predictions; or debug edge-cases for the model. To start, choose input points from the data table or scatter plot."
   },
+  "DataAnalysis": {
+    "TableView": {
+      "description": "View the dataset in a table representation with the ground truth and predicted labels. The table is separated into sub-tables of correct and incorrect predictions.",
+      "infoTitle": "Additional information on table view"
+    }
+  },
   "ErrorAnalysis": {
     "Cohort": {
       "_cohort.comment": "a subset of the data is called a cohort",
@@ -1692,7 +1698,6 @@
       "CorrectPredictions": "Correct predictions",
       "GlobalExplanation": "Aggregate feature importance",
       "IncorrectPredictions": "Incorrect predictions",
-      "InfoTitle": "Additional information on data analysis table view",
       "IndividualFeatureTabular": "Select a datapoint by clicking on a datapoint (up to 5 datapoints) in the table to view their local feature importance values (local explanation) and individual conditional expectation (ICE) plots.",
       "IndividualFeatureText": "Select a datapoint by clicking on a datapoint in the table to view the local feature importance values (local explanation).",
       "LocalExplanation": "Individual feature importance",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.styles.ts
@@ -7,7 +7,6 @@ import {
   IProcessedStyleSet,
   getTheme
 } from "@fluentui/react";
-import { hideXxlUp } from "@responsible-ai/core-ui";
 
 export interface ITabsViewStyles {
   section: IStyle;
@@ -41,8 +40,7 @@ export const tabsViewStyles: () => IProcessedStyleSet<ITabsViewStyles> = () => {
       textOverflow: "ellipsis"
     },
     sectionTooltip: {
-      display: "inline",
-      ...hideXxlUp
+      display: "inline"
     },
     stackStyle: {
       padding: "20px",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/utils.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/utils.ts
@@ -41,17 +41,8 @@ export function getInfo(
       body = localization.Interpret.DatasetExplorer.helperText;
       title = localization.Interpret.DatasetExplorer.infoTitle;
     } else if (dataAnalysisOption === DataAnalysisTabOptions.TableView) {
-      title = localization.ModelAssessment.FeatureImportances.InfoTitle;
-      let hasTextImportances = false;
-      if (props?.modelExplanationData) {
-        hasTextImportances =
-          !!props.modelExplanationData[0]?.precomputedExplanations
-            ?.textFeatureImportance;
-      }
-      body = hasTextImportances
-        ? localization.ModelAssessment.FeatureImportances.IndividualFeatureText
-        : localization.ModelAssessment.FeatureImportances
-            .IndividualFeatureTabular;
+      title = localization.DataAnalysis.TableView.infoTitle;
+      body = localization.DataAnalysis.TableView.description;
     }
   } else if (tabKey === GlobalTabKeys.CausalAnalysisTab) {
     if (causalAnalysisOption === CausalAnalysisOptions.Aggregate) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two fixes for tooltips:

1.) Tooltips seem to be getting hidden in larger screens and shown in smaller screens.  Removing "hideXxlUp" to allow tooltips to be shown.
Before:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/e1700f38-c5ef-4140-9bf1-1d18dbbae764)

After:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/51a39e77-fe01-4a96-bd3b-47046f17b412)

2.) Data analysis info tooltip description incorrect:

Before:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/6adfedaf-f6ae-4d26-b6a6-e89e9ffd4ea2)

After:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/14b7a25c-f794-4222-a623-0cb36eb6dca8)



## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
