### PR TITLE
PL Support on raiwidgets

### DIFF
--- a/raiwidgets/raiwidgets/dashboard.py
+++ b/raiwidgets/raiwidgets/dashboard.py
@@ -61,6 +61,7 @@ class Dashboard(object):
                  port,
                  locale,
                  no_inline_dashboard=False,
+                 is_private_link=False
                  **kwargs):
         """Initialize the dashboard."""
 
@@ -68,7 +69,9 @@ class Dashboard(object):
             raise ValueError("Required parameters not provided")
 
         try:
-            self._service = FlaskHelper(ip=public_ip, port=port)
+            self._service = FlaskHelper(ip=public_ip,
+                                        port=port,
+                                        is_private_link=is_private_link)
         except Exception as e:
             self._service = None
             raise e

--- a/raiwidgets/raiwidgets/dashboard.py
+++ b/raiwidgets/raiwidgets/dashboard.py
@@ -61,7 +61,7 @@ class Dashboard(object):
                  port,
                  locale,
                  no_inline_dashboard=False,
-                 is_private_link=False
+                 is_private_link=False,
                  **kwargs):
         """Initialize the dashboard."""
 

--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -29,10 +29,14 @@ class ResponsibleAIDashboard(Dashboard):
     :param cohort_list:
         List of cohorts defined by the user for the dashboard.
     :type cohort_list: List[Cohort]
+    :param is_private_link: If the dashboard environment is
+        a private link AML workspace.
+    :type is_private_link: bool
     """
     def __init__(self, analysis: RAIInsights,
                  public_ip=None, port=None, locale=None,
-                 cohort_list=None, **kwargs):
+                 cohort_list=None, is_private_link=False,
+                 **kwargs):
         self.input = ResponsibleAIDashboardInput(
             analysis, cohort_list=cohort_list)
 
@@ -43,6 +47,7 @@ class ResponsibleAIDashboard(Dashboard):
             port=port,
             locale=locale,
             no_inline_dashboard=True,
+            is_private_link=is_private_link,
             **kwargs)
 
         def predict():

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.2,<=1.26.2
 pandas>=0.25.1,<2.0.0
 scipy>=1.4.1
-rai-core-flask==0.7.2
+rai-core-flask==0.7.3
 itsdangerous<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request primarily focuses on introducing a new parameter, `is_private_link`, to the `FlaskHelper` and `ResponsibleAIDashboard` classes in the `raiwidgets` package. This parameter is used to determine if the dashboard environment is a private link Azure Machine Learning workspace.

Here are the key changes:

* [`raiwidgets/raiwidgets/dashboard.py`](diffhunk://#diff-05033ffdb54e823bad4b4f1ce6235e958e28b10da06beb834c5a03bde2a50a79R64-R74): Added a new parameter `is_private_link` to the `__init__` method of the `FlaskHelper` class. This parameter is used when initializing the `FlaskHelper` service.

* [`raiwidgets/raiwidgets/responsibleai_dashboard.py`](diffhunk://#diff-19863f912eef4114249b3314a255ffa5ee75e36453eda7da1d41b332ee9d0e4fR32-R39): Introduced the `is_private_link` parameter to the `ResponsibleAIDashboard` class. It is added to the `__init__` method and passed to the `FlaskHelper` service initialization. [[1]](diffhunk://#diff-19863f912eef4114249b3314a255ffa5ee75e36453eda7da1d41b332ee9d0e4fR32-R39) [[2]](diffhunk://#diff-19863f912eef4114249b3314a255ffa5ee75e36453eda7da1d41b332ee9d0e4fR50)

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
