### PR TITLE
add AccessibleDetailsList with resizable columns for accessibility

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateTable.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/CausalAggregateView/CausalAggregateTable.tsx
@@ -3,7 +3,6 @@
 
 import {
   CheckboxVisibility,
-  DetailsList,
   DetailsListLayoutMode,
   IColumn,
   IDetailsColumnRenderTooltipProps,
@@ -13,6 +12,7 @@ import {
   TooltipHost
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   defaultModelAssessmentContext,
   ICausalAnalysisSingleData,
   ModelAssessmentContext,
@@ -113,7 +113,7 @@ export class CausalAggregateTable extends React.PureComponent<ICausalAggregateTa
         return roundedData;
       }) ?? [];
     return (
-      <DetailsList
+      <AccessibleDetailsList
         items={items}
         columns={columns}
         selectionMode={SelectionMode.none}

--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentList.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentList.tsx
@@ -3,7 +3,6 @@
 
 import {
   CheckboxVisibility,
-  DetailsList,
   DetailsListLayoutMode,
   IColumn,
   IDetailsColumnRenderTooltipProps,
@@ -14,6 +13,7 @@ import {
   Text
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   defaultModelAssessmentContext,
   ModelAssessmentContext,
   toScientific
@@ -106,7 +106,7 @@ export class TreatmentList extends React.Component<ITreatmentListProps> {
     const convertedItems = items.map((item) => toScientific(item));
     return (
       <div className={styles.listContainer}>
-        <DetailsList
+        <AccessibleDetailsList
           items={convertedItems}
           columns={columns}
           selectionMode={SelectionMode.none}

--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -67,6 +67,7 @@ export * from "./lib/util/ITelemetryEvent";
 export * from "./lib/util/TelemetryEventName";
 export * from "./lib/util/generateDefaultChartAxes";
 export * from "./lib/util/datasetUtils/getColumnRanges";
+export * from "./lib/components/AccessibleDetailsList";
 export * from "./lib/components/Announce";
 export * from "./lib/components/OverallMetricChart";
 export * from "./lib/components/AxisConfig";

--- a/libs/core-ui/src/lib/Cohort/CohortList/CohortList.tsx
+++ b/libs/core-ui/src/lib/Cohort/CohortList/CohortList.tsx
@@ -4,7 +4,6 @@
 import {
   CheckboxVisibility,
   IColumn,
-  DetailsList,
   DetailsListLayoutMode,
   Stack,
   Text
@@ -12,6 +11,7 @@ import {
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
+import { AccessibleDetailsList } from "../../components/AccessibleDetailsList";
 import { ErrorCohort } from "../ErrorCohort";
 
 import { cohortListStyles } from "./CohortList.styles";
@@ -112,7 +112,7 @@ export class CohortList extends React.Component<
       <div className={classNames.section}>
         <div className={classNames.subsection}>
           <div className={classNames.header}>Cohort List</div>
-          <DetailsList
+          <AccessibleDetailsList
             items={items}
             columns={this.columns}
             setKey="set"

--- a/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortBar.tsx
+++ b/libs/core-ui/src/lib/Cohort/ManualCohortManagement/CohortBar.tsx
@@ -1,17 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-  DetailsList,
-  IColumn,
-  Panel,
-  SelectionMode,
-  Stack,
-  Text
-} from "@fluentui/react";
+import { IColumn, Panel, SelectionMode, Stack, Text } from "@fluentui/react";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
+import { AccessibleDetailsList } from "../../components/AccessibleDetailsList";
 import { ICohort } from "../../Interfaces/ICohort";
 import { IExplanationModelMetadata } from "../../Interfaces/IExplanationContext";
 import { JointDataset } from "../../util/JointDataset";
@@ -108,7 +102,7 @@ export class CohortBar extends React.Component<
             />
           ) : (
             <Panel isOpen onDismiss={this.hideEditList} isLightDismiss>
-              <DetailsList
+              <AccessibleDetailsList
                 items={this.props.cohorts}
                 selectionMode={SelectionMode.none}
                 columns={columns}

--- a/libs/core-ui/src/lib/components/AccessibleDetailsList.tsx
+++ b/libs/core-ui/src/lib/components/AccessibleDetailsList.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  DetailsList,
+  Dialog,
+  DialogFooter,
+  DialogType,
+  IDetailsList,
+  IDetailsListProps,
+  IColumn,
+  PrimaryButton,
+  DefaultButton,
+  ColumnActionsMode,
+  TextField
+} from "@fluentui/react";
+import { localization } from "@responsible-ai/localization";
+import * as React from "react";
+
+const RADIX = 10;
+const DefaultColumnMinWidth = 10;
+
+type IAccessibleDetailsListProps = IDetailsListProps;
+
+interface IAccessibleDetailsListState {
+  isDialogHidden: boolean;
+  columnToResize?: IColumn;
+  newWidth?: number;
+  errorMessage?: string;
+}
+
+export class AccessibleDetailsList extends React.PureComponent<
+  IAccessibleDetailsListProps,
+  IAccessibleDetailsListState
+> {
+  private detailsListRef = React.createRef<IDetailsList>();
+  public constructor(props: IAccessibleDetailsListProps) {
+    super(props);
+
+    this.state = {
+      columnToResize: undefined,
+      errorMessage: undefined,
+      isDialogHidden: true,
+      newWidth: undefined
+    };
+  }
+
+  public render(): React.ReactNode {
+    const { columns, ...rest } = this.props;
+    const clickableColumns = columns?.map((column) => {
+      column.onColumnClick = this.onColumnClick;
+      column.columnActionsMode = ColumnActionsMode.clickable;
+      return column;
+    });
+
+    return (
+      <div>
+        <DetailsList
+          componentRef={this.detailsListRef}
+          columns={clickableColumns}
+          {...rest}
+        />
+        <Dialog
+          hidden={this.state.isDialogHidden}
+          onDismiss={this.closeDialog}
+          dialogContentProps={{
+            subText:
+              localization.Core.AccessibleDetailsList.ResizableDialog.subText,
+            title:
+              localization.Core.AccessibleDetailsList.ResizableDialog.title,
+            type: DialogType.normal
+          }}
+        >
+          <TextField
+            ariaLabel={
+              localization.Core.AccessibleDetailsList.ResizableDialog.subText
+            }
+            errorMessage={this.state.errorMessage}
+            onChange={this.onTextFieldChange}
+          />
+          <DialogFooter>
+            <PrimaryButton
+              onClick={this.confirmDialog}
+              text={localization.Core.AccessibleDetailsList.resize}
+              ariaLabel={localization.Core.AccessibleDetailsList.resize}
+              disabled={this.state.errorMessage !== undefined}
+            />
+            <DefaultButton
+              onClick={this.closeDialog}
+              text={localization.Core.AccessibleDetailsList.cancel}
+              ariaLabel={localization.Core.AccessibleDetailsList.cancel}
+            />
+          </DialogFooter>
+        </Dialog>
+      </div>
+    );
+  }
+
+  private getMinMaxErrorMessage = (
+    column: IColumn,
+    columnMinWidth: number
+  ): string => {
+    return localization.formatString(
+      localization.Core.AccessibleDetailsList.minMaxErrorMessage,
+      columnMinWidth,
+      column.maxWidth
+    );
+  };
+
+  private getMinErrorMessage = (columnMinWidth: number): string => {
+    return localization.formatString(
+      localization.Core.AccessibleDetailsList.minErrorMessage,
+      columnMinWidth
+    );
+  };
+
+  private onColumnClick = (
+    _: React.MouseEvent<HTMLElement>,
+    column: IColumn
+  ): void => {
+    const columnMinWidth = column.minWidth ?? DefaultColumnMinWidth;
+    let errorMessage = "";
+    if (column.maxWidth) {
+      errorMessage = this.getMinMaxErrorMessage(column, columnMinWidth);
+    } else {
+      errorMessage = this.getMinErrorMessage(columnMinWidth);
+    }
+    this.setState({
+      columnToResize: column,
+      errorMessage,
+      isDialogHidden: false
+    });
+  };
+
+  private onTextFieldChange = (
+    _: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+    newValue?: string
+  ): void => {
+    if (newValue) {
+      const newWidth = Number.parseInt(newValue, RADIX);
+      const column = this.state.columnToResize;
+      const columnMinWidth = column?.minWidth ?? DefaultColumnMinWidth;
+      if (column?.maxWidth) {
+        if (newWidth > column.maxWidth || newWidth < columnMinWidth) {
+          this.setState({
+            errorMessage: this.getMinMaxErrorMessage(column, columnMinWidth),
+            newWidth: undefined
+          });
+          return;
+        }
+      } else if (newWidth < columnMinWidth) {
+        this.setState({
+          errorMessage: this.getMinErrorMessage(columnMinWidth),
+          newWidth: undefined
+        });
+        return;
+      }
+      if (newWidth) {
+        this.setState({ errorMessage: undefined, newWidth });
+      }
+    }
+  };
+
+  private confirmDialog = (): void => {
+    if (this.state.columnToResize && this.state.newWidth) {
+      const columnToResize = this.state.columnToResize;
+      this.detailsListRef.current?.updateColumn(columnToResize, {
+        width: this.state.newWidth
+      });
+      this.closeDialog();
+    }
+  };
+
+  private closeDialog = (): void => {
+    this.setState({
+      columnToResize: undefined,
+      isDialogHidden: true,
+      newWidth: undefined
+    });
+  };
+}

--- a/libs/counterfactuals/src/lib/CounterfactualList.tsx
+++ b/libs/counterfactuals/src/lib/CounterfactualList.tsx
@@ -5,7 +5,6 @@ import {
   IComboBoxOption,
   IComboBox,
   ConstrainMode,
-  DetailsList,
   DetailsListLayoutMode,
   DetailsRow,
   DetailsRowFields,
@@ -17,6 +16,7 @@ import {
   SelectionMode
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   defaultModelAssessmentContext,
   ICounterfactualData,
   ITelemetryEvent,
@@ -99,7 +99,7 @@ export class CounterfactualList extends React.Component<
       );
     }
     return (
-      <DetailsList
+      <AccessibleDetailsList
         items={items}
         columns={columns}
         selectionMode={SelectionMode.none}

--- a/libs/dataset-explorer/src/lib/DataBalanceView/AggregateBalanceMeasuresTable.tsx
+++ b/libs/dataset-explorer/src/lib/DataBalanceView/AggregateBalanceMeasuresTable.tsx
@@ -3,13 +3,13 @@
 
 import {
   CheckboxVisibility,
-  DetailsList,
   DetailsListLayoutMode,
   IColumn,
   SelectionMode,
   Stack
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   HeaderWithInfo,
   IAggregateBalanceMeasures,
   MissingParametersPlaceholder
@@ -104,7 +104,7 @@ export class AggregateBalanceMeasuresTable extends React.PureComponent<IAggregat
         <Stack.Item>{headerWithInfo}</Stack.Item>
 
         <Stack.Item>
-          <DetailsList
+          <AccessibleDetailsList
             items={items}
             columns={columns}
             selectionMode={SelectionMode.none}

--- a/libs/dataset-explorer/src/lib/TableView/TableView.tsx
+++ b/libs/dataset-explorer/src/lib/TableView/TableView.tsx
@@ -3,7 +3,6 @@
 
 import {
   ConstrainMode,
-  DetailsList,
   DetailsListLayoutMode,
   IGroup,
   MarqueeSelection,
@@ -26,7 +25,8 @@ import {
   LabelWithCallout,
   ModelAssessmentContext,
   TelemetryEventName,
-  TelemetryLevels
+  TelemetryLevels,
+  AccessibleDetailsList
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
@@ -181,7 +181,7 @@ export class TableView extends React.Component<
     selectionMode: SelectionMode
   ): React.ReactNode {
     return (
-      <DetailsList
+      <AccessibleDetailsList
         items={this.state.rows}
         columns={this.state.columns}
         groups={this.state.groups}

--- a/libs/e2e/src/lib/describer/modelAssessment/Constants.ts
+++ b/libs/e2e/src/lib/describer/modelAssessment/Constants.ts
@@ -178,7 +178,7 @@ export enum Locators {
   AggregateBalanceMeasures = "#aggregateBalanceMeasures",
   AggregateBalanceMeasuresHeader = "#aggregateBalanceMeasures #aggregateBalanceMeasuresHeader",
   AggregateBalanceMeasuresTable = "#aggregateBalanceMeasures .ms-DetailsList",
-  AggregateBalanceMeasuresTableColumns = "#aggregateBalanceMeasures .ms-DetailsList-headerWrapper div[aria-label]",
+  AggregateBalanceMeasuresTableColumns = "#aggregateBalanceMeasures .ms-DetailsList-headerWrapper span[aria-label]",
   AggregateBalanceMeasuresTableRows = "#aggregateBalanceMeasures .ms-DetailsRow",
   ForecastingDashboard = "#ModelAssessmentDashboard #ForecastingDashboard",
   ForecastingTimeSeriesDropdown = "#ForecastingDashboard #ForecastingTimeSeriesDropdown",

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -4,7 +4,6 @@
 import {
   Checkbox,
   IColumn,
-  DetailsList,
   DetailsListLayoutMode,
   DetailsRow,
   DetailsRowFields,
@@ -38,7 +37,8 @@ import {
   ModelAssessmentContext,
   defaultModelAssessmentContext,
   Announce,
-  stringFormat
+  stringFormat,
+  AccessibleDetailsList
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
@@ -205,7 +205,7 @@ export class FeatureList extends React.Component<
                     selection={this._selection}
                     isEnabled={this.props.isEnabled}
                   >
-                    <DetailsList
+                    <AccessibleDetailsList
                       items={this.state.tableState.rows}
                       columns={this.state.tableState.columns}
                       setKey="set"

--- a/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationsTable.tsx
+++ b/libs/forecasting/src/lib/ForecastingDashboard/Controls/TransformationsTable.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { DetailsList, SelectionMode, Stack, Text } from "@fluentui/react";
+import { SelectionMode, Stack, Text } from "@fluentui/react";
 import {
   defaultModelAssessmentContext,
   JointDataset,
-  ModelAssessmentContext
+  ModelAssessmentContext,
+  AccessibleDetailsList
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
@@ -102,7 +103,7 @@ export class TransformationsTable extends React.Component<
           </Text>
         </Stack.Item>
         <Stack.Item>
-          <DetailsList
+          <AccessibleDetailsList
             items={this.state.rows}
             columns={[
               {

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/Controls/TableList.tsx
@@ -3,7 +3,6 @@
 
 import {
   FocusZone,
-  DetailsList,
   DetailsHeader,
   IDetailsHeaderProps,
   IGroup,
@@ -14,12 +13,17 @@ import {
   Selection,
   MarqueeSelection
 } from "@fluentui/react";
-import { DatasetTaskType, IVisionListItem } from "@responsible-ai/core-ui";
+import {
+  DatasetTaskType,
+  IVisionListItem,
+  AccessibleDetailsList
+} from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
 import { getAltTextForItem } from "../utils/getAltTextUtils";
 import { getFilteredDataFromSearch } from "../utils/getFilteredData";
+import { getTableListColumns } from "../utils/getTableListColumns";
 import { isItemPredTrueEqual } from "../utils/labelUtils";
 import { visionExplanationDashboardStyles } from "../VisionExplanationDashboard.styles";
 
@@ -68,76 +72,10 @@ export class TableList extends React.Component<
       filteredItems,
       groups
     );
-    const columns: IColumn[] = [
-      {
-        fieldName: "image",
-        isResizable: true,
-        key: "image",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnOne
-      },
-      {
-        fieldName: "index",
-        isResizable: true,
-        key: "index",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnTwo
-      }
-    ];
-    const labelColumns: IColumn[] = [
-      {
-        fieldName: "trueY",
-        isResizable: true,
-        key: "truey",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnThree
-      },
-      {
-        fieldName: "predictedY",
-        isResizable: true,
-        key: "predictedy",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnFour
-      }
-    ];
-    const objectDetectionLabelColumns: IColumn[] = [
-      {
-        fieldName: "correctDetections",
-        isResizable: true,
-        key: "correctDetections",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnThreeOD
-      },
-      {
-        fieldName: "incorrectDetections",
-        isResizable: true,
-        key: "incorrectDetections",
-        maxWidth: 400,
-        minWidth: 200,
-        name: localization.InterpretVision.Dashboard.columnFourOD
-      }
-    ];
-    if (this.props.taskType === DatasetTaskType.ObjectDetection) {
-      columns.push(...objectDetectionLabelColumns);
-    } else {
-      columns.push(...labelColumns);
-    }
-    const fieldNames = this.props.otherMetadataFieldNames;
-    fieldNames.forEach((fieldName) => {
-      columns.push({
-        fieldName,
-        isResizable: true,
-        key: fieldName,
-        maxWidth: 400,
-        minWidth: 200,
-        name: fieldName
-      });
-    });
+    const columns = getTableListColumns(
+      this.props.taskType,
+      this.props.otherMetadataFieldNames
+    );
     this.setState({
       columns,
       filteredGroups,
@@ -153,7 +91,7 @@ export class TableList extends React.Component<
         <Stack id="tabsViewTableList">
           <Stack.Item>
             <MarqueeSelection selection={this._selection}>
-              <DetailsList
+              <AccessibleDetailsList
                 key={this.props.searchValue}
                 items={this.state.filteredItems}
                 groups={this.state.filteredGroups}

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getTableListColumns.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/utils/getTableListColumns.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IColumn } from "@fluentui/react";
+import { DatasetTaskType } from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+
+export function getTableListColumns(
+  taskType: string,
+  otherMetadataFieldNames: string[]
+): IColumn[] {
+  const columns: IColumn[] = [
+    {
+      fieldName: "image",
+      isResizable: true,
+      key: "image",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnOne
+    },
+    {
+      fieldName: "index",
+      isResizable: true,
+      key: "index",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnTwo
+    }
+  ];
+  const labelColumns: IColumn[] = [
+    {
+      fieldName: "trueY",
+      isResizable: true,
+      key: "truey",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnThree
+    },
+    {
+      fieldName: "predictedY",
+      isResizable: true,
+      key: "predictedy",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnFour
+    }
+  ];
+  const objectDetectionLabelColumns: IColumn[] = [
+    {
+      fieldName: "correctDetections",
+      isResizable: true,
+      key: "correctDetections",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnThreeOD
+    },
+    {
+      fieldName: "incorrectDetections",
+      isResizable: true,
+      key: "incorrectDetections",
+      maxWidth: 400,
+      minWidth: 200,
+      name: localization.InterpretVision.Dashboard.columnFourOD
+    }
+  ];
+  if (taskType === DatasetTaskType.ObjectDetection) {
+    columns.push(...objectDetectionLabelColumns);
+  } else {
+    columns.push(...labelColumns);
+  }
+  const fieldNames = otherMetadataFieldNames;
+  fieldNames.forEach((fieldName) => {
+    columns.push({
+      fieldName,
+      isResizable: true,
+      key: fieldName,
+      maxWidth: 400,
+      minWidth: 200,
+      name: fieldName
+    });
+  });
+  return columns;
+}

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -91,6 +91,16 @@
     }
   },
   "Core": {
+    "AccessibleDetailsList": {
+      "ResizableDialog": {
+        "title": "Resize Column",
+        "subText": "Enter desired column width in pixels:"
+      },
+      "resize": "Resize",
+      "cancel": "Cancel",
+      "minErrorMessage": "Column width must be a positive integer greater than {0}.",
+      "minMaxErrorMessage": "Column width must be a positive integer greater than {0} and less than {1}."
+    },
     "ExpandableText": {
       "SeeLess": "See less",
       "SeeMore": "See more"

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Cohort/CohortList.tsx
@@ -4,11 +4,11 @@
 import {
   CheckboxVisibility,
   IColumn,
-  DetailsList,
   DetailsListLayoutMode,
   SelectionMode
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   Cohort,
   CohortEditor,
   DatasetCohort,
@@ -76,7 +76,7 @@ export class CohortList extends React.Component<
     const items = this.getCohortListItems();
     return (
       <>
-        <DetailsList
+        <AccessibleDetailsList
           items={items}
           columns={columns}
           setKey="set"

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/DashboardSettings.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/DashboardSettings.tsx
@@ -1,13 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-  DetailsList,
-  IColumn,
-  Panel,
-  SelectionMode,
-  Text
-} from "@fluentui/react";
+import { IColumn, Panel, SelectionMode, Text } from "@fluentui/react";
+import { AccessibleDetailsList } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import React from "react";
 
@@ -50,7 +45,7 @@ export class DashboardSettings extends React.PureComponent<IDashboardSettingsPro
         title={localization.ModelAssessment.DashboardSettings.Title}
       >
         <Text>{localization.ModelAssessment.DashboardSettings.Content}</Text>
-        <DetailsList
+        <AccessibleDetailsList
           items={this.props.activeGlobalTabs.map((a) => ({
             // removing key here because fluent ui also pick it to identify row
             name: a.name

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/FeatureConfigurationFlyout.tsx
@@ -9,7 +9,6 @@ import {
   DefaultButton,
   Text,
   PanelType,
-  DetailsList,
   IColumn,
   Label,
   SpinButton,
@@ -19,6 +18,7 @@ import {
   MessageBarType
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   defaultModelAssessmentContext,
   getCompositeFilterString,
   ModelAssessmentContext
@@ -162,7 +162,7 @@ export class FeatureConfigurationFlyout extends React.Component<
                 .flyoutDescription
             }
           </Text>
-          <DetailsList
+          <AccessibleDetailsList
             items={items}
             columns={columns}
             selectionMode={SelectionMode.multiple}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/MetricConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/MetricConfigurationFlyout.tsx
@@ -12,11 +12,11 @@ import {
   Text,
   Selection,
   SelectionMode,
-  DetailsList,
   PanelType,
   IColumn
 } from "@fluentui/react";
 import {
+  AccessibleDetailsList,
   defaultModelAssessmentContext,
   ModelAssessmentContext
 } from "@responsible-ai/core-ui";
@@ -140,7 +140,7 @@ export class MetricConfigurationFlyout extends React.Component<
                 .flyoutDescription
             }
           </Text>
-          <DetailsList
+          <AccessibleDetailsList
             items={this.state.items}
             columns={columns}
             selectionMode={SelectionMode.multiple}


### PR DESCRIPTION
## Description

add AccessibleDetailsList with resizable columns for accessibility

Video demo of new accessibility feature:

https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/fc090672-8fff-44f8-b5b4-d115b6ad7fb0

User Experience: 
Users who rely on keyboard navigation will not be able to perform the actions properly if the column separator is not keyboard accessible. As a result, they will not be aware of the complete information present inside the table and face difficulty in accessing the table.

Repro Steps:
Open RAI Vision Dashboard
Navigate to "Data analysis" section.
Select "Table view" tab and navigate the table.
Observe whether table column separators are accessible by keyboard or not
Actual Result:

"Data analysis" table column separators are not keyboard accessible.

Observation: 
Keyboard focus is not moving to the table column headers while navigating using tab key.
Table column separators are accessible through mouse.
Expected Result:
"Data analysis" table column separators should be keyboard accessible. 

Example: When focus is on the column header expand/collapse button, by pressing arrow keys or tab key, the focus should move to the column separators, and it should be accessible with CTRL + arrow keys.

Notes: for reference on this keyboard accessible version of the details list, please see the official sample in fluentui for reference:
https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist/keyboardcolumnreorderresize
The class created here was based on this reference.  Note that instead of a popup menu to select column resize, reorder and sort we just have the resize option open directly.  In the future if we need the other functionalities we can add them in a similar way to this guide.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
