### PR TITLE
announce search results in RAI Vision dashboard toolbar for accessibility

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristics.tsx
@@ -186,7 +186,8 @@ export class DataCharacteristics extends React.Component<
     const filteredItems = getFilteredDataFromSearch(
       this.props.searchValue,
       this.props.items,
-      this.props.taskType
+      this.props.taskType,
+      this.props.onSearchUpdated
     );
     this.setState(
       processItems(
@@ -262,7 +263,6 @@ export class DataCharacteristics extends React.Component<
     showBackArrow[index] = true;
     this.setState({ renderStartIndex, showBackArrow });
   };
-
   private loadPrevItems = (index: number) => (): void => {
     const { renderStartIndex, showBackArrow } = this.state;
     renderStartIndex[index] -= this.state.columnCount[index];

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/DataCharacteristicsHelper.ts
@@ -13,6 +13,7 @@ export interface IDataCharacteristicsProps extends ISearchable {
   imageDim: number;
   numRows: number;
   taskType: string;
+  onSearchUpdated: (successCount: number, errorCount: number) => void;
   selectItem(item: IVisionListItem): void;
 }
 
@@ -188,7 +189,7 @@ export function processItems(
     showBackArrow.push(false);
     columnCount.push(0);
   });
-  return {
+  const result = {
     columnCount,
     dropdownOptionsPredicted,
     dropdownOptionsTrue,
@@ -201,6 +202,7 @@ export function processItems(
     selectedKeysTrue,
     showBackArrow
   };
+  return result;
 }
 
 export function getLabelVisibility(

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ImageList.tsx
@@ -26,6 +26,7 @@ export interface IImageListProps extends ISearchable {
   imageDim: number;
   selectItem: (item: IVisionListItem) => void;
   taskType: string;
+  onSearchUpdated: (successCount: number, errorCount: number) => void;
 }
 
 export interface IImageListState {
@@ -93,7 +94,8 @@ export class ImageList extends React.Component<
       filteredItems = getFilteredDataFromSearch(
         searchValue,
         filteredItems,
-        this.props.taskType
+        this.props.taskType,
+        this.props.onSearchUpdated
       );
     }
     return filteredItems;

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
@@ -187,7 +187,8 @@ export class TableList extends React.Component<
     const filteredItems = getFilteredDataFromSearch(
       searchValue,
       items,
-      this.props.taskType
+      this.props.taskType,
+      this.props.onSearchUpdated
     );
     return filteredItems;
   }

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableListHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableListHelper.ts
@@ -15,6 +15,7 @@ export interface ITableListProps extends ISearchable {
   selectItem: (item: IVisionListItem) => void;
   updateSelectedIndices: (indices: number[]) => void;
   taskType: string;
+  onSearchUpdated: (successCount: number, errorCount: number) => void;
 }
 
 export interface ITableListState {

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ToolBar.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/ToolBar.tsx
@@ -22,6 +22,7 @@ export interface IToolBarProps {
     newValue?: string
   ) => void;
   selectedCohort: ErrorCohort;
+  searchResultsAriaLabel: string;
   setSelectedCohort: (cohort: ErrorCohort) => void;
 }
 
@@ -68,6 +69,7 @@ export class ToolBar extends React.Component<IToolBarProps> {
                 placeholder={localization.InterpretVision.Dashboard.search}
                 value={this.props.searchValue}
                 onChange={this.props.onSearch}
+                ariaLabel={this.props.searchResultsAriaLabel}
               />
             </Stack.Item>
           </Stack>

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Interfaces/IVisionExplanationDashboardState.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Interfaces/IVisionExplanationDashboardState.ts
@@ -12,6 +12,7 @@ export interface IVisionExplanationDashboardState {
   otherMetadataFieldNames: string[];
   numRows: number;
   panelOpen: boolean;
+  searchResultsAriaLabel: string;
   searchValue: string;
   selectedIndices: number[];
   selectedItem: IVisionListItem | undefined;

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.tsx
@@ -17,7 +17,7 @@ import { TabsView } from "./Controls/TabsView";
 import { IVisionExplanationDashboardProps } from "./Interfaces/IVisionExplanationDashboardProps";
 import { IVisionExplanationDashboardState } from "./Interfaces/IVisionExplanationDashboardState";
 import { visionExplanationDashboardStyles } from "./VisionExplanationDashboard.styles";
-import { VisionExplanationDashboardCommon } from "./VisionExplanationDashboardCommon";
+import { VisionExplanationDashboardHeader } from "./VisionExplanationDashboardHeader";
 import {
   preprocessData,
   getItems,
@@ -35,10 +35,12 @@ export class VisionExplanationDashboard extends React.Component<
     defaultModelAssessmentContext;
   private originalErrorInstances: IVisionListItem[] = [];
   private originalSuccessInstances: IVisionListItem[] = [];
+
   public constructor(props: IVisionExplanationDashboardProps) {
     super(props);
     this.state = defaultState;
   }
+
   public componentDidMount(): void {
     const data = preprocessData(this.props, this.context.dataset);
     if (!data) {
@@ -48,6 +50,7 @@ export class VisionExplanationDashboard extends React.Component<
     this.originalSuccessInstances = data.successInstances;
     this.setState(data);
   }
+
   public componentDidUpdate(prevProps: IVisionExplanationDashboardProps): void {
     if (this.props.selectedCohort !== prevProps.selectedCohort) {
       this.setState(
@@ -59,6 +62,7 @@ export class VisionExplanationDashboard extends React.Component<
       );
     }
   }
+
   public render(): React.ReactNode {
     const classNames = visionExplanationDashboardStyles();
     const imageStyles = imageListStyles();
@@ -69,11 +73,22 @@ export class VisionExplanationDashboard extends React.Component<
         id="VisionDataExplorer"
         tokens={{ childrenGap: "l1", padding: "m 40px" }}
       >
-        <VisionExplanationDashboardCommon
-          thisdashboard={this}
+        <VisionExplanationDashboardHeader
+          cohorts={this.props.cohorts}
+          selectedKey={this.state.selectedKey}
+          searchResultsAriaLabel={this.state.searchResultsAriaLabel}
+          searchValue={this.state.searchValue}
+          selectedCohort={this.props.selectedCohort}
           imageStyles={imageStyles}
           classNames={classNames}
           taskType={this.context.dataset.task_type}
+          handleLinkClick={this.handleLinkClick}
+          setSelectedCohort={this.props.setSelectedCohort}
+          onSearch={this.onSearch}
+          selectedIndices={this.state.selectedIndices}
+          onSliderChange={this.onSliderChange}
+          onNumRowsSelect={this.onNumRowsSelect}
+          addCohortWrapper={this.addCohortWrapper}
         />
         <Stack.Item>
           <TabsView
@@ -87,6 +102,7 @@ export class VisionExplanationDashboard extends React.Component<
             selectedItem={this.state.selectedItem}
             selectedKey={this.state.selectedKey}
             onItemSelect={this.onItemSelect}
+            onSearchUpdated={this.onSearchUpdated}
             updateSelectedIndices={this.updateSelectedIndices}
             selectedCohort={this.props.selectedCohort}
             setSelectedCohort={this.props.setSelectedCohort}
@@ -118,9 +134,11 @@ export class VisionExplanationDashboard extends React.Component<
       </Stack>
     );
   }
+
   public updateSelectedIndices = (indices: number[]): void => {
     this.setState({ selectedIndices: indices });
   };
+
   public addCohortWrapper = (name: string, switchCohort: boolean): void => {
     this.context.addCohort(
       getCohort(name, this.state.selectedIndices, this.context.jointDataset),
@@ -128,15 +146,22 @@ export class VisionExplanationDashboard extends React.Component<
       switchCohort
     );
   };
+
   public onPanelClose = (): void => {
     this.setState({ panelOpen: !this.state.panelOpen });
   };
+
   public onSearch = (
     _event?: React.ChangeEvent<HTMLInputElement>,
     newValue?: string
   ): void => {
     this.setState({ searchValue: newValue || "" });
   };
+
+  public onSearchUpdated = (searchResultsAriaLabel: string): void => {
+    this.setState({ searchResultsAriaLabel });
+  };
+
   public onItemSelect = (item: IVisionListItem): void => {
     this.setState({ panelOpen: !this.state.panelOpen, selectedItem: item });
     const index = item.index;
@@ -165,6 +190,7 @@ export class VisionExplanationDashboard extends React.Component<
         });
     }
   };
+
   public onItemSelectObjectDetection = (
     item: IVisionListItem,
     selectedObject = -1
@@ -202,6 +228,7 @@ export class VisionExplanationDashboard extends React.Component<
         });
     }
   };
+
   /* For onSliderChange, the max imageDims per tab (400 and 100) are selected arbitrary to look like the Figma. 
   For handleLinkClick, the default are half the max values chosen in onSliderChange. */
   public onSliderChange = (value: number): void => {
@@ -214,12 +241,14 @@ export class VisionExplanationDashboard extends React.Component<
       this.setState({ imageDim: Math.floor((value / 100) * 100) });
     }
   };
+
   public onNumRowsSelect = (
     _event: React.FormEvent<HTMLDivElement>,
     item: IDropdownOption | undefined
   ): void => {
     this.setState({ numRows: Number(item?.text) });
   };
+
   public handleLinkClick = (item?: PivotItem): void => {
     if (item && item.props.itemKey !== undefined) {
       this.setState({ selectedKey: item.props.itemKey });

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHeader.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHeader.tsx
@@ -7,9 +7,15 @@ import {
   Stack,
   Slider,
   Separator,
-  Text
+  Text,
+  PivotItem,
+  IDropdownOption
 } from "@fluentui/react";
-import { DatasetTaskType, IVisionListItem } from "@responsible-ai/core-ui";
+import {
+  DatasetTaskType,
+  ErrorCohort,
+  IVisionListItem
+} from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
@@ -18,33 +24,49 @@ import { IDatasetExplorerTabStyles } from "./Controls/ImageList.styles";
 import { PageSizeSelectors } from "./Controls/PageSizeSelectors";
 import { Pivots } from "./Controls/Pivots";
 import { ToolBar } from "./Controls/ToolBar";
-import { VisionExplanationDashboard } from "./VisionExplanationDashboard";
 import { IVisionExplanationDashboardStyles } from "./VisionExplanationDashboard.styles";
 import { VisionDatasetExplorerTabOptions } from "./VisionExplanationDashboardHelper";
 
-export interface IVisionExplanationDashboardCommonProps {
-  thisdashboard: VisionExplanationDashboard;
+export interface IVisionExplanationDashboardHeaderProps {
+  cohorts: ErrorCohort[];
+  selectedKey: string;
+  searchValue: string;
+  selectedCohort: ErrorCohort;
+  searchResultsAriaLabel: string;
   imageStyles: IProcessedStyleSet<IDatasetExplorerTabStyles>;
   classNames: IProcessedStyleSet<IVisionExplanationDashboardStyles>;
   taskType: string;
+  selectedIndices: number[];
+  handleLinkClick: (item?: PivotItem) => void;
+  setSelectedCohort: (cohort: ErrorCohort) => void;
+  onSliderChange: (value: number) => void;
+  onNumRowsSelect: (
+    _event: React.FormEvent<HTMLDivElement>,
+    item: IDropdownOption | undefined
+  ) => void;
+  addCohortWrapper: (name: string, switchCohort: boolean) => void;
+  onSearch: (
+    _event?: React.ChangeEvent<HTMLInputElement>,
+    newValue?: string
+  ) => void;
 }
 
-export interface IVisionExplanationDashboardCommonState {
+export interface IVisionExplanationDashboardHeaderState {
   item: IVisionListItem | undefined;
   metadata: Array<Array<string | number | boolean>> | undefined;
 }
 
-export class VisionExplanationDashboardCommon extends React.Component<
-  IVisionExplanationDashboardCommonProps,
-  IVisionExplanationDashboardCommonState
+export class VisionExplanationDashboardHeader extends React.Component<
+  IVisionExplanationDashboardHeaderProps,
+  IVisionExplanationDashboardHeaderState
 > {
   public render(): React.ReactNode {
     return (
       <Stack>
         <Stack.Item>
           <Pivots
-            selectedKey={this.props.thisdashboard.state.selectedKey}
-            onLinkClick={this.props.thisdashboard.handleLinkClick}
+            selectedKey={this.props.selectedKey}
+            onLinkClick={this.props.handleLinkClick}
           />
         </Stack.Item>
         <Stack.Item>
@@ -52,11 +74,12 @@ export class VisionExplanationDashboardCommon extends React.Component<
         </Stack.Item>
         <Stack.Item>
           <ToolBar
-            cohorts={this.props.thisdashboard.props.cohorts}
-            searchValue={this.props.thisdashboard.state.searchValue}
-            onSearch={this.props.thisdashboard.onSearch}
-            selectedCohort={this.props.thisdashboard.props.selectedCohort}
-            setSelectedCohort={this.props.thisdashboard.props.setSelectedCohort}
+            cohorts={this.props.cohorts}
+            searchResultsAriaLabel={this.props.searchResultsAriaLabel}
+            searchValue={this.props.searchValue}
+            onSearch={this.props.onSearch}
+            selectedCohort={this.props.selectedCohort}
+            setSelectedCohort={this.props.setSelectedCohort}
           />
         </Stack.Item>
         <Stack.Item>
@@ -75,23 +98,23 @@ export class VisionExplanationDashboardCommon extends React.Component<
                 label={localization.InterpretVision.Dashboard.thumbnailSize}
                 defaultValue={50}
                 showValue={false}
-                onChange={this.props.thisdashboard.onSliderChange}
+                onChange={this.props.onSliderChange}
                 disabled={
-                  this.props.thisdashboard.state.selectedKey ===
+                  this.props.selectedKey ===
                   VisionDatasetExplorerTabOptions.ClassView
                 }
               />
             </Stack.Item>
-            {this.props.thisdashboard.state.selectedKey ===
+            {this.props.selectedKey ===
               VisionDatasetExplorerTabOptions.ClassView && (
               <Stack.Item>
                 <PageSizeSelectors
-                  selectedKey={this.props.thisdashboard.state.selectedKey}
-                  onNumRowsSelect={this.props.thisdashboard.onNumRowsSelect}
+                  selectedKey={this.props.selectedKey}
+                  onNumRowsSelect={this.props.onNumRowsSelect}
                 />
               </Stack.Item>
             )}
-            {this.props.thisdashboard.state.selectedKey ===
+            {this.props.selectedKey ===
               VisionDatasetExplorerTabOptions.ImageExplorerView &&
               this.props.taskType !== DatasetTaskType.ObjectDetection && (
                 <Stack
@@ -130,13 +153,13 @@ export class VisionExplanationDashboardCommon extends React.Component<
               )}
           </Stack>
         </Stack.Item>
-        {this.props.thisdashboard.state.selectedKey ===
+        {this.props.selectedKey ===
           VisionDatasetExplorerTabOptions.TableView && (
           <Stack.Item>
             <CohortToolBar
-              addCohort={this.props.thisdashboard.addCohortWrapper}
-              cohorts={this.props.thisdashboard.props.cohorts}
-              selectedIndices={this.props.thisdashboard.state.selectedIndices}
+              addCohort={this.props.addCohortWrapper}
+              cohorts={this.props.cohorts}
+              selectedIndices={this.props.selectedIndices}
             />
           </Stack.Item>
         )}

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHelper.ts
@@ -202,6 +202,8 @@ export const defaultState: IVisionExplanationDashboardState = {
   numRows: 3,
   otherMetadataFieldNames: ["mean_pixel_value"],
   panelOpen: false,
+  searchResultsAriaLabel:
+    localization.InterpretVision.Search.defaultSearchLabel,
   searchValue: "",
   selectedIndices: [],
   selectedItem: undefined,

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getFilteredData.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getFilteredData.ts
@@ -3,12 +3,15 @@
 
 import { DatasetTaskType, IVisionListItem } from "@responsible-ai/core-ui";
 
+import { updateSearchSuccessErrorCounts } from "./searchTextUtils";
+
 export function getFilteredDataFromSearch(
   searchVal: string,
   items: IVisionListItem[],
-  taskType: string
+  taskType: string,
+  onSearchUpdated: (successCount: number, errorCount: number) => void
 ): IVisionListItem[] {
-  return items.filter((item) => {
+  const filteredItems = items.filter((item) => {
     const predOrIncorrectY =
       taskType === DatasetTaskType.ObjectDetection
         ? item.odIncorrect
@@ -27,6 +30,8 @@ export function getFilteredDataFromSearch(
     );
     return predOrIncorrectYIncludesSearchVal || trueOrCorrectYIncludesSearchVal;
   });
+  updateSearchSuccessErrorCounts(onSearchUpdated, filteredItems, taskType);
+  return filteredItems;
 }
 
 export function includesSearchVal(

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/searchTextUtils.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/searchTextUtils.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  DatasetTaskType,
+  IVisionListItem,
+  NoLabel
+} from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+
+export function getSearchTextAriaLabel(
+  successCount: number,
+  totalCount: number,
+  searchValue: string
+): string {
+  const failureCount = totalCount - successCount;
+  if (!searchValue) {
+    return localization.InterpretVision.Search.defaultSearchLabel;
+  }
+  if (totalCount === 0) {
+    return localization.formatString(
+      localization.InterpretVision.Search.emptySearchResultsAriaLabel,
+      searchValue
+    );
+  }
+  return localization.formatString(
+    localization.InterpretVision.Search.searchResultsAriaLabel,
+    totalCount,
+    searchValue,
+    successCount,
+    failureCount
+  );
+}
+
+export function getCorrectCountForItems(
+  items: IVisionListItem[],
+  taskType: string
+): number {
+  let count = 0;
+  items.forEach((itemEntry) => {
+    if (taskType === DatasetTaskType.ObjectDetection) {
+      // For object detection, we define correct images as
+      // those with no incorrect bounding boxes
+      count += itemEntry.odIncorrect === NoLabel ? 1 : 0;
+    } else {
+      count += itemEntry.predictedY === itemEntry.trueY ? 1 : 0;
+    }
+  });
+  return count;
+}
+
+export function updateSearchSuccessErrorCounts(
+  onSearchUpdated: (successCount: number, errorCount: number) => void,
+  examples: IVisionListItem[],
+  taskType: string
+): void {
+  const successCount = getCorrectCountForItems(examples, taskType);
+  const errorCount = examples.length - successCount;
+  onSearchUpdated(successCount, errorCount);
+}
+
+export function updateSearchTextAriaLabel(
+  onSearchUpdated: (searchResultsAriaLabel: string) => void,
+  successCount: number,
+  errorCount: number,
+  searchValue: string
+): void {
+  const totalCount = successCount + errorCount;
+  const searchResultsAriaLabel = getSearchTextAriaLabel(
+    successCount,
+    totalCount,
+    searchValue
+  );
+  onSearchUpdated(searchResultsAriaLabel);
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -1489,6 +1489,11 @@
       "titleBarError": "Error instances",
       "titleBarSuccess": "Success instances",
       "trueY": "Ground truth: "
+    },
+    "Search": {
+      "defaultSearchLabel": "Search for image instances",
+      "searchResultsAriaLabel": "{0} results found for the entered keyword {1} where the number of success instances is {2} and the number of error instances is {3}",
+      "emptySearchResultsAriaLabel": "No results found for the entered keyword {0}"
     }
   },
   "ModelAssessment": {


### PR DESCRIPTION
## Description

announce search results in RAI Vision dashboard toolbar for accessibility

[Screen reader – Responsible AI Dashboard – Vision Data Explorer>Table View]: Screen reader does not announce the search results information on entering valid/invalid data. 

User Experience: 
Screen reader dependent people will not be able to know whether the Success/Error instances data are getting filtered by the entered value or not if the screen reader doesn't announce any updated information after entering the valid/invalid data. 

Pre-Requisite: 
Turn on the NVDA.
Repro Steps:
Open RAI Dashboard
 "Analyse_ model" page appears.
Navigate the "Vision Data Explorer" section, navigate the "Table View" tab and all the controls present under it.
Navigate to the search edit field and filter the list items.
Observe whether screen reader announces the search results information on entering valid or invalid data.
Actual Result:


Screen reader does not announce the search results information on entering valid/invalid data.

Observation:
On entering valid/invalid data in the search edit field, the screen reader remains silent.
On entering valid/invalid data in the search edit field, NVDA and JAWS screen readers remain silent.
Expected Result:
Screen reader should announce the search results information on entering valid/invalid data.

Example: On entering valid data such as "can", the screen reader should announce as “9 result found for the entered keyword can where success instances are 8 and Error instances is 1” and by entering invalid data, the screen reader should announce as “0 results found”.

Screenshot of aria label on search:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/ae3eaaca-4b74-4307-9e79-32174b09f49a)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
