### PR TITLE
Add python 3.11 for erroranalysis, raiutils and rai-test-utils

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   ci-python:
     strategy:
+      fail-fast: false
       matrix:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -30,6 +30,8 @@ jobs:
             pythonVersion: "3.7"
           - operatingSystem: macos-latest
             pythonVersion: "3.8"
+          - packageDirectory: "responsibleai"
+            pythonVersion: "3.11"
 
     runs-on: ${{ matrix.operatingSystem }}
 

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   ci-python:
     strategy:
-      fail-fast: false
       matrix:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -19,7 +19,7 @@ jobs:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ["3.7", "3.8", "3.9", "3.10"]
+        pythonVersion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           - operatingSystem: macos-latest
             pythonVersion: "3.7"

--- a/erroranalysis/README.md
+++ b/erroranalysis/README.md
@@ -1,6 +1,6 @@
 # Error Analysis SDK for Python
 
-### This package has been tested with Python 3.6, 3.7, 3.8, 3.9 and 3.10
+### This package has been tested with Python 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 
 The error analysis sdk enables users to get a deeper understanding of machine learning model errors. When evaluating a machine learning model, aggregate accuracy is not sufficient and single-score evaluation may hide important conditions of inaccuracies. Use Error Analysis to identify cohorts with higher error rates and diagnose the root causes behind these errors.
 

--- a/erroranalysis/setup.py
+++ b/erroranalysis/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"

--- a/rai_test_utils/README.md
+++ b/rai_test_utils/README.md
@@ -1,6 +1,6 @@
 # Responsible AI test utilities for Python
 
-### This package has been tested with Python 3.6, 3.7, 3.8, 3.9 and 3.10
+### This package has been tested with Python 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 
 The Responsible AI Test Utilities package contains common testing utilities and functions shared across various RAI tools, including fairlearn, interpret-community, responsibleai, raiwidgets, ml-wrappers and other packages.
 

--- a/rai_test_utils/setup.py
+++ b/rai_test_utils/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"

--- a/raiutils/README.md
+++ b/raiutils/README.md
@@ -1,6 +1,6 @@
 # Responsible AI Utilities for Python
 
-### This package has been tested with Python 3.6, 3.7, 3.8, 3.9 and 3.10
+### This package has been tested with Python 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 
 The Responsible AI Utilities package contains common functions shared across various RAI tools, including fairlearn, interpret-community, responsibleai, raiwidgets and other packages, as well as notebook examples.
 

--- a/raiutils/setup.py
+++ b/raiutils/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Development Status :: 3 - Alpha"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The python 3.11 cannot be added for `responsibleai` because shap dependencies don't support it.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
