### PR TITLE
fix release github actions for RAI vision and text packages

### DIFF
--- a/.github/workflows/release-rai-text.yml
+++ b/.github/workflows/release-rai-text.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install pytorch
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum cpuonly "numpy<1.24.0" -c pytorch
+          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" cpuonly "numpy<1.24.0" -c pytorch
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}
@@ -41,6 +41,7 @@ jobs:
       - name: install requirements.txt for responsibleai-text
         shell: bash -l {0}
         run: |
+          pip install captum
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
         working-directory: responsibleai_text
@@ -62,7 +63,7 @@ jobs:
 
       - name: install responsibleai-text wheel locally
         shell: bash -l {0}
-        run: find ./dist/ -name '*.whl' -exec pip install {} \;
+        run: find ./dist/ -name '*.whl' -exec pip install {}[qa] \;
         working-directory: responsibleai_text
 
       - name: run responsibleai-text tests

--- a/.github/workflows/release-rai-vision.yml
+++ b/.github/workflows/release-rai-vision.yml
@@ -30,13 +30,13 @@ jobs:
       - name: Install pytorch
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" cpuonly "numpy<1.24.0" -c pytorch
 
       # pycocotools is a downstream dependency of automl requirements, but fails to install with pip
       - name: Install pycocotools
         shell: bash -l {0}
         run: |
-          conda install pycocotools==2.0.4 -c conda-forge
+          conda install pycocotools==2.0.6 -c conda-forge
 
       - name: update and upgrade pip, setuptools, wheel, and twine
         shell: bash -l {0}
@@ -47,6 +47,7 @@ jobs:
       - name: install requirements.txt for responsibleai-vision
         shell: bash -l {0}
         run: |
+          pip install captum
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
         working-directory: responsibleai_vision


### PR DESCRIPTION
## Description

fix release github actions for RAI vision and text packages

Github actions for text and vision seem to be failing in CI due to errors:


[Text github action:](https://pipelinesghubeus23.actions.githubusercontent.com/8fru5FEWcsSqPY4bPY6n4Xkm1TtTUv1zSdknAnbOgoTcX7qDbc/_apis/pipelines/1/runs/74785/signedlogcontent/2?urlExpires=2024-02-12T16%3A35%3A17.6235778Z&urlSigningMethod=HMACV1&urlSignature=UMZzHSY5t1j%2FYd51KVjVtnvw7NFJ4x1qs0gu%2BC70RtU%3D)
```
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/torch/_custom_op/impl.py:1052: in error_not_found
    raise ValueError(
E   ValueError: Could not find the operator torchvision::nms. Please make sure you have already registered the operator and (if registered from C++) loaded it via torch.ops.load_library.
```

[Vision github action:](https://pipelinesghubeus23.actions.githubusercontent.com/8fru5FEWcsSqPY4bPY6n4Xkm1TtTUv1zSdknAnbOgoTcX7qDbc/_apis/pipelines/1/runs/74786/signedlogcontent/2?urlExpires=2024-02-12T16%3A35%3A51.9848197Z&urlSigningMethod=HMACV1&urlSignature=M4pQMlkY0KrlfOsJPYmcoTrQWCEZYDB9hg%2Bmu1AhVBo%3D)
```
  Attempting uninstall: cryptography
    Found existing installation: cryptography 42.0.2
Error: -12T2024-02-12T15:44:40.9776411Z ##[error]No space left on device : '/home/runner/runners/2.312.0/_diag/pages/08edee05-83f0-428a-ba89-169b6c454d4d_2a5570e3-06cd-5cc4-41e4-bbdaf36dbb4d_1.log'
```

This PR aims to resolve this by incrementing pycocotools==2.0.6 and making builds more similar to the unit tests github action which is passing:
https://github.com/microsoft/responsible-ai-toolbox/blob/main/.github/workflows/CI-responsibleai-text-vision-pytest.yml

Link to passing responsibleai-vision release:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7875199845

Link to passing responsibleai-text release:
https://github.com/microsoft/responsible-ai-toolbox/actions/runs/7876079640

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
