### PR TITLE
Removed python 3.6 from CI-notebook gate

### DIFF
--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        pythonVersion: [3.7, 3.8, 3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}
 


### PR DESCRIPTION
This pull request removes the Python version 3.6 from the `pythonVersion` matrix in the `jobs` section of the `.github/workflows/CI-notebook.yml` file.

Main change:

* <a href="diffhunk://#diff-87f39ff81c9b498d190c996f2bd2b3c2d553e59c972c710cb1062b583a973dbeL16-R16">`.github/workflows/CI-notebook.yml`</a>: Removed Python version 3.6 from the `pythonVersion` matrix in the `jobs` section.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
