### PR TITLE
fix aria label for screen reader on scatter plot color axis picker

### DIFF
--- a/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
+++ b/libs/dataset-explorer/src/lib/ChartView/DataAnalysisView/SidePanel.tsx
@@ -127,6 +127,15 @@ export class SidePanel extends React.Component<
                   this.props.chartProps.colorAxis.property
                 ].label
               }
+              ariaLabel={
+                this.props.chartProps.colorAxis
+                  ? `${localization.Interpret.DatasetExplorer.colorValue} - ${
+                      this.props.jointDataset.metaDict[
+                        this.props.chartProps.colorAxis.property
+                      ].label
+                    }`
+                  : localization.Interpret.DatasetExplorer.colorValue
+              }
             />
             <div className={classNames.legendAndText}>
               {colorSeries?.length && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix aria label for screen reader on scatter plot color axis picker

[Screen reader – Responsible AI Dashboard – Vision Dashboard>Data analysis]: Screen reader does not announce the associated label information when focus lands on the "Predicted Y" button.

User Experience: 
Visually impaired people who depend on screen readers for navigation will get impacted if screen reader does not announce the associated text information for the button. Due to this the end user will find difficulty in identifying the purpose of the button.

Note: User credentials should NOT be included in the bug.

Pre-Requisite: Turn on the screen reader (NVDA)
Repro Steps:
Open RAI dashboard
Navigate to the "Data analysis" section and select the 'Chart view' tab.
Select "Individual data points" radio button present under 'Chart type' and navigate using tab key.
Observe whether the screen reader announces the associated label information when focus lands on the "Predicted Y" button or not.
Actual Result:
Screen reader does not announce the associated label information when focus lands on the "Predicted Y" button.

Observation:
When focus lands on the "Predicted Y" button, the screen reader announces as "Predicted Y" button.
Narrator and JAWS do not announce the associated label information when focus lands on the "Predicted Y" button.
Expected Result:
Screen reader should announce the associated label information when focus lands on the "Predicted Y" button.

Example: When focus lands on the "Predicted Y" button, the screen reader should announce as "Color value - Predicted Y" button.

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/fe6d7935-0b04-4a92-b332-389ff8c56fa4)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
