### PR TITLE
add socket implementation to RAI dashboard object detection and question answering metrics calls

### DIFF
--- a/apps/widget/src/app/ModelAssessment.tsx
+++ b/apps/widget/src/app/ModelAssessment.tsx
@@ -14,7 +14,7 @@ import {
 import { ModelAssessmentDashboard } from "@responsible-ai/model-assessment";
 import React from "react";
 
-import { callFlaskService } from "./callFlaskService";
+import { callFlaskService, connectToFlaskService } from "./callFlaskService";
 import { CallbackType, IModelAssessmentProps } from "./ModelAssessmentUtils";
 
 export class ModelAssessment extends React.Component<IModelAssessmentProps> {
@@ -33,7 +33,7 @@ export class ModelAssessment extends React.Component<IModelAssessmentProps> {
         objectDetectionCache: Map<string, [number, number, number]>,
         abortSignal: AbortSignal
       ): Promise<any[]> => {
-        return callFlaskService(
+        return connectToFlaskService(
           this.props.config,
           [
             selectionIndexes,
@@ -42,7 +42,7 @@ export class ModelAssessment extends React.Component<IModelAssessmentProps> {
             iouThreshold,
             objectDetectionCache
           ],
-          "/get_object_detection_metrics",
+          "handle_object_detection_json",
           abortSignal
         );
       };
@@ -57,10 +57,10 @@ export class ModelAssessment extends React.Component<IModelAssessmentProps> {
         >,
         abortSignal: AbortSignal
       ): Promise<any[]> => {
-        return callFlaskService(
+        return connectToFlaskService(
           this.props.config,
           [selectionIndexes, questionAnsweringCache],
-          "/get_question_answering_metrics",
+          "handle_question_answering_json",
           abortSignal
         );
       };

--- a/apps/widget/src/app/callFlaskService.ts
+++ b/apps/widget/src/app/callFlaskService.ts
@@ -2,8 +2,13 @@
 // Licensed under the MIT License.
 
 import json5 from "json5";
+import { io } from "socket.io-client";
 
 import { IAppConfig } from "./config";
+
+interface IDataResponse<TResponse> {
+  data: TResponse;
+}
 
 export async function callFlaskService<TRequest, TResponse>(
   config: Pick<IAppConfig, "baseUrl" | "withCredentials">,
@@ -29,5 +34,37 @@ export async function callFlaskService<TRequest, TResponse>(
       return json.data;
     }
     return Promise.reject(new Error(resp.statusText));
+  });
+}
+
+export async function connectToFlaskService<TRequest, TResponse>(
+  config: Pick<IAppConfig, "baseUrl" | "withCredentials">,
+  data: TRequest,
+  urlPath: string,
+  abortSignal?: AbortSignal
+): Promise<TResponse> {
+  return new Promise<TResponse>((resolve, reject) => {
+    if (abortSignal?.aborted) {
+      return reject(new Error("Aborted socket connection"));
+    }
+    const url = config.baseUrl;
+    const socket = io(url, {
+      reconnectionDelayMax: 10000
+    });
+    socket.on("connect", () => {
+      console.log(`socket connected, socket id: ${socket.id}, url: ${url}`);
+    });
+    socket.on("disconnect", () => {
+      console.log("socket disconnected");
+    });
+    socket.emit(
+      urlPath,
+      {
+        data: JSON.stringify(data)
+      },
+      (response: IDataResponse<TResponse>) => {
+        return resolve(response.data);
+      }
+    );
   });
 }

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/CovidTextExplanationData.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/CovidTextExplanationData.ts
@@ -158,7 +158,7 @@ export const textExplanationData = {
   ],
   expectedFeaturesValues: {
     allFeaturesExpectedValues: 13,
-    negativeFeaturesExpectedValues: 5,
+    negativeFeaturesExpectedValues: 4,
     positiveFeaturesExpectedValues: 13
   },
   explanationIndex: 0,

--- a/libs/e2e/src/lib/describer/modelAssessment/datasets/DBPediaTextExplanationData.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/datasets/DBPediaTextExplanationData.ts
@@ -239,7 +239,7 @@ export const textExplanationData = {
   expectedFeaturesValues: {
     allFeaturesExpectedValues: 13,
     negativeFeaturesExpectedValues: 13,
-    positiveFeaturesExpectedValues: 10
+    positiveFeaturesExpectedValues: 6
   },
   explanationIndex: 13,
   localExplanations: localExplanationData,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-plotly.js": "^2.5.0",
     "react-router-dom": "^5.0.1",
     "regenerator-runtime": "0.13.7",
+    "socket.io-client": "^4.7.2",
     "tslib": "^2.5.0",
     "uuid": "^8.3.0",
     "vott-ct": "^2.4.2-rc.0"

--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 Flask-Cors
+flask-socketio
 ipython<=7.16.3; python_version <= '3.6'
 ipython>=7.31.1; python_version > '3.6'
 itsdangerous>=2.0.1

--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -3,6 +3,8 @@
 
 """Defines the Model Analysis Dashboard class."""
 
+import json
+
 from flask import jsonify, request
 
 from raiutils.models import ModelTask
@@ -114,3 +116,14 @@ class ResponsibleAIDashboard(Dashboard):
             '/get_question_answering_metrics',
             methods=["POST"]
         )
+
+        if hasattr(self._service, 'socketio'):
+            @self._service.socketio.on('handle_object_detection_json')
+            def handle_object_detection_json(od_json):
+                od_data = json.loads(od_json['data'])
+                return self.input.get_object_detection_metrics(od_data)
+
+            @self._service.socketio.on('handle_question_answering_json')
+            def handle_question_answering_json(qa_json):
+                qa_data = json.loads(qa_json['data'])
+                return self.input.get_question_answering_metrics(qa_data)

--- a/raiwidgets/requirements-dev.txt
+++ b/raiwidgets/requirements-dev.txt
@@ -12,6 +12,8 @@ fairlearn==0.7.0
 ml-wrappers>=0.4.0
 sktime
 pmdarima
+# temporary fix for gevent error until rai-core-flask updated
+shap<0.41.0
 
 # Jupyter dependency that fails with python 3.6
 pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'


### PR DESCRIPTION
## Description

add socket implementation to RAI dashboard object detection and question answering metrics calls

Use sockets instead of post requests for object detection and question answering metrics calls to avoid issues with timeouts.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
