### PR TITLE
Refer to predicted value from Counterfactual data

### DIFF
--- a/libs/counterfactuals/src/util/getOriginalData.ts
+++ b/libs/counterfactuals/src/util/getOriginalData.ts
@@ -4,7 +4,6 @@
 import {
   ICounterfactualData,
   IDataset,
-  ifEnableLargeData,
   JointDataset
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
@@ -21,7 +20,7 @@ export function getOriginalData(
       index
     )
   };
-  if (ifEnableLargeData(dataset) && counterfactualData) {
+  if (counterfactualData) {
     const featureNames = counterfactualData.feature_names_including_target;
     const dataPoint = counterfactualData.test_data[0][0];
     featureNames.forEach((f, index) => {


### PR DESCRIPTION
## Description

We need to refer to the predicted value from counterfactual data if it is available in all cases as it carries the original class values.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/47334368/8931ee60-8e1f-4b41-8cd1-1eeac131eba0)
The highlighted value is either 0 or 1 since it is read from `JointDataset`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
