### PR TITLE
ignore error when uploading test dashboard from build for external forks

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -118,6 +118,7 @@ jobs:
 
       - name: Upload dashboard ${{steps.publish_url_for_js.outputs.url}}
         uses: Azure/cli@v1.0.0
+        id: uploaddashboard
         with:
           azcliversion: 2.16.0
           inlineScript: |
@@ -130,16 +131,18 @@ jobs:
             else
               echo "Invalid event $${{ github.event_name }}"
             fi
+        continue-on-error: true
 
-      - uses: unsplash/comment-on-pr@master
-        if: ${{ github.event_name  == 'pull_request' }}
+      - if: ${{ (github.event_name  == 'pull_request') && (steps.uploaddashboard.outcome != 'failure') }}
+        uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           msg: ${{steps.publish_url_for_js.outputs.url}}
           check_for_duplicate_msg: true
 
-      - name: Upload responsible-ai
+      - if: ${{ (steps.uploaddashboard.outcome != 'failure') }}
+        name: Upload responsible-ai
         uses: Azure/cli@v1.0.0
         with:
           azcliversion: 2.16.0
@@ -154,7 +157,8 @@ jobs:
               echo "Invalid event $${{ github.event_name }}"
             fi
 
-      - name: Upload raiwidgets
+      - if: ${{ (steps.uploaddashboard.outcome != 'failure') }}
+        name: Upload raiwidgets
         uses: Azure/cli@v1.0.0
         with:
           azcliversion: 2.16.0
@@ -173,7 +177,8 @@ jobs:
         id: retention_date
         run: echo "::set-output name=date::$(date --date='${{env.retentionDays}} days ago' +'%Y-%m-%dT00:00Z')"
 
-      - name: Delete old files before ${{steps.retention_date.outputs.date}}
+      - if: ${{ (steps.uploaddashboard.outcome != 'failure') }}
+        name: Delete old files before ${{steps.retention_date.outputs.date}}
         uses: Azure/cli@v1.0.0
         with:
           azcliversion: 2.16.0


### PR DESCRIPTION
## Description

External contributors may encounter auth errors on PRs from their forks during CD build.
Here, we continue on error if auth is missing to upload the test dashboard.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
