### PR TITLE
fix failing builds due to pytorch dependencies

### DIFF
--- a/.github/workflows/CI-notebook-vision.yml
+++ b/.github/workflows/CI-notebook-vision.yml
@@ -19,7 +19,7 @@ jobs:
       node-version: 16.x
     strategy:
       matrix:
-        operatingSystem: [ubuntu-latest, windows-latest]
+        operatingSystem: [ubuntu-latest]
         pythonVersion: [3.7, 3.8, 3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}
@@ -48,17 +48,29 @@ jobs:
       - name: Build Typescript
         run: yarn buildall
 
-      - if: ${{ matrix.operatingSystem != 'macos-latest' }}
+      - if: ${{ matrix.operatingSystem != 'macos-latest' && matrix.pythonVersion == '3.7' }}
+        name: Install pytorch on non-MacOS with python 3.7
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet "pytorch==1.13.1" "torchvision<0.15" captum cpuonly -c pytorch
+
+      - if: ${{ matrix.operatingSystem == 'macos-latest' && matrix.pythonVersion == '3.7' }}
+        name: Install Anaconda packages on MacOS with python 3.7
+        shell: bash -l {0}
+        run: |
+          conda install --yes --quiet "pytorch==1.13.1" "torchvision<0.15" captum -c pytorch
+
+      - if: ${{ matrix.operatingSystem != 'macos-latest' && matrix.pythonVersion != '3.7' }}
         name: Install pytorch on non-MacOS
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+          conda install --yes --quiet "pytorch<2.1,>1.13.1" "torchvision<0.16" captum cpuonly -c pytorch
 
-      - if: ${{ matrix.operatingSystem == 'macos-latest' }}
+      - if: ${{ matrix.operatingSystem == 'macos-latest' && matrix.pythonVersion != '3.7' }}
         name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum -c pytorch
+          conda install --yes --quiet "pytorch<2.1,>1.13.1" "torchvision<0.16" captum -c pytorch
 
       - name: Setup tools
         shell: bash -l {0}

--- a/.github/workflows/CI-responsibleai-text-vision-pytest.yml
+++ b/.github/workflows/CI-responsibleai-text-vision-pytest.yml
@@ -57,13 +57,13 @@ jobs:
         name: Install pytorch on non-MacOS
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" captum cpuonly -c pytorch
 
       - if: ${{ matrix.operatingSystem == 'macos-latest' }}
         name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum -c pytorch
+          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" captum -c pytorch
 
       - name: Setup tools
         shell: bash -l {0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1.) Fix ci-notebook-vision pipeline after torch 2.1 release since fastai tries to uninstall the latest 2.1 version causing OS out of disk space errors
2.) Fix ci-responsibleai-text-vision-python pipeline by pinning to 1.13.1 which is the version that automl depends on since automl tries to uninstall torch 2.1 leading to OS out of disk space errors
It is unknown why uninstalling the latest pytorch 2.1 is causing out of disk space errors as this did not happen before for prior pytorch versions.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
