### PR TITLE
fix permissions for RAI tabular release workflow to add release tags to repository

### DIFF
--- a/.github/workflows/release-rai-tabular.yml
+++ b/.github/workflows/release-rai-tabular.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    permissions:
+      content: write
 
     steps:
       - name: fail if Test nor Prod


### PR DESCRIPTION
## Description

fix permissions for RAI tabular release workflow to add release tags to repository

Github actions release workflow is failing:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7837013273

Specifically, the yarn auto-version command is failing to update the release tags in the repository:
![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/48efac50-3be2-4e3b-8a99-0e140b094a41)

This is due to a similar issue that PR https://github.com/microsoft/responsible-ai-toolbox/pull/2525 resolved.

As of Feb 1, 2024, permissions are set as read-only by default for github actions based on the alert:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/b97f5273-368b-4ff4-8142-ff578b43ea50)

For more details, please see:
https://docs.opensource.microsoft.com/github/apps/permission-changes/#what-steps-must-i-take-to-avoid-a-bad-time

To resolve the issue, we allow the github actions workflow to modify repository contents - specifically the release tags.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
