### PR TITLE
Fix CI notebook text and vision tests

### DIFF
--- a/.github/workflows/CI-e2e-notebooks-text-vision.yml
+++ b/.github/workflows/CI-e2e-notebooks-text-vision.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         # TODO: add macos
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
         flights: [""]
         notebookGroup: ["vis_nb_group_1", "text_nb_group_1"]
 
@@ -103,7 +103,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install tf-keras
-          pip install keras==2.15
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -117,6 +116,8 @@ jobs:
         name: Install vision dependencies
         shell: bash -l {0}
         run: |
+          pip install fastai
+          pip install --upgrade "spacy<4"
           pip install -r requirements-dev.txt
           pip install .
         working-directory: responsibleai_vision
@@ -142,7 +143,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') && (matrix.flights == '') && (matrix.notebookGroup == 'vis_nb_group_1') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -169,5 +171,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: raiwidgets-e2e-screen-shot
+          name: raiwidgets-ci-e2e-text-vision-screen-shot-${{ matrix.notebookGroup }}-${{ matrix.flights }}-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: ./dist/cypress

--- a/.github/workflows/CI-notebook-text.yml
+++ b/.github/workflows/CI-notebook-text.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        pythonVersion: [3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -71,7 +71,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install tf-keras
-          pip install keras==2.15
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -99,7 +98,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -120,5 +120,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: raiwidgets-e2e-screen-shot
+          name: raiwidgets-ci-notebook-vision-screen-shot-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: dist/cypress

--- a/.github/workflows/CI-notebook-vision.yml
+++ b/.github/workflows/CI-notebook-vision.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         operatingSystem: [ubuntu-latest]
-        pythonVersion: [3.8, 3.9, "3.10"]
+        pythonVersion: [3.9, "3.10"]
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -75,6 +75,12 @@ jobs:
           pip install .
         working-directory: raiwidgets
 
+      - name: Install fastai and latest spacy individually to fix conflicts
+        shell: bash -l {0}
+        run: |
+          pip install fastai
+          pip install --upgrade "spacy<4"
+
       - name: Install vision dependencies
         shell: bash -l {0}
         run: |
@@ -96,7 +102,8 @@ jobs:
           cat installed-requirements-dev.txt
         working-directory: raiwidgets
 
-      - name: Upload requirements
+      - if: ${{ (matrix.operatingSystem == 'windows-latest') && (matrix.pythonVersion == '3.9') }}
+        name: Upload requirements
         uses: actions/upload-artifact@v4
         with:
           name: requirements-dev.txt
@@ -110,12 +117,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: notebook-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
+          name: ci-notebook-vision-test-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: notebooks
 
       - name: Upload e2e test screen shot
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: raiwidgets-e2e-screen-shot
+          name: raiwidgets-ci-notebook-vision-screen-shot-${{ matrix.operatingSystem }}-${{ matrix.pythonVersion }}
           path: dist/cypress

--- a/.github/workflows/CI-responsibleai-text-vision-pytest.yml
+++ b/.github/workflows/CI-responsibleai-text-vision-pytest.yml
@@ -16,21 +16,15 @@ jobs:
       matrix:
         packageDirectory: ["responsibleai_text", "responsibleai_vision"]
         operatingSystem: [ubuntu-latest, macos-latest, windows-latest]
-        pythonVersion: ["3.8", "3.9", "3.10"]
+        pythonVersion: ["3.9", "3.10"]
         # TODO: re-add macos-latest once build timeout issues are resolved
         exclude:
-          - packageDirectory: "responsibleai_text"
-            operatingSystem: macos-latest
-            pythonVersion: "3.8"
           - packageDirectory: "responsibleai_text"
             operatingSystem: macos-latest
             pythonVersion: "3.9"
           - packageDirectory: "responsibleai_text"
             operatingSystem: macos-latest
             pythonVersion: "3.10"
-          - packageDirectory: "responsibleai_vision"
-            operatingSystem: macos-latest
-            pythonVersion: "3.8"
           - packageDirectory: "responsibleai_vision"
             operatingSystem: macos-latest
             pythonVersion: "3.9"
@@ -51,13 +45,13 @@ jobs:
         name: Install pytorch on non-MacOS
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" cpuonly "numpy<1.24.0" -c pytorch
+          conda install --yes --quiet pytorch torchvision cpuonly "numpy<1.24.0" -c pytorch
 
       - if: ${{ matrix.operatingSystem == 'macos-latest' }}
         name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
         shell: bash -l {0}
         run: |
-          conda install --yes --quiet pytorch==1.13.1 "torchvision<0.15" "numpy<1.24.0" -c pytorch
+          conda install --yes --quiet pytorch torchvision "numpy<1.24.0" -c pytorch
 
       - name: Setup tools
         shell: bash -l {0}
@@ -76,7 +70,13 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install tf-keras
-          pip install keras==2.15
+
+      - if: ${{ (matrix.packageDirectory == 'responsibleai_vision') }}
+        name: Install fastai and latest spacy individually to fix conflicts
+        shell: bash -l {0}
+        run: |
+          pip install fastai
+          pip install --upgrade "spacy<4"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/responsibleai_vision/requirements-dev.txt
+++ b/responsibleai_vision/requirements-dev.txt
@@ -21,12 +21,10 @@ sphinx==3.1.1
 sphinx-gallery==0.8.1
 pydata-sphinx-theme==0.3.0
 
-tensorflow<=2.15
+tensorflow
 transformers
 datasets
 opencv-python
 
-fastai
 mlflow
-pydantic<2.0.0
 piexif


### PR DESCRIPTION
## Description

Fix CI notebook text and vision tests
Copilot summary:
This pull request includes several updates to the CI workflows and a minor update to the development requirements. The most important changes are the removal of Python 3.8 from the test matrix and the addition of specific conditions for uploading artifacts.

Updates to CI workflows:

* [`.github/workflows/CI-e2e-notebooks-text-vision.yml`](diffhunk://#diff-d698c5dc54c593450ea7ed8d81a6bf5286d71e61cfee3729fd8a93aaf0a134faL59-R59): Removed Python 3.8 from the `pythonVersion` matrix and added specific conditions for the `Upload requirements` step. Additionally, updated the naming convention for the screenshot artifact to include matrix variables. [[1]](diffhunk://#diff-d698c5dc54c593450ea7ed8d81a6bf5286d71e61cfee3729fd8a93aaf0a134faL59-R59) [[2]](diffhunk://#diff-d698c5dc54c593450ea7ed8d81a6bf5286d71e61cfee3729fd8a93aaf0a134faL145-R146) [[3]](diffhunk://#diff-d698c5dc54c593450ea7ed8d81a6bf5286d71e61cfee3729fd8a93aaf0a134faL172-R173)
* [`.github/workflows/CI-notebook-text.yml`](diffhunk://#diff-d49b048ce01c4b7b1def3ffcdd5a8bf6609decddcad31a5c44d135988863fb01L23-R23): Removed Python 3.8 from the `pythonVersion` matrix.
* [`.github/workflows/CI-notebook-vision.yml`](diffhunk://#diff-a22ae60354307c7012f99843e72064e47cd72b1a6a3c010e19c34a5cda2b8be0L23-R23): Removed Python 3.8 from the `pythonVersion` matrix.

Update to development requirements:

* [`responsibleai_vision/requirements-dev.txt`](diffhunk://#diff-7c854524c754698ba5301013964e985ab94c6a82f2092dc0a1cb0e60f7c66a09L24-R24): Removed the version constraint on `tensorflow`.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [x] I have added screenshots above for all UI changes.
- [x] I have added e2e tests for all UI changes.
- [x] Documentation was updated if it was needed.
