### PR TITLE
fix vision dashboard flyout accessibility on smaller screen size

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.styles.ts
@@ -25,6 +25,7 @@ export interface IFlyoutStyles {
   successIcon: IStyle;
   sectionIndent: IStyle;
   separator: IStyle;
+  stackDynamicScreenSize: IStyle;
   title: IStyle;
 }
 
@@ -89,6 +90,14 @@ export const flyoutStyles: () => IProcessedStyleSet<IFlyoutStyles> = () => {
     },
     separator: {
       width: "100%"
+    },
+    stackDynamicScreenSize: {
+      selectors: {
+        "@media (max-width: 740px)": {
+          alignItems: "flex-start",
+          flexFlow: "column"
+        }
+      }
     },
     successIcon: {
       color: theme.semanticColors.successIcon,

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/Flyout.tsx
@@ -124,6 +124,7 @@ export class Flyout extends React.Component<IFlyoutProps, IFlyoutState> {
                 tokens={stackTokens.medium}
                 horizontalAlign="space-around"
                 verticalAlign="center"
+                className={classNames.stackDynamicScreenSize}
               >
                 <Stack.Item>
                   <Stack


### PR DESCRIPTION
## Description

fix vision dashboard flyout accessibility on smaller screen size

Repro:
Navigate the "Vision Data Explorer" section, navigate the "Image Explorer View" tab and all the controls present under it.
Navigate to "Error Instances/Success instances" section.
Select an Error instance "Can".
"Selected Instance" dialog opens. Navigate all the controls present on the dialog.
Observe and verify whether Controls present under "Error Instances" section on "Selected Instance" dialog are truncated after setting the viewport to 320*256 pixel or not.

Background:
Low vision users who depend on zooming functionality for better readability will be impacted if the controls present under page/dialog are truncated after setting the viewport to 320*256 pixel. As a result, users will miss the important information present under the dialog.

Issue:
All the texts present under "Error Instances" section on "Selected Instance" dialog are truncated after setting the viewport to 320*256 pixel.

Text such as "X Error instances", "Image 26", "Predicted: can" and "Ground truth: water bottle" are truncated after setting the viewport to 320*256 pixel.
Dialog controls are truncated even after scrolling the dialog using arrow keys.

Expected Result:
After setting the viewport to 320*256 pixel, all the text such as "X Error instances", "Image 26", "Predicted: can" and "Ground truth: water bottle" present under "Selected Instance" dialog should be clearly visible without any truncation.

Video before fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/986ee062-071a-4ff9-9ea8-942b8c898946

Video after fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/f75bc50b-d8ce-4589-b082-4645df63817e


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
