### PR TITLE
Optional support for IS_CROWD for OD COCO label format

### DIFF
--- a/responsibleai_vision/responsibleai_vision/utils/image_utils.py
+++ b/responsibleai_vision/responsibleai_vision/utils/image_utils.py
@@ -129,6 +129,9 @@ def transform_object_detection_labels(test, target_column, classes):
                     xmax = label[BOTTOM_X] * width
                     ymax = label[BOTTOM_Y] * height
 
+                    if IS_CROWD not in label:
+                      label[IS_CROWD] = 0
+
                     image_labels.append([class_id, int(xmin), int(ymin),
                                          int(xmax), int(ymax),
                                          int(label[IS_CROWD])])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

Fix for the below stack trace with OD labels without IS_CROWD key:

<class 'KeyError'>
File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/azureml/rai/utils/telemetry/loggerfactory.py", line 153 in wrapper
  return func(*args, **kwargs)
File "./rai_vision_insights.py", line 456 in main
  rai_vi = RAIVisionInsights(
File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/rai_vision_insights/rai_vision_insights.py", line 239 in __init__
  test = transform_object_detection_labels(
File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/responsibleai_vision/utils/image_utils.py", line 134 in transform_object_detection_labels
  int(label[IS_CROWD])])

Making it optional instead of removing it, due to significance (and potential support in future) for use-cases with crowds of people: https://github.com/AlexeyAB/darknet/issues/5567#issuecomment-626753196

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
