### PR TITLE
Accessibility fix for 'Error Analysis' header

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -213,7 +213,7 @@ export class TabsView extends React.PureComponent<
                       className={classNames.sectionHeader}
                       id="errorAnalysisHeader"
                     >
-                      <Text variant={"xxLarge"}>
+                      <Text as="h2" variant={"xxLarge"}>
                         {
                           localization.ModelAssessment.ComponentNames
                             .ErrorAnalysis


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Actual Result: 'Error Analysis' text is not defined as heading programmatically.

Observation: The role is defined as "static text" for the 'Error Analysis'.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/9eed0205-6681-4b29-8d86-3be1c3606fd2)

Solution: 'Error Analysis' text which is visually appearing as heading should be defined as headings present under 'analyse_ model' page. It should be defined as heading <h2>/<h3>.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/2c7e816e-3fa2-43f9-915d-3cab5235fcf2)

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
