### PR TITLE
Update responsibleai to scikit-learn 1.5.1

### DIFF
--- a/erroranalysis/requirements-dev.txt
+++ b/erroranalysis/requirements-dev.txt
@@ -4,5 +4,5 @@ pytest-mock==3.6.1
 
 requirements-parser==0.2.0
 rai-test-utils[object_detection]>=0.4.2
-scikit-learn<=1.3.2
+scikit-learn<=1.5.1
 interpret-core[required]<=0.3.2

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -9,7 +9,7 @@ numpy>=1.17.2,<=1.26.2
 numba<=0.58.1
 pandas>=0.25.1,<2.0.0
 # See PR 1429 about upper bound
-scikit-learn>=0.22.1,!=1.1,<1.4.1.post1
+scikit-learn>=0.22.1,!=1.1,<=1.5.1
 scipy>=1.4.1
 semver~=2.13.0
 ml-wrappers


### PR DESCRIPTION
## Description

Update responsibleai to scikit-learn 1.5.1

Edit: there were some errors due to issue https://github.com/scikit-learn/scikit-learn/pull/29018 which was fixed in latest scikit-learn 1.5.1.  Hopefully upgrading to latest scikit-learn will resolve the econml errors.  For more details on error please see:

https://github.com/py-why/EconML/issues/854

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
