### PR TITLE
remove pins on werkzeug, itsdangerous and markupsafe since they are currently not needed

### DIFF
--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -3,8 +3,5 @@ Flask-Cors
 flask-socketio
 ipython<=7.16.3; python_version <= '3.6'
 ipython>=7.31.1; python_version > '3.6'
-itsdangerous>=2.0.1
 greenlet>=1.1.2
 gevent>=21.12.0
-markupsafe<=2.1.2
-Werkzeug<=3.0.2

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -2,7 +2,6 @@ numpy>=1.17.2,<=1.26.2
 pandas>=0.25.1,<2.0.0
 scipy>=1.4.1
 rai-core-flask==0.7.5
-itsdangerous<=2.1.2
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
 erroranalysis>=0.5.4

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -18,5 +18,4 @@ ml-wrappers
 networkx<=2.5
 ipykernel<=6.8.0; python_version <= '3.7'
 ipykernel>=6.22.0; python_version > '3.7'
-markupsafe<=2.1.2
 raiutils>=0.4.2


### PR DESCRIPTION
## Description

Removing pins on werkzeug, itsdangerous and markupsafe since they are currently not needed.
Some of these were added about a year ago to fix build breaks:
https://github.com/microsoft/responsible-ai-toolbox/pull/1238
However these issues have been resolved and we should not be pinning them but instead rely on flask to pin to the correct versions unless we encounter issues again.
Otherwise, downstream customers are seeing problems with our pins being too restrictive.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
