### PR TITLE
fix confusion matrix highcharts heatmap keyboard focus order accessibility

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ConfusionMatrixHeatmap.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/ConfusionMatrixHeatmap.tsx
@@ -236,7 +236,6 @@ export class ConfusionMatrixHeatmap extends React.Component<
                   },
                   yAxis: {
                     categories: this.state.selectedClasses,
-                    reversed: true,
                     title: {
                       text: `<b>${confusionMatrixLocString.confusionMatrixYAxisLabel}</b>`
                     }


### PR DESCRIPTION
## Description

fix confusion matrix highcharts heatmap keyboard focus order accessibility

Screenshot of confusion matrix with fixed keyboard focus order (note it's difficult to portray this bug without understanding which key is pressed when since this is an issue with up/down arrow keys going to the wrong cell):
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/4e1d289e-ff8c-4702-80e0-7d4c0a0861bf)

Based on this stack overflow I discovered this is occurring due to the "reversed" attribute on the y axis:
https://stackoverflow.com/questions/64450163/highcharts-js-keyboard-navigation-issue


[Keyboard navigation – Responsible AI Dashboard – Vision Dashboard>Model overview]: Keyboard focus order is not logical while navigating the 'Confusion matrix' chart using up/down arrow keys.

User Experience: 
People who depend on keyboard for navigation will get impacted if focus order is not logical while navigating the chart using up and down arrow keys. As a result, the end user will not be able to access the chart and will find difficulty in understanding the 'Confusion matrix'.

Repro Steps:
Open RAI dashboard
Navigate to the "Model overview" section and select 'Confusion matrix' tab.
Navigate the 'Confusion matrix' chart using arrow keys.
Observe whether keyboard focus order is logical or not while navigating using up and down arrow keys.
Actual Result:
Keyboard focus order is not logical while navigating the 'Confusion matrix' chart using up/down arrow keys.

Observation: 
While navigating the 'Confusion matrix' chart, up and down arrow keys are performing reverse functionality.
When focus is on the first cell i.e., on the "Can", by pressing up arrow, the focus is moving to the below cell i.e., on the "Carton".
Expected Result:
Keyboard focus order should be in logical order while navigating the 'Confusion matrix' chart using up/down arrow keys. 

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
