### PR TITLE
fix wrong metrics count missing in vision explorer of RAI Vision dashboard for object detection

### DIFF
--- a/responsibleai_vision/tests/test_image_utils.py
+++ b/responsibleai_vision/tests/test_image_utils.py
@@ -17,7 +17,8 @@ from responsibleai_vision.utils.image_reader import \
     _requests_sessions as image_reader_requests_sessions
 from responsibleai_vision.utils.image_reader import get_all_exif_feature_names
 from responsibleai_vision.utils.image_utils import (
-    BOTTOM_X, BOTTOM_Y, HEIGHT, IS_CROWD, TOP_X, TOP_Y, WIDTH, classes_to_dict,
+    _NOLABEL, BOTTOM_X, BOTTOM_Y, HEIGHT, IS_CROWD, TOP_X, TOP_Y, WIDTH,
+    classes_to_dict, generate_od_error_labels,
     transform_object_detection_labels)
 
 LABEL = ImageColumns.LABEL.value
@@ -99,3 +100,35 @@ class TestImageUtils(object):
             set(['Orientation', 'ExifOffset', 'ImageWidth', 'GPSInfo',
                  'Model', 'DateTime', 'YCbCrPositioning', 'ImageLength',
                  'ResolutionUnit', 'Software', 'Make'])
+
+    def test_generate_od_error_labels(self):
+        true_y = np.array([[[3, 142, 257, 395, 463, 0]],
+                           [[3, 107, 272, 240, 501, 0],
+                            [1, 261, 274, 393, 449, 0]],
+                           [[4, 139, 253, 339, 506, 0]],
+                           [[2, 100, 173, 233, 521, 0]],
+                           [[1, 175, 253, 355, 416, 0]],
+                           [[2, 86, 102, 216, 439, 0],
+                            [3, 150, 377, 445, 490, 0]],
+                           [[3, 103, 272, 358, 475, 0]],
+                           [[4, 65, 289, 436, 414, 0]],
+                           [[1, 130, 271, 367, 467, 0]],
+                           [[1, 144, 260, 318, 429, 0]]])
+        pred_y = np.array([[[3, 140, 260, 396, 469, 0]],
+                           [[3, 108, 270, 237, 505, 0],
+                            [1, 259, 271, 401, 450, 0]],
+                           [[4, 131, 250, 330, 485, 0]],
+                           [[2, 97, 170, 241, 516, 0]],
+                           [[1, 175, 250, 354, 414, 0]],
+                           [[2, 83, 98, 222, 445, 0],
+                            [3, 130, 366, 438, 496, 0]],
+                           [[3, 104, 265, 360, 468, 0]],
+                           [[4, 58, 284, 483, 420, 0]],
+                           [[1, 128, 265, 367, 471, 0]],
+                           [[1, 137, 260, 325, 430, 0]]])
+        class_names = ["can", "carton", "milk_bottle", "water_bottle"]
+        error_labels = generate_od_error_labels(true_y, pred_y, class_names)
+        assert len(error_labels) == 10
+        assert error_labels[0]['aggregate'] == "1 correct, 0 incorrect"
+        assert error_labels[0]['correct'] == "1 milk_bottle"
+        assert error_labels[0]['incorrect'] == _NOLABEL


### PR DESCRIPTION
## Description

fix wrong metrics count missing in vision explorer of RAI Vision dashboard for object detection

Several customers are seeing the wrong metrics count missing in RAI Vision dashboard - this was tracked down to extra whitespace added in the generate_od_error_labels methods for linting:

```
            rendered_labels[_AGGREGATE_LABEL] = \
                f"{sum(image_labels[_CORRECT].values())} {_CORRECT}, \
                  {sum(image_labels[_INCORRECT].values())} \
                  {_INCORRECT}"
```
The generated json file then had all of this whitespace for incorrect labels:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/45836e64-fc4f-48dd-8256-863013305f37)

This extra whitespace at the start of the line caused parsing errors later in the UI code:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/feaccb2e-a2ee-433c-8180-00a86e7750d2)

This PR fixes the issue and also adds some validation checks in the code.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
