### PR TITLE
fix label column incorrectly added by feature extractors in RAI Vision dashboard for automl models

### DIFF
--- a/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
+++ b/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
@@ -12,8 +12,8 @@ from PIL.ExifTags import TAGS
 from tqdm import tqdm
 
 from responsibleai.feature_metadata import FeatureMetadata
-from responsibleai_vision.common.constants import (
-    ExtractedFeatures, ImageColumns)
+from responsibleai_vision.common.constants import (ExtractedFeatures,
+                                                   ImageColumns)
 from responsibleai_vision.utils.image_reader import (
     get_all_exif_feature_names, get_image_from_path,
     get_image_pointer_from_path)

--- a/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
+++ b/responsibleai_vision/responsibleai_vision/utils/feature_extractors.py
@@ -12,13 +12,15 @@ from PIL.ExifTags import TAGS
 from tqdm import tqdm
 
 from responsibleai.feature_metadata import FeatureMetadata
-from responsibleai_vision.common.constants import ExtractedFeatures
+from responsibleai_vision.common.constants import (
+    ExtractedFeatures, ImageColumns)
 from responsibleai_vision.utils.image_reader import (
     get_all_exif_feature_names, get_image_from_path,
     get_image_pointer_from_path)
 
 MEAN_PIXEL_VALUE = ExtractedFeatures.MEAN_PIXEL_VALUE.value
 MAX_CUSTOM_LEN = 100
+IMAGE_DETAILS = ImageColumns.IMAGE_DETAILS.value
 
 
 def extract_features(image_dataset: pd.DataFrame,
@@ -58,6 +60,8 @@ def extract_features(image_dataset: pd.DataFrame,
     start_meta_index = 2
     if isinstance(target_column, list):
         start_meta_index = len(target_column) + 1
+    if IMAGE_DETAILS in column_names:
+        start_meta_index += 1
     for j in range(start_meta_index, image_dataset.shape[1]):
         if has_dropped_features and column_names[j] in dropped_features:
             continue

--- a/responsibleai_vision/tests/rai_vision_insights_validator.py
+++ b/responsibleai_vision/tests/rai_vision_insights_validator.py
@@ -31,6 +31,13 @@ def validate_rai_vision_insights(
         pd.testing.assert_frame_equal(rai_vision_test, test_data)
     assert rai_vision_insights.target_column == target_column
     assert rai_vision_insights.task_type == task_type
+    # make sure label column not in _ext_test extracted features data
+    assert target_column not in rai_vision_insights._ext_features
+    # also not in last column of _ext_test, which is prone to happen
+    # if incorrect number of metadata columns specified in
+    # feature_extractors call
+    first_row = rai_vision_insights._ext_test[0]
+    assert not isinstance(first_row[len(first_row) - 1], list)
 
 
 def run_and_validate_serialization(

--- a/responsibleai_vision/tests/test_feature_extractors.py
+++ b/responsibleai_vision/tests/test_feature_extractors.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pytest
 from common_vision_utils import (load_flowers_dataset, load_fridge_dataset,
                                  load_fridge_object_detection_dataset,
                                  load_imagenet_dataset)
@@ -39,8 +40,10 @@ def extract_dataset_features(data, feature_metadata=None):
 
 
 class TestFeatureExtractors(object):
-    def test_extract_features_fridge_object_detection(self):
-        data = load_fridge_object_detection_dataset(automl_format=False)
+    @pytest.mark.parametrize("automl_format", [True, False])
+    def test_extract_features_fridge_object_detection(self, automl_format):
+        data = load_fridge_object_detection_dataset(
+            automl_format=automl_format)
         extracted_features, feature_names = extract_dataset_features(data)
         expected_feature_names = [MEAN_PIXEL_VALUE] + FRIDGE_METADATA_FEATURES
         validate_extracted_features(extracted_features, feature_names,


### PR DESCRIPTION
## Description

fix label column incorrectly added by feature extractors in RAI Vision dashboard for automl models

One of our customers was not able to run error analysis when attaching to compute instance due to label column being incorrectly included in the RAI Vision dashboard extracted metadata.  They encountered the error:

```
Traceback (most recent call last):
  File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/raiwidgets/responsibleai_dashboard_input.py", line 182, in debug_ml
    filtered_data_df = self._prepare_filtered_error_analysis_data(
  File "/azureml-envs/responsibleai-vision/lib/python3.8/site-packages/raiwidgets/responsibleai_dashboard_input.py", line 166, in _prepare_filtered_error_analysis_data
    raise UserConfigValidationException(
Feature label not found in dataset. Existing features: <REMOVED>
...
```


This seems to be an issue that occurs only for automl models due to the extra "image_details" column which is not skipped in the logic of ```extract_features``` function.
This PR fixes the errors and adds both a unit test for the ```extract_features``` function and an e2e test for the RAI vision dashboard on the fridge dataset.
I was also able to reproduce the error for our AutoML notebook.  Note when viewing image metadata we see the extra label column which should not be included:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/e11f7dff-587d-47a7-b460-8e8ed1adc29c)


## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
