### PR TITLE
update vscode settings for codeActionsOnSave to use new field instead of boolean

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
     "**/yarn.lock": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "[json]": {
     "editor.formatOnSave": true,


### PR DESCRIPTION
## Description

update vscode settings for codeActionsOnSave to use new field instead of boolean

See more info here:
https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own
And also vscode release docs:
https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

Since vscode 1.85.0 release this field has changed from a boolean true/false to the string values explicit/always/never.
Setting this field since on every save action in vscode this file appears to have changes.
 
## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
