### PR TITLE
fix RangeIndex error in error analysis for object detection models

### DIFF
--- a/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
+++ b/responsibleai_vision/responsibleai_vision/managers/error_analysis_manager.py
@@ -115,6 +115,22 @@ class WrappedIndexPredictorModel:
             self.predictions = np.array(predictions_joined)
         self.predict_proba = self.model.predict_proba(test)
 
+    def index_predictions(self, index, predictions):
+        """Index the predictions.
+
+        :param index: The index to use.
+        :type index: list
+        :param predictions: The predictions to index.
+        :type predictions: list
+        """
+        if not isinstance(index, list):
+            index = list(index)
+        if isinstance(predictions, list):
+            predictions = [predictions[i] for i in index]
+        else:
+            predictions = predictions[index]
+        return predictions
+
     def predict(self, X):
         """Predict the class labels for the provided data.
 
@@ -124,7 +140,7 @@ class WrappedIndexPredictorModel:
         :rtype: list
         """
         index = X.index
-        predictions = self.predictions[index]
+        predictions = self.index_predictions(index, self.predictions)
         if self.task_type == ModelTask.MULTILABEL_IMAGE_CLASSIFICATION or \
                 self.task_type == ModelTask.OBJECT_DETECTION:
             return predictions
@@ -141,7 +157,7 @@ class WrappedIndexPredictorModel:
         :rtype: list[list]
         """
         index = X.index
-        pred_proba = self.predict_proba[index]
+        pred_proba = self.index_predictions(index, self.predict_proba)
         return pred_proba
 
 

--- a/responsibleai_vision/tests/rai_vision_insights_validator.py
+++ b/responsibleai_vision/tests/rai_vision_insights_validator.py
@@ -19,9 +19,14 @@ def validate_rai_vision_insights(
     rai_vision_insights,
     test_data,
     target_column,
-    task_type
+    task_type,
+    ignore_index=False
 ):
-    pd.testing.assert_frame_equal(rai_vision_insights.test, test_data)
+    rai_vision_test = rai_vision_insights.test
+    if ignore_index:
+        rai_vision_test = rai_vision_test.reset_index(drop=True)
+        test_data = test_data.reset_index(drop=True)
+    pd.testing.assert_frame_equal(rai_vision_test, test_data)
     assert rai_vision_insights.target_column == target_column
     assert rai_vision_insights.task_type == task_type
 


### PR DESCRIPTION
## Description

fix RangeIndex error in error analysis for object detection models.

Fix customer exception when using error analysis with RAI Vision Dashboard on a custom object detection model that outputs predictions as a jagged list.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
