### PR TITLE
release tensorflow pin in RAI vision and text package tests which was added last year to fix huggingface transformer models

### DIFF
--- a/responsibleai_text/requirements-dev.txt
+++ b/responsibleai_text/requirements-dev.txt
@@ -6,7 +6,7 @@ requirements-parser==0.2.0
 
 transformers
 datasets
-tensorflow<2.11.0
+tensorflow
 opencv-python
 
 fastai

--- a/responsibleai_vision/requirements-dev.txt
+++ b/responsibleai_vision/requirements-dev.txt
@@ -23,7 +23,7 @@ pydata-sphinx-theme==0.3.0
 
 transformers
 datasets
-tensorflow<2.11.0
+tensorflow
 opencv-python
 
 fastai


### PR DESCRIPTION
## Description

release tensorflow pin in RAI vision and text package tests which was added last year to fix huggingface transformer models

Last year we added a pin to the test cases to tensorflow<2.11.0 because the responsibleai-text package build was failing due to latest tensorflow breaking latest huggingface transformers package.  Reverting this change back now that huggingface has caught up to ensure we are testing on the latest version of tensorflow in our unit tests.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
