### PR TITLE
Remove detection extra from torchmetrics install

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -117,7 +117,7 @@ jobs:
         run: pytest -s -v --durations=10
 
       - name: Upload a Build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -224,7 +224,7 @@ jobs:
           node-version: ${{ env.node-version }}
       - id: download
         name: Download a Build Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/CI-e2e-notebooks-text-vision.yml
+++ b/.github/workflows/CI-e2e-notebooks-text-vision.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn buildall
 
       - name: Upload the build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-js
           path: raiwidgets/raiwidgets/widget
@@ -77,7 +77,7 @@ jobs:
         run: yarn install --frozen-lock-file
 
       - name: Download the UI build result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: raiwidgets-js
           path: raiwidgets/raiwidgets/widget
@@ -143,7 +143,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: ./dist/cypress

--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
         run: yarn buildall
 
       - name: Upload the build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-js
           path: raiwidgets/raiwidgets/widget
@@ -73,7 +73,7 @@ jobs:
         run: yarn install --frozen-lock-file
 
       - name: Download the UI build result
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: raiwidgets-js
           path: raiwidgets/raiwidgets/widget
@@ -110,7 +110,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: ./dist/cypress

--- a/.github/workflows/CI-notebook-text.yml
+++ b/.github/workflows/CI-notebook-text.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -111,14 +111,14 @@ jobs:
 
       - name: Upload notebook test result
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: notebook-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: notebooks
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: dist/cypress

--- a/.github/workflows/CI-notebook-vision.yml
+++ b/.github/workflows/CI-notebook-vision.yml
@@ -97,7 +97,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -108,14 +108,14 @@ jobs:
 
       - name: Upload notebook test result
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: notebook-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: notebooks
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: dist/cypress

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -75,7 +75,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -86,14 +86,14 @@ jobs:
 
       - name: Upload notebook test result
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: notebook-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: notebooks
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: dist/cypress

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -70,7 +70,7 @@ jobs:
         working-directory: raiwidgets
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: raiwidgets/installed-requirements-dev.txt
@@ -81,7 +81,7 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.packageDirectory }}-code-coverage-results
           path: ${{ matrix.packageDirectory }}/htmlcov

--- a/.github/workflows/CI-rai_core_flask-pytest.yml
+++ b/.github/workflows/CI-rai_core_flask-pytest.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: rai_core_flask
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev-comp.txt
           path: rai_core_flask/requirements-dev-comp.txt
@@ -78,7 +78,7 @@ jobs:
         working-directory: rai_core_flask
 
       - name: Upload code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rai_core_flask-code-coverage-results
           path: rai_core_flask/htmlcov

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -103,7 +103,7 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload requirements
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
           path: ${{ matrix.packageDirectory }}/installed-requirements-dev.txt
@@ -117,7 +117,7 @@ jobs:
 
       - if: ${{ (steps.raiwidgettests.outcome == 'success') }}
         name: Upload code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.packageDirectory }}-code-coverage-results
           path: ${{ matrix.packageDirectory }}/htmlcov

--- a/.github/workflows/CI-responsibleai-text-vision-pytest.yml
+++ b/.github/workflows/CI-responsibleai-text-vision-pytest.yml
@@ -119,7 +119,7 @@ jobs:
         working-directory: ${{ matrix.packageDirectory }}
 
       - name: Upload code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.packageDirectory }}-code-coverage-results
           path: ${{ matrix.packageDirectory }}/htmlcov

--- a/.github/workflows/CI-typescript.yml
+++ b/.github/workflows/CI-typescript.yml
@@ -32,19 +32,19 @@ jobs:
         run: yarn ci
       - name: Upload unit test code coverage
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-coverage-${{ matrix.node-version }}
           path: coverage
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-screen-shot-${{ matrix.node-version }}
           path: dist/cypress
       - name: Upload yarn error
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: yarn-error.log-${{ matrix.node-version }}
           path: yarn-error.log

--- a/.github/workflows/release-rai-tabular.yml
+++ b/.github/workflows/release-rai-tabular.yml
@@ -107,19 +107,19 @@ jobs:
         working-directory: ${{ env.raiDirectory }}
 
       - name: Upload a raiwidgets build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.widgetDirectory }}
           path: ${{ env.widgetDirectory }}/dist/
 
       - name: Upload a responsibleai build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.raiDirectory }}
           path: ${{ env.raiDirectory }}/dist/
 
       - name: Upload a typescript build result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.typescriptBuildArtifactName }}
           path: ${{ env.typescriptBuildOutput }}
@@ -147,14 +147,14 @@ jobs:
 
       - id: download_rai_unit
         name: Download responsibleai wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.raiDirectory }}
           path: ${{ env.raiDirectory }}
 
       - id: download_raiwidgets_unit
         name: Download raiwidgets wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.widgetDirectory }}
           path: ${{ env.widgetDirectory }}
@@ -209,14 +209,14 @@ jobs:
 
       - id: download_rai_e2e
         name: Download responsibleai wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: responsibleai
           path: responsibleai
 
       - id: download_raiwidgets_e2e
         name: Download raiwidgets wheel
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: raiwidgets
           path: raiwidgets
@@ -253,7 +253,7 @@ jobs:
 
       - name: Upload e2e test screen shot
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raiwidgets-e2e-screen-shot
           path: ./dist/cypress
@@ -273,7 +273,7 @@ jobs:
 
       - id: download
         name: Download a Build Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.package }}
           path: ${{ matrix.package }}
@@ -343,7 +343,7 @@ jobs:
 
       - id: download
         name: Download a Build Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.typescriptBuildArtifactName }}
           path: ${{ env.typescriptBuildOutput }}

--- a/responsibleai_vision/requirements.txt
+++ b/responsibleai_vision/requirements.txt
@@ -6,5 +6,5 @@ scikit-learn>=0.22.1
 scipy>=1.4.1
 semver~=2.13.0
 responsibleai>=0.35.0
-torchmetrics[detection]
+torchmetrics
 vision_explanation_methods


### PR DESCRIPTION
## Description

Remove detection extra from torchmetrics install

Seeing warnings in builds like:
```
2024-11-26T19:04:23: WARNING: torchmetrics 0.5.1 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.5.1 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.5.0 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.5.0 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.4.1 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.4.1 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.3.2 does not provide the extra 'detection'
2024-11-26T19:04:23: WARNING: torchmetrics 0.3.2 does not provide the extra 'detection'
```

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
