### PR TITLE
Data Imputation Fix in `erroranalysis`

### DIFF
--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -476,12 +476,12 @@ class BaseAnalyzer(ABC):
                                                      IMPORTANCES_THRESHOLD)
             input_data = input_data[indexes]
             diff = diff[indexes]
-        # For numerical data types to make calculation/imputation error-free
-        input_data = input_data.astype(float)
         try:
             importances = self._compute_error_correlation(
                 input_data, diff, error_correlation_method)
         except ValueError:
+            # For numerical data types to make calculation/imputation error-free
+            input_data = input_data.astype(float)
             # Impute input_data if it contains NaNs, infinity or a value too
             # large for dtype('float64')
             input_data = np.nan_to_num(input_data)

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -476,6 +476,8 @@ class BaseAnalyzer(ABC):
                                                      IMPORTANCES_THRESHOLD)
             input_data = input_data[indexes]
             diff = diff[indexes]
+        # For numerical data types to make calculation/imputation error-free
+        input_data = input_data.astype(float)
         try:
             importances = self._compute_error_correlation(
                 input_data, diff, error_correlation_method)

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -480,7 +480,8 @@ class BaseAnalyzer(ABC):
             importances = self._compute_error_correlation(
                 input_data, diff, error_correlation_method)
         except ValueError:
-            # For numerical data types to make calculation/imputation error-free
+            # For numerical data types to make calculation/
+            # imputation error-free
             input_data = input_data.astype(float)
             # Impute input_data if it contains NaNs, infinity or a value too
             # large for dtype('float64')

--- a/erroranalysis/erroranalysis/analyzer/error_analyzer.py
+++ b/erroranalysis/erroranalysis/analyzer/error_analyzer.py
@@ -480,12 +480,9 @@ class BaseAnalyzer(ABC):
             importances = self._compute_error_correlation(
                 input_data, diff, error_correlation_method)
         except ValueError:
-            # For numerical data types to make calculation/
-            # imputation error-free
-            input_data = input_data.astype(float)
             # Impute input_data if it contains NaNs, infinity or a value too
             # large for dtype('float64')
-            input_data = np.nan_to_num(input_data)
+            input_data = np.nan_to_num(input_data.astype(float))
             importances = self._compute_error_correlation(
                 input_data, diff, error_correlation_method)
         return importances

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -139,6 +139,44 @@ class TestImportances(object):
         scores = model_analyzer.compute_importances(error_correlation_method)
         assert len(scores) == DEFAULT_SAMPLE_COLS
 
+    @pytest.mark.parametrize('num_rows', [1, 2, 3, 4])
+    @pytest.mark.parametrize('nan_correlation_method',
+                             [MUTUAL_INFO, EBM, GBM_SHAP])
+    def test_nan_data_importances(self, num_rows, error_correlation_method):
+        # validate we can run on very few rows
+        X_train, y_train, X_test, y_test, _ = \
+            create_binary_classification_dataset(NUM_SAMPLE_ROWS)
+        feature_names = list(X_train.columns)
+
+        from sklearn.base import BaseEstimator
+
+        class DummyModel(BaseEstimator):
+            def fit(self, X, y=None):
+                return self
+
+            def predict(self, X):
+                return np.zeros((len(X),), dtype=bool)
+
+            def predict_proba(self, X):
+                return np.zeros((len(X),), dtype=bool)
+
+        # Use the dummy model
+        model = DummyModel()
+
+        X_test = X_test[:num_rows]
+        y_test = y_test[:num_rows]
+
+        # Randomly replace some values in X_test with NaN
+        nan_mask = np.random.choice([True, False], size=X_test.shape)
+        X_test = X_test.astype(float)
+        X_test[nan_mask] = np.nan
+
+        categorical_features = []
+        model_analyzer = ModelAnalyzer(model, X_test, y_test,
+                                       feature_names,
+                                       categorical_features)
+        scores = model_analyzer.compute_importances(error_correlation_method)
+
     @pytest.mark.parametrize('error_correlation_method',
                              [MUTUAL_INFO, EBM, GBM_SHAP])
     def test_importances_missings(self, error_correlation_method):

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -5,8 +5,8 @@ import time
 
 import numpy as np
 import pytest
-from sklearn.base import BaseEstimator
 from common_utils import replicate_dataset
+from sklearn.base import BaseEstimator
 
 from erroranalysis._internal.constants import (ErrorCorrelationMethods,
                                                ModelTask)

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -140,7 +140,7 @@ class TestImportances(object):
         scores = model_analyzer.compute_importances(error_correlation_method)
         assert len(scores) == DEFAULT_SAMPLE_COLS
 
-    @pytest.mark.parametrize('num_rows', [1, 2, 3, 4])
+    @pytest.mark.parametrize('num_rows', [3, 4])
     @pytest.mark.parametrize('nan_correlation_method',
                              [MUTUAL_INFO, EBM, GBM_SHAP])
     def test_nan_data_importances(self, num_rows, nan_correlation_method):

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -5,6 +5,7 @@ import time
 
 import numpy as np
 import pytest
+from sklearn.base import BaseEstimator
 from common_utils import replicate_dataset
 
 from erroranalysis._internal.constants import (ErrorCorrelationMethods,
@@ -147,8 +148,6 @@ class TestImportances(object):
         X_train, y_train, X_test, y_test, _ = \
             create_binary_classification_dataset(NUM_SAMPLE_ROWS)
         feature_names = list(X_train.columns)
-
-        from sklearn.base import BaseEstimator
 
         class DummyModel(BaseEstimator):
             def fit(self, X, y=None):

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -174,7 +174,7 @@ class TestImportances(object):
         model_analyzer = ModelAnalyzer(model, X_test, y_test,
                                        feature_names,
                                        categorical_features)
-        scores = model_analyzer.compute_importances(error_correlation_method)
+        model_analyzer.compute_importances(error_correlation_method)
 
     @pytest.mark.parametrize('error_correlation_method',
                              [MUTUAL_INFO, EBM, GBM_SHAP])

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -143,9 +143,9 @@ class TestImportances(object):
     @pytest.mark.parametrize('num_rows', [1, 2, 3, 4])
     @pytest.mark.parametrize('nan_correlation_method',
                              [MUTUAL_INFO, EBM, GBM_SHAP])
-    def test_nan_data_importances(self, num_rows, error_correlation_method):
+    def test_nan_data_importances(self, num_rows, nan_correlation_method):
         # validate we can run on very few rows
-        X_train, y_train, X_test, y_test, _ = \
+        X_train, _, X_test, y_test, _ = \
             create_binary_classification_dataset(NUM_SAMPLE_ROWS)
         feature_names = list(X_train.columns)
 
@@ -174,7 +174,7 @@ class TestImportances(object):
         model_analyzer = ModelAnalyzer(model, X_test, y_test,
                                        feature_names,
                                        categorical_features)
-        model_analyzer.compute_importances(error_correlation_method)
+        model_analyzer.compute_importances(nan_correlation_method)
 
     @pytest.mark.parametrize('error_correlation_method',
                              [MUTUAL_INFO, EBM, GBM_SHAP])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Generating the multilabel & OD dashboards from notebooks would result in an uncaught error statement:

Input X contains NaN. Traceback (most recent call last): File "c:\workspace\rai\responsible-ai-toolbox\erroranalysis\erroranalysis\analyzer\error_analyzer.py", line 480, in compute_importances importances = self._compute_error_correlation( File "c:\workspace\rai\responsible-ai-toolbox\erroranalysis\erroranalysis\analyzer\error_analyzer.py", line 519, in _compute_error_correlation return mutual_info_classif( File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\utils_param_validation.py", line 211, in wrapper return func(*args, **kwargs) File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\feature_selection_mutual_info.py", line 493, in mutual_info_classif return _estimate_mi(X, y, discrete_features, True, n_neighbors, copy, random_state) File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\feature_selection_mutual_info.py", line 258, in _estimate_mi X, y = check_X_y(X, y, accept_sparse="csc", y_numeric=not discrete_target) File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\utils\validation.py", line 1147, in check_X_y X = check_array( File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\utils\validation.py", line 959, in check_array _assert_all_finite( File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\utils\validation.py", line 124, in _assert_all_finite _assert_all_finite_element_wise( File "c:\Users\agemawat\Anaconda3\envs\rai\lib\site-packages\sklearn\utils\validation.py", line 173, in _assert_all_finite_element_wise raise ValueError(msg_err) ValueError: Input X contains NaN.

This was because the imputer in `erroranalysis` was not replacing nans due to non-numeric dtype. This PR enforces a numeric dtype for successful imputation and to remove this uncaught exception.

Copilot:
This pull request to the `erroranalysis/erroranalysis` repository adds code to convert the `input_data` array to the `float` data type in the `compute_importances` method of the `ErrorAnalyzer` class. This change ensures error-free calculation and imputation of numerical data types.

* <a href="diffhunk://#diff-2028ff518d9b0e9719fd48a960cc1184cb8ca83990fb9270f590340a927f292aR479-R480">`erroranalysis/erroranalysis/analyzer/error_analyzer.py`</a>: Added code to convert `input_data` array to `float` data type in the `compute_importances` method of the `ErrorAnalyzer` class.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
