### PR TITLE
Upgrade flask to resolve notebook error " ImportError: cannot import name 'url_quote' from 'werkzeug.urls'"

### DIFF
--- a/rai_core_flask/requirements.txt
+++ b/rai_core_flask/requirements.txt
@@ -1,4 +1,4 @@
-Flask
+Flask>=3.0.0
 Flask-Cors
 flask-socketio
 ipython<=7.16.3; python_version <= '3.6'

--- a/rai_core_flask/setup.py
+++ b/rai_core_flask/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 # The version must be incremented every time we push an update to pypi (but
 # not before)
-VERSION = "0.7.6"
+VERSION = "0.7.7"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:


### PR DESCRIPTION
For ImportError: cannot import name 'url_quote' from 'werkzeug.urls', since we pinned werkzeug>=3.0.3 to fix the vulnerability issue on wekzeug, and the url_quote function was removed in Werkzeug version 3.0.0, we need to upgrade the Flask version to be compatible with the Werkzeug version 3.0.3.

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
