### PR TITLE
fix vision data explorer elements truncated in smaller screen

### DIFF
--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.styles.ts
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboard.styles.ts
@@ -7,6 +7,7 @@ import {
   IProcessedStyleSet,
   getTheme
 } from "@fluentui/react";
+import { flexMdDown } from "@responsible-ai/core-ui";
 export interface IVisionExplanationDashboardStyles {
   cohortDropdown: IStyle;
   cohortPickerLabel: IStyle;
@@ -17,6 +18,7 @@ export interface IVisionExplanationDashboardStyles {
   toolBarContainer: IStyle;
   itemsSelectedContainer: IStyle;
   legendIndicator: IStyle;
+  lowerToolbarContainer: IStyle;
   mainContainer: IStyle;
   mainImageContainer: IStyle;
   halfContainer: IStyle;
@@ -67,6 +69,7 @@ export const visionExplanationDashboardStyles: () => IProcessedStyleSet<IVisionE
         paddingRight: 20,
         paddingTop: 2
       },
+      lowerToolbarContainer: flexMdDown,
       mainContainer: {
         alignItems: "center",
         justifyContent: "space-between",
@@ -103,6 +106,7 @@ export const visionExplanationDashboardStyles: () => IProcessedStyleSet<IVisionE
         position: "relative"
       },
       toolBarContainer: {
+        ...flexMdDown,
         width: "100%"
       }
     });

--- a/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHeader.tsx
+++ b/libs/interpret-vision/src/lib/VisionExplanationDashboard/VisionExplanationDashboardHeader.tsx
@@ -87,6 +87,7 @@ export class VisionExplanationDashboardHeader extends React.Component<
             horizontal
             horizontalAlign="space-between"
             verticalAlign="start"
+            className={this.props.classNames.lowerToolbarContainer}
           >
             <Stack.Item>
               <Slider


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix vision data explorer elements truncated in smaller screen

Before fix:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/d690e6dd-0c12-4666-ad2b-d1ffdeaa44b6)


After fix:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/322ea318-df85-4e99-8931-21061dd9bc0f)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
