### PR TITLE
fix pivot focus indicator for accessibility

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/CausalInsights.styles.ts
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/CausalInsights.styles.ts
@@ -26,7 +26,6 @@ export const causalInsightsStyles: () => IProcessedStyleSet<ICausalInsightsStyle
           "[role='tablist'].ms-Pivot": {
             display: "flex",
             flexWrap: "wrap",
-            overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap"
           }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/FeatureImportances.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/FeatureImportances.styles.ts
@@ -31,7 +31,6 @@ export const featureImportanceTabStyles: () => IProcessedStyleSet<IFeatureImport
           "[role='tablist'].ms-Pivot": {
             display: "flex",
             flexWrap: "wrap",
-            overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap"
           }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ModelOverview.styles.ts
@@ -65,7 +65,6 @@ export const modelOverviewStyles: () => IProcessedStyleSet<IModelOverviewStyles>
           "[role='tablist'].ms-Pivot": {
             display: "flex",
             flexWrap: "wrap",
-            overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap"
           }


### PR DESCRIPTION
## Description

fix pivot focus indicator for accessibility

Specifically, fixes the model overview pivots, causal pivots and feature importances pivots in the dashboard.

[Usable – Responsible AI Dashboard – Vision Dashboard>Model overview]: Only one side of the keyboard focus indicator is visible on the "Metrices visualization" tab.

User Experience: 
Users who depend on keyboard for navigation will get impacted if focus is visible only one side on the control. As a result, they will not be able to know the exact focus of the keyboard while navigating the page.

Note: User credentials should NOT be included in the bug.

Repro Steps:
Open RAI dashboard
Navigate the page using tab key.
Navigate to the "Model overview" section.
Observe whether all four sides of the keyboard focus indicators are visible on the "Metrices visualization" or not. 
Actual Result:
Only one side of the keyboard focus indicator is visible on the "Metrices visualization" tab while navigating using tab/arrow key.
Expected Result:
All four sides of the keyboard focus indicators should be visible on the "Metrices visualization" tab while navigating using tab/arrow key.

Video before fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/47412e45-1379-4d59-87e9-965daa142493

Video after fix:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/415235e7-a9fd-4196-bf17-cc64a6559dae


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
