### PR TITLE
Accessibility Fix for Metric Checkboxes

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/MetricConfigurationFlyout.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/MetricConfigurationFlyout.tsx
@@ -154,6 +154,10 @@ export class MetricConfigurationFlyout extends React.Component<
               localization.ModelAssessment.ModelOverview.featureConfiguration
                 .metricSelectionAriaLabel
             }
+            checkButtonAriaLabel={
+              localization.ModelAssessment.FeatureImportances
+                .RowCheckboxAriaLabel
+            }
           />
         </Stack>
       </Panel>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->
This pull request includes a single change to improve the accessibility of the `MetricConfiguration` component in the `ModelAssessmentDashboard` module. The change adds a new prop `checkButtonAriaLabel` to provide an aria label for the check button.

* [`libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/ModelOverview/MetricConfigurationFlyout.tsx`](diffhunk://#diff-84b3b1387e6ac1bf0581887b3dd381f7aef6be73c4ebb09f6401a12c578dad03R157-R160): Added a new prop `checkButtonAriaLabel` to the `MetricConfiguration` component to improve accessibility.

Before change:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/03f6ca80-dae5-4ede-befc-64dac91ec718)

After change:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/37190647/3a4e1885-1ea0-444c-b7a9-31f7b9af5a3c)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
