### PR TITLE
fix bad whitespace in url format for azure compute instance base url

### DIFF
--- a/rai_core_flask/rai_core_flask/environments/azure_nb_environment.py
+++ b/rai_core_flask/rai_core_flask/environments/azure_nb_environment.py
@@ -11,6 +11,12 @@ from rai_core_flask.environments.base_environment import BaseEnvironment
 AZURE_NB = "azure_nb"
 
 
+def get_url_format(is_private_link, instance_name, domain_suffix, port):
+    if is_private_link:
+        return f"{instance_name}.{domain_suffix}:{port}"
+    return f"{instance_name}-{port}.{domain_suffix}"
+
+
 class AzureNBEnvironment(BaseEnvironment):
     """Environment class for Azure notebook environments.
 
@@ -36,14 +42,10 @@ class AzureNBEnvironment(BaseEnvironment):
             else:
                 instance_name = self.nbvm["instance"]
                 domain_suffix = self.nbvm["domainsuffix"]
-                if service.is_private_link:
-                    url_format = f"{instance_name}.{domain_suffix}\
-                        :{service.port}"
-                else:
-                    url_format = f"{instance_name}-{service.port}\
-                        .{domain_suffix}"
-                self.base_url = \
-                    f"https://{url_format}"
+                url_format = get_url_format(
+                    service.is_private_link, instance_name, domain_suffix,
+                    service.port)
+                self.base_url = f"https://{url_format}"
                 self.successfully_detected = True
                 self.nbvm_origins = [
                     f"https://{instance_name}.{domain_suffix}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix bad whitespace in url format for azure compute instance base url

Seeing bad whitespace in base_url causing errors when trying to connect to compute instance:

![image](https://github.com/microsoft/responsible-ai-toolbox/assets/24683184/4c2fe606-759c-4657-a99d-25399a847458)

This results in RAI dashboard missing all dynamic functionality since it can't connect to the python backend.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
