### PR TITLE
added generative text explainer

### DIFF
--- a/responsibleai_text/setup.py
+++ b/responsibleai_text/setup.py
@@ -24,6 +24,10 @@ EXTRAS = {
         'bert_score',
         'nltk',
         'rouge_score'
+    ],
+    "generative_text": [
+        'interpret_text',
+        'sentence_transformers'
     ]
 }
 setuptools.setup(


### PR DESCRIPTION
Added generative text explainer and it's respective in the reponsibleai_text setup.py. 

Note to be able to use this explainer fully kartik727's pull request "Added metrics for genai text #2514" needs to be approved since it includes code that extends the RAI toolbox to handle the model task type "generative_text"
