### PR TITLE
fix alignment of true and predicted labels in vision data explorer

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.styles.ts
@@ -58,7 +58,7 @@ export const imageListStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles
         color: "white",
         fontSize: FontSizes.small,
         fontWeight: "600",
-        paddingLeft: 10
+        paddingLeft: 5
       },
       labelContainer: {
         background: "rgba(0,0,0,0.4)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the alignment of true and predicted labels in vision data explorer.

Before:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/1a009413-659c-4fb9-8838-c282ee8a118c)

After:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/8620a782-75f0-45b4-8f12-7fbbb3b1ee22)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
