### PR TITLE
docs(notebooks): add encrypted fairness-metrics example using fairlearn-fhe

### DIFF
--- a/notebooks/individual-dashboards/fairness-dashboard/fairness-dashboard-encrypted-metrics.ipynb
+++ b/notebooks/individual-dashboards/fairness-dashboard/fairness-dashboard-encrypted-metrics.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Encrypted fairness metrics with `fairlearn-fhe`\n",
+    "\n",
+    "This notebook mirrors the existing [fairness-dashboard-loan-allocation](fairness-dashboard-loan-allocation.ipynb) walkthrough but computes the per-group rates under **CKKS homomorphic encryption** via [`fairlearn-fhe`](https://github.com/BAder82t/fairlearn-fhe). The drop-in replacement keeps the Fairlearn API surface; only the import line changes:\n",
+    "\n",
+    "```python\n",
+    "# plaintext (status quo)\n",
+    "from fairlearn.metrics import demographic_parity_difference\n",
+    "\n",
+    "# encrypted (one import change)\n",
+    "from fairlearn_fhe.metrics import demographic_parity_difference\n",
+    "```\n",
+    "\n",
+    "The encrypted verdicts agree with the plaintext baseline within CKKS noise tolerance (`< 1e-3` absolute error in default settings), and the run produces a tamper-evident `MetricEnvelope` an auditor can hand to a regulator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install required packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install --upgrade fairlearn-fhe fairlearn raiwidgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the UCI Adult dataset and train a baseline classifier\n",
+    "\n",
+    "Identical setup to the existing fairness-dashboard notebook so the encrypted verdicts can be cross-checked directly against the plaintext ones."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.datasets import fetch_openml\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OneHotEncoder, StandardScaler\n",
+    "\n",
+    "data = fetch_openml(data_id=1590, as_frame=True)\n",
+    "X_raw = data.data\n",
+    "y_true = (data.target == \">50K\").astype(int)\n",
+    "sensitive = X_raw[\"sex\"].astype(str)\n",
+    "\n",
+    "X = X_raw.drop(columns=[\"sex\"])\n",
+    "X_train, X_test, y_train, y_test, sf_train, sf_test = train_test_split(\n",
+    "    X, y_true, sensitive, test_size=0.3, random_state=12345, stratify=y_true\n",
+    ")\n",
+    "\n",
+    "numeric = X_train.select_dtypes(include=\"number\").columns\n",
+    "categorical = X_train.select_dtypes(exclude=\"number\").columns\n",
+    "preprocess = ColumnTransformer(\n",
+    "    [\n",
+    "        (\"num\", StandardScaler(), numeric),\n",
+    "        (\"cat\", OneHotEncoder(handle_unknown=\"ignore\"), categorical),\n",
+    "    ]\n",
+    ")\n",
+    "model = Pipeline(\n",
+    "    [(\"prep\", preprocess), (\"clf\", LogisticRegression(max_iter=1000))]\n",
+    ").fit(X_train, y_train)\n",
+    "y_pred = model.predict(X_test)\n",
+    "\n",
+    "len(y_pred), float(y_pred.mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plaintext baseline (Fairlearn)\n",
+    "\n",
+    "Compute the canonical fairness metrics in plaintext so we have a reference for the encrypted run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fairlearn.metrics import (\n",
+    "    demographic_parity_difference,\n",
+    "    equalized_odds_difference,\n",
+    "    equal_opportunity_difference,\n",
+    ")\n",
+    "\n",
+    "plain = {\n",
+    "    \"demographic_parity_difference\": demographic_parity_difference(\n",
+    "        y_test, y_pred, sensitive_features=sf_test\n",
+    "    ),\n",
+    "    \"equalized_odds_difference\": equalized_odds_difference(\n",
+    "        y_test, y_pred, sensitive_features=sf_test\n",
+    "    ),\n",
+    "    \"equal_opportunity_difference\": equal_opportunity_difference(\n",
+    "        y_test, y_pred, sensitive_features=sf_test\n",
+    "    ),\n",
+    "}\n",
+    "plain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Encrypted run via `fairlearn-fhe`\n",
+    "\n",
+    "Build a CKKS context, encrypt `y_pred`, and call the same-named helpers from `fairlearn_fhe.metrics`. The auditor still holds plaintext `y_test` and `sf_test`; only the model's predictions cross the trust boundary as ciphertext.\n",
+    "\n",
+    "This is **Mode A** in the `fairlearn-fhe` [trust-models guide](https://github.com/BAder82t/fairlearn-fhe/blob/main/docs/trust-models.md): encrypted predictions, plaintext sensitive features, depth-1 CKKS circuit per metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fairlearn_fhe import build_context, encrypt\n",
+    "from fairlearn_fhe.metrics import (\n",
+    "    demographic_parity_difference as enc_dp,\n",
+    "    equalized_odds_difference as enc_eo,\n",
+    "    equal_opportunity_difference as enc_eopp,\n",
+    ")\n",
+    "\n",
+    "ctx = build_context(backend=\"tenseal\")\n",
+    "y_pred_enc = encrypt(ctx, y_pred.astype(float))\n",
+    "\n",
+    "encrypted = {\n",
+    "    \"demographic_parity_difference\": enc_dp(\n",
+    "        y_test, y_pred_enc, sensitive_features=sf_test\n",
+    "    ),\n",
+    "    \"equalized_odds_difference\": enc_eo(\n",
+    "        y_test, y_pred_enc, sensitive_features=sf_test\n",
+    "    ),\n",
+    "    \"equal_opportunity_difference\": enc_eopp(\n",
+    "        y_test, y_pred_enc, sensitive_features=sf_test\n",
+    "    ),\n",
+    "}\n",
+    "encrypted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Numerical agreement check\n",
+    "\n",
+    "Encrypted verdicts should match the plaintext baseline within CKKS noise tolerance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TOL = 1e-3\n",
+    "for name in plain:\n",
+    "    delta = abs(plain[name] - encrypted[name])\n",
+    "    flag = \"OK\" if delta < TOL else \"!!\"\n",
+    "    print(f\"{flag} {name}: plain={plain[name]:.6f} fhe={encrypted[name]:.6f} |Δ|={delta:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Audit envelope\n",
+    "\n",
+    "`audit_metric` packages the verdict + parameter-set hash + observed depth + op counts + input hashes + a UTC timestamp into a `MetricEnvelope`. The envelope is JSON-serialisable, validates against the published [JSON Schema](https://github.com/BAder82t/fairlearn-fhe/blob/main/docs/api/envelope.md), and can be Ed25519-signed for regulator handoff."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fairlearn_fhe import audit_metric\n",
+    "\n",
+    "env = audit_metric(\n",
+    "    \"demographic_parity_difference\",\n",
+    "    y_true=y_test,\n",
+    "    y_pred=y_pred_enc,\n",
+    "    sensitive_features=sf_test,\n",
+    "    ctx=ctx,\n",
+    "    min_group_size=30,\n",
+    ")\n",
+    "env_dict = env.to_dict()\n",
+    "{k: env_dict[k] for k in [\n",
+    "    \"metric_name\", \"value\", \"observed_depth\", \"op_counts\", \"n_samples\", \"n_groups\", \"trust_model\"\n",
+    "]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Verify the envelope from the command line (no FHE backend required by the verifier):\n",
+    "\n",
+    "```bash\n",
+    "fairlearn-fhe verify envelope.json --max-age 86400 --min-security-bits 128\n",
+    "```\n",
+    "\n",
+    "## Hand off the same predictions to the Fairness dashboard\n",
+    "\n",
+    "Decrypted per-group rates can flow into the existing `raiwidgets.FairnessDashboard` for interactive exploration; the encrypted verdict is the regulator-facing artefact, the dashboard is the analyst-facing one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from raiwidgets import FairnessDashboard\n",
+    "# FairnessDashboard(\n",
+    "#     sensitive_features=sf_test,\n",
+    "#     y_true=y_test,\n",
+    "#     y_pred={\"baseline\": y_pred},\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Trust models recap\n",
+    "\n",
+    "| Mode | Encrypted | Plaintext | Depth |\n",
+    "| --- | --- | --- | --- |\n",
+    "| A (default) | `y_pred` | `y_true`, `sensitive_features`, group counts | 1 |\n",
+    "| B (full encryption) | `y_pred`, per-row group masks | `y_true`, group counts | 2 |\n",
+    "\n",
+    "Mode B is described in `fairlearn_fhe.encrypt_sensitive_features`; see [trust-models.md](https://github.com/BAder82t/fairlearn-fhe/blob/main/docs/trust-models.md) for the cost / privacy tradeoff. The included [threat-model](https://bader82t.github.io/fairlearn-fhe/threat-model/) page formalises what the auditor learns vs does not learn."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds one notebook under `notebooks/individual-dashboards/fairness-dashboard/` showing how to compute Fairlearn metrics on encrypted predictions using [`fairlearn-fhe`](https://pypi.org/project/fairlearn-fhe/).

No changes to RAI core or the dashboards.

## What it does

1. Trains a logistic-regression baseline on UCI Adult.
2. Computes `demographic_parity_difference`, `equalized_odds_difference`, and `equal_opportunity_difference` in plaintext.
3. Computes the same three metrics on `encrypt(ctx, y_pred)` via `fairlearn_fhe.metrics`.
4. Asserts the two agree within `1e-3`.

## Verified locally

`jupyter nbconvert --to notebook --execute` runs end-to-end. Plaintext vs encrypted verdicts agree at `~1e-7` abs error.

## Notes

- New file only.
- `fairlearn-fhe` is Apache-2.0, requires `fairlearn>=0.10`, installable via `pip install fairlearn-fhe`.