### PR TITLE
fix RAI dashboard treat as categorical accessibility on new cohort create

### DIFF
--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditorFilter.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortEditorFilter.tsx
@@ -113,6 +113,20 @@ export class CohortEditorFilter extends React.Component<ICohortEditorFilterProps
               label={localization.Interpret.CohortEditor.TreatAsCategorical}
               checked={isCategorical}
               onChange={this.props.setAsCategorical}
+              ariaLabel={
+                isCategorical
+                  ? localization.formatString(
+                      localization.Interpret.CohortEditor
+                        .TreatAsCategoricalAriaLabelChecked,
+                      categoricalOptions?.length
+                    )
+                  : localization.formatString(
+                      localization.Interpret.CohortEditor
+                        .TreatAsCategoricalAriaLabelUnchecked,
+                      columnRange.min,
+                      columnRange.max
+                    )
+              }
             />
           )}
         {isCategorical ? (

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -915,6 +915,8 @@
         "regressionError": "Error"
       },
       "TreatAsCategorical": "Treat as categorical",
+      "TreatAsCategoricalAriaLabelChecked": "Treat as categorical checked, number of unique values: {0}",
+      "TreatAsCategoricalAriaLabelUnchecked": "Treat as categorical unchecked, min value: {0}, max value: {1}",
       "_TreatAsCategorical.comment": "a checkbox label to treat integers as categories instead of as numbers",
       "_addFilter.comment": "button text to add the current settings as a new filter",
       "_addedFilters.comment": "header above the list of filters that have been saved",


### PR DESCRIPTION
## Description

fix RAI dashboard treat as categorical accessibility on new cohort create

[Screen reader – Responsible AI Dashboard – Vision Dashboard>New cohort]: Screen reader does not announce the associated text information which appears after selecting the "Treat as categorical" checkbox. 

User Experience: 
Visually impaired people who depend on screen readers for navigation will get impacted if screen reader does not announce the associated text which appears on the screen after selecting the checkbox. Due to this the end user will miss the information which is related to the value combo box and cannot access it precisely.

Note: User credentials should NOT be included in the bug.

Pre-Requisite: Turn on the screen reader (NVDA)
Repro Steps:
Open RAI dashboard
 "Analyse_ model" page appears.
Navigate to the "New cohort" button and invoke it.
Navigate to the Treat as categorical" checkbox and select it.
Observe whether screen reader announces the associated text which appears after selecting the Treat as categorical" checkbox or not.
Actual Result:
Screen reader does not announce the associated text which appears after selecting the "Treat as categorical" checkbox.

Observation:
After selecting the Treat as categorical" checkbox, the screen reader announces as "Checked".
After selecting the Treat as categorical" checkbox, Narrator and JAWS announces as "Checked".
Expected Result:
Screen reader should announce the associated text information which appears after selecting the "Treat as categorical" checkbox.

Example: After selecting the Treat as categorical" checkbox, the screen reader should announce as "Checked - # of unique values: 28 and by unchecking it, the screen reader should announce as "Unchecked - Min 0 Max 27".

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/0a106865-0e69-4543-a1a3-894b21751711)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
