### PR TITLE
make elements under image explorer view tab keyboard accessible

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
@@ -79,6 +79,7 @@ export class ImageList extends React.Component<
           className={classNames.list}
           getPageHeight={this.getPageHeight}
           getItemCountForPage={this.getItemCountForPage}
+          tabIndex={0}
         />
       </FocusZone>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix for accessibility bug:
[Programmatic access - Responsible AI Dashboard – Vision Data Explorer>Image Explorer View]: Elements that have scrollable content under "Image explorer view" tab are not accessible by keyboard.

Users who rely on the keyboard for navigation will get impacted and miss the functionality of the control if the "Success Instances" section that has scrollable image contents under the "Image explorer view" tab are not accessible by keyboard.

Repro steps:
1.) Navigate the "Vision Data Explorer" section, navigate the "Image Explorer View" tab and all the controls present under it.
2.) Navigate to all the Image controls present under the "Success Instances" section.
3.) Observe and weather Elements that have scrollable content under "Image explorer view" tab are accessible by keyboard or not.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/854fc78f-1243-43e8-9b3f-fd9a02d1841a)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
