### PR TITLE
fix save and switch button text overflowing for accessibility

### DIFF
--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditor.tsx
@@ -109,7 +109,7 @@ export class CohortEditor extends React.PureComponent<
   private renderFooter = (): JSX.Element => {
     const styles = cohortEditorStyles();
     return (
-      <Stack horizontal tokens={{ childrenGap: "l1", padding: "l1" }}>
+      <Stack horizontal tokens={{ childrenGap: "s1", padding: "s1" }}>
         {!this.props.isNewCohort && !this.props.disableEditName && (
           <DefaultButton
             disabled={this.props.deleteIsDisabled}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix overflowing "Save and switch" button text in panel footer for accessibility.

Screenshot of overflowing text:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/a29e7a35-543b-4bd3-84c2-89ef676730ed)

Video of fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/6ba65c91-a7e3-4894-9c26-ee53e24f080d

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
