### PR TITLE
fix release script due to dependency test errors

### DIFF
--- a/.github/workflows/release-rai-text.yml
+++ b/.github/workflows/release-rai-text.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install pytorch
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+          conda install --yes --quiet pytorch torchvision captum cpuonly "numpy<1.24.0" -c pytorch
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix release script due to dependency test errors

The responsibleai-text package release script is failing due numpy version conflict issue with shap package in test cases.  Note this has been fixed in latest shap but we haven't upgraded to it yet.  For now pinning "numpy<1.24.0" in test cases.  This pin will be removed once next version of interpret-community is released with latest shap.

Link to failing build:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7390202783/job/20104608524

Error message from shap package:
```
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/responsibleai/rai_insights/rai_base_insights.py:87: in compute
    manager.compute()
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/responsibleai_text/managers/explainer_manager.py:117: in compute
    self._explanation = explainer(eval_examples)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/shap/explainers/_partition.py:136: in __call__
    return super().__call__(
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/shap/explainers/_explainer.py:266: in __call__
    row_result = self.explain_row(
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/shap/explainers/_partition.py:154: in explain_row
    fm = MaskedModel(self.model, self.masker, self.link, self.linearize_link, *row_args)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/shap/utils/_masked_model.py:28: in __init__
    self._variants = ~self.masker.invariants(*args)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/shap/maskers/_text.py:297: in invariants
    invariants = np.zeros(len(self._tokenized_s), dtype=np.bool)
...
        if attr in __former_attrs__:
>           raise AttributeError(__former_attrs__[attr])
E           AttributeError: module 'numpy' has no attribute 'bool'.
E           `np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

Successful build to validate this branch:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7390367586

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
