### PR TITLE
Restrict CORS origins in rai_core_flask to prevent cross-origin data exfiltration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,11 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron:  '30 5 * * *'
+    - cron: "30 5 * * *"
 
 jobs:
   analyze:
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: python
-          build-mode: none
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -56,46 +56,46 @@ jobs:
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/rai_core_flask/rai_core_flask/environments/local_ipython_environment.py
+++ b/rai_core_flask/rai_core_flask/environments/local_ipython_environment.py
@@ -31,5 +31,16 @@ class LocalIPythonEnvironment(BaseEnvironment):
 
     def select(self, service):
         service.with_credentials = False
-        service.cors = CORS(service.app)
+        if service.allow_all_origins:
+            # User explicitly opted into allowing all origins (less secure)
+            service.cors = CORS(service.app)
+        else:
+            # Default: restrict CORS to localhost origins (any port)
+            origins = [
+                r"^http://localhost:\d+$",
+                r"^https://localhost:\d+$",
+                r"^http://127\.0\.0\.1:\d+$",
+                r"^https://127\.0\.0\.1:\d+$",
+            ]
+            service.cors = CORS(service.app, origins=origins)
         service.env_name = LOCAL

--- a/rai_core_flask/rai_core_flask/environments/public_vm_environment.py
+++ b/rai_core_flask/rai_core_flask/environments/public_vm_environment.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import re
+
 from flask_cors import CORS
 
 from rai_core_flask.environments.base_environment import BaseEnvironment
@@ -31,5 +33,13 @@ class PublicVMEnvironment(BaseEnvironment):
 
     def select(self, service):
         service.with_credentials = False
-        service.cors = CORS(service.app)
+        if service.allow_all_origins:
+            # User explicitly opted into allowing all origins (less secure)
+            service.cors = CORS(service.app)
+        else:
+            # Default: restrict CORS to the same host over HTTP/HTTPS
+            # on any port (notebook may run on a different port)
+            escaped_ip = re.escape(service.ip)
+            origin_pattern = rf"^https?://{escaped_ip}(:\d+)?$"
+            service.cors = CORS(service.app, origins=[origin_pattern])
         service.env_name = PUBLIC_VM

--- a/rai_core_flask/rai_core_flask/flask_helper.py
+++ b/rai_core_flask/rai_core_flask/flask_helper.py
@@ -25,7 +25,7 @@ class FlaskHelper(object):
     """FlaskHelper is a class for common Flask utilities used in dashboards."""
 
     def __init__(self, ip=None, port=None, with_credentials=False,
-                 is_private_link=False):
+                 is_private_link=False, allow_all_origins=False):
         # The name passed to Flask needs to be unique per instance.
         self.app = Flask(uuid.uuid4().hex)
 
@@ -33,6 +33,7 @@ class FlaskHelper(object):
         self.ip = ip
         self.with_credentials = with_credentials
         self.is_private_link = is_private_link
+        self.allow_all_origins = allow_all_origins
         # dictionary to store arbitrary state for use by consuming classes
         self.shared_state = {}
         if self.ip is None:

--- a/rai_core_flask/tests/test_environment_detector.py
+++ b/rai_core_flask/tests/test_environment_detector.py
@@ -61,3 +61,69 @@ class TestEnvironmentDetector(object):
             assert isinstance(service.env, DatabricksEnvironment)
         finally:
             del os.environ[DATABRICKS_ENV_VAR]
+
+    def test_local_cors_restricted_by_default(self):
+        service = FlaskHelper()
+        assert isinstance(service.env, LocalIPythonEnvironment)
+        assert not service.allow_all_origins
+
+        # Verify allowed localhost origin gets CORS header
+        with service.app.test_client() as client:
+            resp = client.get('/', headers={'Origin': 'http://localhost:8888'})
+            assert resp.headers.get('Access-Control-Allow-Origin') == \
+                'http://localhost:8888'
+
+            # Verify disallowed origin does NOT get CORS header
+            resp = client.get('/', headers={'Origin': 'http://evil.com'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is None
+
+            # Verify attacker origin with similar IP does NOT match
+            resp = client.get('/',
+                              headers={'Origin': 'http://127a0b0c1:1234'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is None
+
+    def test_local_cors_wildcard_when_opted_in(self):
+        service = FlaskHelper(allow_all_origins=True)
+        assert isinstance(service.env, LocalIPythonEnvironment)
+        assert service.allow_all_origins
+
+        # Verify any origin gets CORS header
+        with service.app.test_client() as client:
+            resp = client.get('/', headers={'Origin': 'http://evil.com'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is not None
+
+    def test_public_vm_cors_restricted_by_default(self, mocker):
+        mocker.patch('rai_core_flask.FlaskHelper._is_local_port_available',
+                     return_value=True)
+        service = FlaskHelper(ip="10.0.0.5", with_credentials=False)
+        assert isinstance(service.env, PublicVMEnvironment)
+        assert not service.allow_all_origins
+
+        # Verify allowed origin gets CORS header
+        with service.app.test_client() as client:
+            resp = client.get('/',
+                              headers={'Origin': 'http://10.0.0.5:8888'})
+            assert resp.headers.get('Access-Control-Allow-Origin') == \
+                'http://10.0.0.5:8888'
+
+            # Verify disallowed origin does NOT get CORS header
+            resp = client.get('/', headers={'Origin': 'http://evil.com'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is None
+
+            # Verify attacker prefix origin does NOT match
+            resp = client.get(
+                '/', headers={'Origin': 'http://10.0.0.5.evil.com'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is None
+
+    def test_public_vm_cors_wildcard_when_opted_in(self, mocker):
+        mocker.patch('rai_core_flask.FlaskHelper._is_local_port_available',
+                     return_value=True)
+        service = FlaskHelper(ip="10.0.0.5", with_credentials=False,
+                              allow_all_origins=True)
+        assert isinstance(service.env, PublicVMEnvironment)
+        assert service.allow_all_origins
+
+        # Verify any origin gets CORS header
+        with service.app.test_client() as client:
+            resp = client.get('/', headers={'Origin': 'http://evil.com'})
+            assert resp.headers.get('Access-Control-Allow-Origin') is not None


### PR DESCRIPTION
## Description

Restrict CORS origins in rai_core_flask to prevent cross-origin data exfiltration
Also reformatted codeql file with prettier

Note: these are rai-core-flask package changes only

- Restrict CORS origins in PublicVMEnvironment to specific service origin
- Restrict CORS origins in LocalIPythonEnvironment to localhost origins
- Add allow_all_origins parameter as escape hatch for users who need wildcard CORS and understand the security implications

This fixes CWE-942 (Wildcard CORS) by defaulting to restrictive CORS policy while preserving backward compatibility via opt-in parameter.

## Checklist

<!--- Make sure to satisfy all the criteria listed below. -->

- [ ] I have added screenshots above for all UI changes.
- [ ] I have added e2e tests for all UI changes.
- [ ] Documentation was updated if it was needed.
