### PR TITLE
[A11y] Fix 'Vision data explorer' text present under 'analyse_ model' page is not defined as heading programmatically.

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -164,7 +164,7 @@ export class TabsView extends React.PureComponent<
                 this.props.dataset.class_names && (
                   <>
                     <div className={classNames.sectionHeader}>
-                      <Text as="h2" variant={"xxLarge"}>
+                      <Text as="h3" variant={"xxLarge"}>
                         {localization.ModelAssessment.ComponentNames.VisionTab}
                       </Text>
                     </div>

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/TabsView/TabsView.tsx
@@ -164,7 +164,7 @@ export class TabsView extends React.PureComponent<
                 this.props.dataset.class_names && (
                   <>
                     <div className={classNames.sectionHeader}>
-                      <Text variant={"xxLarge"}>
+                      <Text as="h2" variant={"xxLarge"}>
                         {localization.ModelAssessment.ComponentNames.VisionTab}
                       </Text>
                     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5c4bd783-8d71-46ff-a6ba-93c631418152)

## Description

<!--- Describe your changes and elaborate on motivation and context. -->
<!--- Make sure to refer to relevant GitHub issues using # -->

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
