### PR TITLE
fix luminosity ratio of RAI Vision dashboard success and failure instances text to background for accessibility

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TitleBar.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TitleBar.styles.ts
@@ -34,7 +34,7 @@ export const titleBarStyles: () => IProcessedStyleSet<ITitleBarStyles> = () => {
       fontWeight: "600"
     },
     titleBarNumber: {
-      color: theme.palette.blue
+      color: theme.palette.blueDark
     }
   });
 };


### PR DESCRIPTION
## Description

fix luminosity ratio of RAI Vision dashboard success and failure instances text to background for accessibility

[Visual Requirement – Responsible AI Dashboard – Vision Data Explorer>Image Explorer View]: Luminosity ratio of Success Instances "27" numeric value is less than 4.5:1.

User Experience: 
Low vision users will get impacted as they will not be able to see the controls such as static text/numeric value present on the page properly & will face difficulties while reading the content on the page if the luminosity ratio of the any control does not meet the minimum requirement of 4.5:1 ratio.

Repro Steps:
Open RAI dashboard
Navigate the "Vision Data Explorer" section, navigate the "Image Explorer View" tab and all the controls present under it.
Navigate to the "Success Instances" section.
Observe weather luminosity ratio of Success Instances count "27" numeric value with respect to its background color is greater than 4.5:1 or not.
Actual Result:
Luminosity ratio of Success Instances "27" numeric value with respect to its background color is 4.3:1 which is less than minimum contrast ratio: 4.5:1.
Expected Result:
The Luminosity ratio of Success Instances "27" numeric value with respect to its background color should be greater than or equal to 4.5:1.

Issue: 
Ensures the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds (color-contrast - https://accessibilityinsights.io/info-examples/web/color-contrast)

Screenshot before fix:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/6266d62e-d344-4849-ae6e-788ef0f3fe87)


Screenshot after fix:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/a75d93a2-add4-497e-af00-b174ef21907d)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
