### PR TITLE
fix CD.yml permissions errors for dashboard links on PRs

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   cd-build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix CD.yml permissions errors for dashboard links on PRs

As of Feb 1, 2024, permissions are set as read-only by default for github actions based on the alert:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/b97f5273-368b-4ff4-8142-ff578b43ea50)

For more details, please see:
https://docs.opensource.microsoft.com/github/apps/permission-changes/#what-steps-must-i-take-to-avoid-a-bad-time

Due to this change, we now see errors like the following on main:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/c5aa2ea7-1b15-46cd-9b2c-6ba343c3703a)

For example failing build output see:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7758629239/job/21164158648?pr=2522

To fix our broken CD.yml builds, this PR gives write permissions for PRs.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
