### PR TITLE
fallback to request if socket connection fails for object detection and question answering metrics for backcompat

### DIFF
--- a/apps/widget/src/app/ModelAssessment.tsx
+++ b/apps/widget/src/app/ModelAssessment.tsx
@@ -14,7 +14,10 @@ import {
 import { ModelAssessmentDashboard } from "@responsible-ai/model-assessment";
 import React from "react";
 
-import { callFlaskService, connectToFlaskService } from "./callFlaskService";
+import {
+  callFlaskService,
+  connectToFlaskServiceWithBackupCall
+} from "./callFlaskService";
 import { CallbackType, IModelAssessmentProps } from "./ModelAssessmentUtils";
 
 export class ModelAssessment extends React.Component<IModelAssessmentProps> {
@@ -33,16 +36,18 @@ export class ModelAssessment extends React.Component<IModelAssessmentProps> {
         objectDetectionCache: Map<string, [number, number, number]>,
         abortSignal: AbortSignal
       ): Promise<any[]> => {
-        return connectToFlaskService(
+        const parameters = [
+          selectionIndexes,
+          aggregateMethod,
+          className,
+          iouThreshold,
+          objectDetectionCache
+        ];
+        return connectToFlaskServiceWithBackupCall(
           this.props.config,
-          [
-            selectionIndexes,
-            aggregateMethod,
-            className,
-            iouThreshold,
-            objectDetectionCache
-          ],
+          parameters,
           "handle_object_detection_json",
+          "/get_object_detection_metrics",
           abortSignal
         );
       };
@@ -57,10 +62,12 @@ export class ModelAssessment extends React.Component<IModelAssessmentProps> {
         >,
         abortSignal: AbortSignal
       ): Promise<any[]> => {
-        return connectToFlaskService(
+        const parameters = [selectionIndexes, questionAnsweringCache];
+        return connectToFlaskServiceWithBackupCall(
           this.props.config,
-          [selectionIndexes, questionAnsweringCache],
+          parameters,
           "handle_question_answering_json",
+          "/get_question_answering_metrics",
           abortSignal
         );
       };


### PR DESCRIPTION
## Description

fallback to request if socket connection fails for object detection and question answering metrics for backcompat

This is to ensure that users with older versions of the python package but new UI can still view metrics for QA and object detection scenarios.  Also, this ensures that users who may be in environments where socket connections are disallowed may still be able to view metrics if requests are allowed (and the request is small or the timeout is large).

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
