### PR TITLE
Fix builds and update to python 3.9 as default in tests

### DIFF
--- a/.github/workflows/CI-e2e-notebooks.yml
+++ b/.github/workflows/CI-e2e-notebooks.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # TODO: add macos
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
         flights: ["", "dataBalanceExperience"]
         notebookGroup: ["nb_group_1", "nb_group_2", "nb_group_3"]
         exclude:
@@ -109,7 +109,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') && (matrix.flights == '') && (matrix.notebookGroup == 'nb_group_1') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -142,5 +143,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: raiwidgets-e2e-screen-shot
+          name: raiwidgets-ci-e2e-notebooks-screen-shot-${{ matrix.notebookGroup }}-${{ matrix.flights }}-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: ./dist/cypress

--- a/.github/workflows/CI-notebook.yml
+++ b/.github/workflows/CI-notebook.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.7, 3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -74,7 +74,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -95,5 +96,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: raiwidgets-e2e-screen-shot
+          name: raiwidgets-ci-notebook-screen-shot-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: dist/cypress

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -19,18 +19,13 @@ jobs:
         packageDirectory:
           ["responsibleai", "erroranalysis", "raiutils", "rai_test_utils"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pythonVersion: ["3.9", "3.10", "3.11"]
         exclude:
-          - operatingSystem: macos-latest
-            pythonVersion: "3.7"
-          - operatingSystem: ubuntu-latest
-            pythonVersion: "3.7"
-          - operatingSystem: windows-latest
-            pythonVersion: "3.7"
-          - operatingSystem: macos-latest
-            pythonVersion: "3.8"
           - packageDirectory: "responsibleai"
             pythonVersion: "3.11"
+          - packageDirectory: "responsibleai"
+            operatingSystem: "macos-latest"
+            pythonVersion: "3.9"
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -69,7 +64,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') && (matrix.packageDirectory == 'responsibleai') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -83,12 +79,12 @@ jobs:
       - name: Upload code coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.packageDirectory }}-code-coverage-results
-          path: ${{ matrix.packageDirectory }}/htmlcov
+          name: ${{ matrix.packageDirectory }}-${{ matrix.pythonVersion}}-code-coverage-results
+          path: ${{ matrix.packageDirectory }}-${{ matrix.pythonVersion}}/htmlcov
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
 
-      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
         name: Upload to codecov
         id: codecovupload1
         uses: codecov/codecov-action@v3
@@ -102,7 +98,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
 
-      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.9') && (matrix.operatingSystem == 'windows-latest') }}
         name: Retry upload to codecov
         id: codecovupload2
         uses: codecov/codecov-action@v3
@@ -117,7 +113,7 @@ jobs:
           verbose: true
 
       - name: Set codecov status
-        if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+        if: ${{ (matrix.pythonVersion == '3.9') && (matrix.operatingSystem == 'windows-latest') }}
         shell: bash
         run: |
           if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then

--- a/.github/workflows/CI-raiwidgets-pytest.yml
+++ b/.github/workflows/CI-raiwidgets-pytest.yml
@@ -17,17 +17,11 @@ jobs:
       matrix:
         packageDirectory: ["raiwidgets"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: [3.7, 3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
         exclude:
           - packageDirectory: "raiwidgets"
             operatingSystem: macos-latest
             pythonVersion: 3.9
-          - packageDirectory: "raiwidgets"
-            operatingSystem: windows-latest
-            pythonVersion: 3.8
-          - packageDirectory: "raiwidgets"
-            operatingSystem: macos-latest
-            pythonVersion: 3.7
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -102,7 +96,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: ${{ matrix.packageDirectory }}
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -119,10 +114,10 @@ jobs:
         name: Upload code coverage results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.packageDirectory }}-code-coverage-results
-          path: ${{ matrix.packageDirectory }}/htmlcov
+          name: ${{ matrix.packageDirectory }}-${{ matrix.pythonVersion}}-code-coverage-results
+          path: ${{ matrix.packageDirectory }}-${{ matrix.pythonVersion}}/htmlcov
 
-      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.8') }}
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
         name: Upload to codecov
         id: codecovupload1
         uses: codecov/codecov-action@v3
@@ -136,7 +131,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
 
-      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+      - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.9') && (matrix.operatingSystem == 'windows-latest') }}
         name: Retry upload to codecov
         id: codecovupload2
         uses: codecov/codecov-action@v3
@@ -151,7 +146,7 @@ jobs:
           verbose: true
 
       - name: Set codecov status
-        if: ${{ (matrix.pythonVersion == '3.8') && (matrix.operatingSystem == 'windows-latest') }}
+        if: ${{ (matrix.pythonVersion == '3.9') && (matrix.operatingSystem == 'windows-latest') }}
         shell: bash
         run: |
           if ${{ (steps.codecovupload1.outcome == 'success') || (steps.codecovupload2.outcome == 'success') }} ; then


### PR DESCRIPTION
## Description

Fix builds and update to python 3.9 as default in tests

Copilot summary:

This pull request includes several changes to the GitHub workflows to update the supported Python versions and improve the artifact naming conventions. The most important changes include removing Python 3.7 and 3.8 from the supported versions, adding conditional steps for artifact uploads, and refining the naming conventions for uploaded artifacts.

### Updates to Supported Python Versions:
* Removed Python 3.7 and 3.8 from the `pythonVersion` matrix in `.github/workflows/CI-e2e-notebooks.yml`, `.github/workflows/CI-notebook.yml`, `.github/workflows/CI-python.yml`, and `.github/workflows/CI-raiwidgets-pytest.yml`. [[1]](diffhunk://#diff-f1d4358bc8c6ae939b5344b137b910aba13ffbbc666c07afb0b874d1d54c4c78L50-R50) [[2]](diffhunk://#diff-87f39ff81c9b498d190c996f2bd2b3c2d553e59c972c710cb1062b583a973dbeL16-R16) [[3]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L22-L31) [[4]](diffhunk://#diff-9f83f363b90de685e0f9707810d8c84edb5da508991d9138fd632c20773c9ebdL20-L30)

### Conditional Artifact Uploads:
* Added conditions to the `Upload requirements` steps to only run on `windows-latest` with Python 3.9 in the respective workflows. [[1]](diffhunk://#diff-f1d4358bc8c6ae939b5344b137b910aba13ffbbc666c07afb0b874d1d54c4c78L112-R113) [[2]](diffhunk://#diff-87f39ff81c9b498d190c996f2bd2b3c2d553e59c972c710cb1062b583a973dbeL77-R78) [[3]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L72-R65) [[4]](diffhunk://#diff-9f83f363b90de685e0f9707810d8c84edb5da508991d9138fd632c20773c9ebdL105-R100)

### Refining Artifact Naming Conventions:
* Updated the naming convention for screenshots and code coverage results to include more specific details such as `notebookGroup`, `flights`, `operatingSystem`, and `pythonVersion`. [[1]](diffhunk://#diff-f1d4358bc8c6ae939b5344b137b910aba13ffbbc666c07afb0b874d1d54c4c78L145-R146) [[2]](diffhunk://#diff-87f39ff81c9b498d190c996f2bd2b3c2d553e59c972c710cb1062b583a973dbeL98-R99) [[3]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L86-R84) [[4]](diffhunk://#diff-9f83f363b90de685e0f9707810d8c84edb5da508991d9138fd632c20773c9ebdL122-R120)

### Additional Updates to Code Coverage Uploads:
* Modified conditions for code coverage uploads and retries to align with the updated Python version support. [[1]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L105-R98) [[2]](diffhunk://#diff-9f83f363b90de685e0f9707810d8c84edb5da508991d9138fd632c20773c9ebdL139-R134) [[3]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L120-R113) [[4]](diffhunk://#diff-9f83f363b90de685e0f9707810d8c84edb5da508991d9138fd632c20773c9ebdL154-R149)

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
